### PR TITLE
Setup vscode extension for graphene syntax highlighting

### DIFF
--- a/graphene/vscode/.vscode/launch.json
+++ b/graphene/vscode/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "preLaunchTask": "npm: watch",
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ]
+    }
+  ]
+}

--- a/graphene/vscode/.vscode/tasks.json
+++ b/graphene/vscode/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": [
+        "$tsc-watch"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/graphene/vscode/README.md
+++ b/graphene/vscode/README.md
@@ -1,0 +1,66 @@
+# Graphene VS Code Extension
+
+Provides language support for Graphene GQL/GSQL files in VS Code and Cursor.
+
+- Syntax highlighting via a semantic tokens provider (placeholder implementation).
+- Diagnostics stub (unbalanced braces and TODO/FIXME notes).
+- Activation for `.gql` and `.gsql` files.
+
+## Dev setup
+
+1. Open the `graphene/vscode` folder in VS Code or Cursor.
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Start TypeScript in watch mode (optional, the debug target runs this automatically):
+
+```bash
+npm run watch
+```
+
+4. Press F5 (or run "Run and Debug" → "Launch Extension"). This starts a new Extension Development Host window with the extension loaded.
+
+5. Open a `.gql` or `.gsql` file to see highlighting and diagnostics. Edit the code in this workspace — with watch mode on, changes are rebuilt automatically. Use "Developer: Reload Window" in the Dev Host to pick up code changes.
+
+### Cursor support
+
+Cursor uses the VS Code extension host, so the same F5 flow works. After starting the debug session, a new Cursor window (Extension Development Host) opens with the extension enabled.
+
+## Wiring the Lezer grammar
+
+This extension currently uses a simple token scanner. To switch to the real Graphene Lezer grammar from `graphene/lang`:
+
+- Export a parser or parse function from `graphene/lang` (built to JS). For example:
+
+```ts
+// in graphene/lang
+export function parse(text: string): { tokens: Array<{ line: number; start: number; length: number; type: string }> } { /* ... */ }
+```
+
+- In `src/semanticTokens.ts`, replace the `scanTokens` generator with code that calls the exported parser and maps node/tag types to VS Code token types.
+
+- If you publish `graphene/lang` as a package or build it locally, add a dependency in this extension's `package.json` like:
+
+```json
+"dependencies": {
+  "graphene-lang": "file:../lang"
+}
+```
+
+Then update imports accordingly.
+
+## Diagnostics stub → real diagnostics
+
+The diagnostics provider is intentionally simple. Once `/lang` exposes a diagnostics API, update `src/diagnostics.ts` to call into it and translate results into `vscode.Diagnostic` instances.
+
+## Packaging (optional)
+
+To package and install manually as a VSIX:
+
+1. Install `vsce` globally: `npm i -g @vscode/vsce`
+2. Build: `npm run compile`
+3. Package: `vsce package`
+4. In VS Code/Cursor, run "Extensions: Install from VSIX" and select the generated `.vsix`.

--- a/graphene/vscode/language-configuration.json
+++ b/graphene/vscode/language-configuration.json
@@ -1,0 +1,24 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["(", ")"],
+    ["[", "]"],
+    ["{", "}"]
+  ],
+  "autoClosingPairs": [
+    { "open": "(", "close": ")" },
+    { "open": "[", "close": "]" },
+    { "open": "{", "close": "}" },
+    { "open": '"', "close": '"', "notIn": ["string", "comment"] },
+    { "open": "'", "close": "'", "notIn": ["string", "comment"] }
+  ],
+  "surroundingPairs": [
+    { "open": "(", "close": ")" },
+    { "open": "[", "close": "]" },
+    { "open": "{", "close": "}" },
+    { "open": '"', "close": '"' },
+    { "open": "'", "close": "'" }
+  ]
+}

--- a/graphene/vscode/out/diagnostics.js
+++ b/graphene/vscode/out/diagnostics.js
@@ -1,0 +1,86 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.activateDiagnostics = activateDiagnostics;
+const vscode = __importStar(require("vscode"));
+function collectDiagnosticsStub(text) {
+    const diagnostics = [];
+    // Very naive: warn on FIXME/TODO and on unbalanced braces
+    for (const match of text.matchAll(/\b(FIXME|TODO)\b/g)) {
+        diagnostics.push({ message: `Note: ${match[1]}`, start: match.index ?? 0, end: (match.index ?? 0) + match[0].length, severity: vscode.DiagnosticSeverity.Information });
+    }
+    const stack = [];
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (ch === '{' || ch === '(' || ch === '[')
+            stack.push({ ch, index: i });
+        else if (ch === '}' || ch === ')' || ch === ']') {
+            if (!stack.length) {
+                diagnostics.push({ message: `Unmatched closing '${ch}'`, start: i, end: i + 1, severity: vscode.DiagnosticSeverity.Error });
+            }
+            else {
+                const open = stack.pop();
+                const pairs = { '{': '}', '(': ')', '[': ']' };
+                if (pairs[open.ch] !== ch) {
+                    diagnostics.push({ message: `Mismatched '${open.ch}' ... '${ch}'`, start: open.index, end: i + 1, severity: vscode.DiagnosticSeverity.Error });
+                }
+            }
+        }
+    }
+    for (const leftover of stack) {
+        diagnostics.push({ message: `Unclosed '${leftover.ch}'`, start: leftover.index, end: leftover.index + 1, severity: vscode.DiagnosticSeverity.Error });
+    }
+    return diagnostics;
+}
+function activateDiagnostics(context, selector) {
+    const collection = vscode.languages.createDiagnosticCollection('graphene');
+    context.subscriptions.push(collection);
+    const refresh = (document) => {
+        if (!vscode.languages.match(selector, document))
+            return;
+        const diags = [];
+        const text = document.getText();
+        for (const d of collectDiagnosticsStub(text)) {
+            const start = document.positionAt(d.start);
+            const end = document.positionAt(d.end);
+            const range = new vscode.Range(start, end);
+            diags.push(new vscode.Diagnostic(range, d.message, d.severity));
+        }
+        collection.set(document.uri, diags);
+    };
+    context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(refresh), vscode.workspace.onDidChangeTextDocument(e => refresh(e.document)), vscode.workspace.onDidCloseTextDocument(doc => collection.delete(doc.uri)));
+    // Initialize already-open documents
+    vscode.workspace.textDocuments.forEach(refresh);
+}

--- a/graphene/vscode/out/extension.js
+++ b/graphene/vscode/out/extension.js
@@ -1,0 +1,19 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.activate = activate;
+exports.deactivate = deactivate;
+const semanticTokens_1 = require("./semanticTokens");
+const diagnostics_1 = require("./diagnostics");
+function activate(context) {
+    const selector = [
+        { language: 'gql', scheme: 'file' },
+        { language: 'gql', scheme: 'untitled' },
+        { language: 'gsql', scheme: 'file' },
+        { language: 'gsql', scheme: 'untitled' }
+    ];
+    (0, semanticTokens_1.registerSemanticTokens)(context, selector);
+    (0, diagnostics_1.activateDiagnostics)(context, selector);
+}
+function deactivate() {
+    // no-op
+}

--- a/graphene/vscode/out/semanticTokens.js
+++ b/graphene/vscode/out/semanticTokens.js
@@ -1,0 +1,100 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.registerSemanticTokens = registerSemanticTokens;
+const vscode = __importStar(require("vscode"));
+const tokenTypes = [
+    'keyword',
+    'string',
+    'number',
+    'type',
+    'function',
+    'variable',
+    'property',
+    'operator',
+    'comment',
+    'boolean',
+    'enumMember'
+];
+const tokenTypeToIndex = Object.fromEntries(tokenTypes.map((t, i) => [t, i]));
+const legend = new vscode.SemanticTokensLegend(tokenTypes, []);
+// TODO: Replace with real Lezer-based parsing from ../lang once available
+function* scanTokens(document) {
+    const keyword = /\b(type|schema|query|mutation|subscription|scalar|enum|interface|union|input|directive|fragment|on|implements|extend)\b/g;
+    const boolean = /\b(true|false|null)\b/g;
+    const number = /(?<![A-Za-z_])-?\b\d+(?:\.\d+)?\b/g;
+    const string = /"([^"\\]|\\.)*"|'([^'\\]|\\.)*'/g;
+    const comment = /#.*/g;
+    const operator = /[!:=@|&(){}[\],.]/g;
+    for (let line = 0; line < document.lineCount; line++) {
+        const text = document.lineAt(line).text;
+        comment.lastIndex = 0;
+        for (let m; (m = comment.exec(text));) {
+            yield { line, start: m.index, length: m[0].length, type: 'comment' };
+        }
+        string.lastIndex = 0;
+        for (let m; (m = string.exec(text));) {
+            yield { line, start: m.index, length: m[0].length, type: 'string' };
+        }
+        number.lastIndex = 0;
+        for (let m; (m = number.exec(text));) {
+            yield { line, start: m.index, length: m[0].length, type: 'number' };
+        }
+        keyword.lastIndex = 0;
+        for (let m; (m = keyword.exec(text));) {
+            yield { line, start: m.index, length: m[0].length, type: 'keyword' };
+        }
+        boolean.lastIndex = 0;
+        for (let m; (m = boolean.exec(text));) {
+            yield { line, start: m.index, length: m[0].length, type: 'boolean' };
+        }
+        operator.lastIndex = 0;
+        for (let m; (m = operator.exec(text));) {
+            yield { line, start: m.index, length: m[0].length, type: 'operator' };
+        }
+    }
+}
+class GrapheneSemanticTokensProvider {
+    async provideDocumentSemanticTokens(document) {
+        const builder = new vscode.SemanticTokensBuilder(legend);
+        for (const tok of scanTokens(document)) {
+            builder.push(tok.line, tok.start, tok.length, tokenTypeToIndex[tok.type], 0);
+        }
+        return builder.build();
+    }
+}
+function registerSemanticTokens(context, selector) {
+    context.subscriptions.push(vscode.languages.registerDocumentSemanticTokensProvider(selector, new GrapheneSemanticTokensProvider(), legend));
+}

--- a/graphene/vscode/package-lock.json
+++ b/graphene/vscode/package-lock.json
@@ -7,7 +7,11 @@
     "": {
       "name": "graphene-vscode",
       "version": "0.0.1",
+      "dependencies": {
+        "@graphene/lang": "file:../lang"
+      },
       "devDependencies": {
+        "@lezer/common": "^1.2.1",
         "@types/vscode": "^1.84.0",
         "tslib": "^2.6.2",
         "typescript": "^5.4.0"
@@ -15,6 +19,18 @@
       "engines": {
         "vscode": "^1.84.0"
       }
+    },
+    "../lang": {},
+    "node_modules/@graphene/lang": {
+      "resolved": "../lang",
+      "link": true
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.102.0",

--- a/graphene/vscode/package-lock.json
+++ b/graphene/vscode/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "graphene-vscode",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "graphene-vscode",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/vscode": "^1.84.0",
+        "tslib": "^2.6.2",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "vscode": "^1.84.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.102.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.102.0.tgz",
+      "integrity": "sha512-V9sFXmcXz03FtYTSUsYsu5K0Q9wH9w9V25slddcxrh5JgORD14LpnOA7ov0L9ALi+6HrTjskLJ/tY5zeRF3TFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/graphene/vscode/package.json
+++ b/graphene/vscode/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "graphene-vscode",
+  "displayName": "Graphene Language Support",
+  "publisher": "graphene",
+  "description": "Syntax highlighting and diagnostics stubs for Graphene GQL/GSQL using a Lezer-based pipeline.",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.84.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onLanguage:gql",
+    "onLanguage:gsql"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "gql",
+        "aliases": ["Graphene GQL", "GQL"],
+        "extensions": [".gql"],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "gsql",
+        "aliases": ["Graphene GSQL", "GSQL"],
+        "extensions": [".gsql"],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "semanticTokenTypes": [
+      { "id": "keyword", "superType": "" },
+      { "id": "string", "superType": "" },
+      { "id": "number", "superType": "" },
+      { "id": "type", "superType": "" },
+      { "id": "function", "superType": "" },
+      { "id": "variable", "superType": "" },
+      { "id": "property", "superType": "" },
+      { "id": "operator", "superType": "" },
+      { "id": "comment", "superType": "" },
+      { "id": "boolean", "superType": "" },
+      { "id": "enumMember", "superType": "" }
+    ]
+  },
+  "scripts": {
+    "compile": "tsc -p .",
+    "watch": "tsc -w -p ."
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.84.0",
+    "tslib": "^2.6.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/graphene/vscode/package.json
+++ b/graphene/vscode/package.json
@@ -4,6 +4,7 @@
   "publisher": "graphene",
   "description": "Syntax highlighting and diagnostics stubs for Graphene GQL/GSQL using a Lezer-based pipeline.",
   "version": "0.0.1",
+  "type": "module",
   "engines": {
     "vscode": "^1.84.0"
   },
@@ -45,11 +46,16 @@
     ]
   },
   "scripts": {
-    "compile": "tsc -p .",
-    "watch": "tsc -w -p ."
+    "generate:lang": "npm --prefix ../lang run generate",
+    "compile": "npm run generate:lang && tsc -p .",
+    "watch": "npm run generate:lang && tsc -w -p ."
+  },
+  "dependencies": {
+    "@graphene/lang": "file:../lang"
   },
   "devDependencies": {
     "@types/vscode": "^1.84.0",
+    "@lezer/common": "^1.2.1",
     "tslib": "^2.6.2",
     "typescript": "^5.4.0"
   }

--- a/graphene/vscode/src/diagnostics.ts
+++ b/graphene/vscode/src/diagnostics.ts
@@ -1,0 +1,61 @@
+import * as vscode from 'vscode';
+
+function collectDiagnosticsStub(text: string): Array<{ message: string; start: number; end: number; severity: vscode.DiagnosticSeverity }> {
+  const diagnostics: Array<{ message: string; start: number; end: number; severity: vscode.DiagnosticSeverity }> = [];
+
+  // Very naive: warn on FIXME/TODO and on unbalanced braces
+  for (const match of text.matchAll(/\b(FIXME|TODO)\b/g)) {
+    diagnostics.push({ message: `Note: ${match[1]}`, start: match.index ?? 0, end: (match.index ?? 0) + match[0].length, severity: vscode.DiagnosticSeverity.Information });
+  }
+
+  const stack: Array<{ ch: string; index: number }> = [];
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '{' || ch === '(' || ch === '[') stack.push({ ch, index: i });
+    else if (ch === '}' || ch === ')' || ch === ']') {
+      if (!stack.length) {
+        diagnostics.push({ message: `Unmatched closing '${ch}'`, start: i, end: i + 1, severity: vscode.DiagnosticSeverity.Error });
+      } else {
+        const open = stack.pop()!;
+        const pairs: Record<string, string> = { '{': '}', '(': ')', '[': ']' };
+        if (pairs[open.ch] !== ch) {
+          diagnostics.push({ message: `Mismatched '${open.ch}' ... '${ch}'`, start: open.index, end: i + 1, severity: vscode.DiagnosticSeverity.Error });
+        }
+      }
+    }
+  }
+  for (const leftover of stack) {
+    diagnostics.push({ message: `Unclosed '${leftover.ch}'`, start: leftover.index, end: leftover.index + 1, severity: vscode.DiagnosticSeverity.Error });
+  }
+
+  return diagnostics;
+}
+
+export function activateDiagnostics(context: vscode.ExtensionContext, selector: vscode.DocumentSelector) {
+  const collection = vscode.languages.createDiagnosticCollection('graphene');
+  context.subscriptions.push(collection);
+
+  const refresh = (document: vscode.TextDocument) => {
+    if (!vscode.languages.match(selector, document)) return;
+
+    const diags: vscode.Diagnostic[] = [];
+    const text = document.getText();
+    for (const d of collectDiagnosticsStub(text)) {
+      const start = document.positionAt(d.start);
+      const end = document.positionAt(d.end);
+      const range = new vscode.Range(start, end);
+      diags.push(new vscode.Diagnostic(range, d.message, d.severity));
+    }
+
+    collection.set(document.uri, diags);
+  };
+
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument(refresh),
+    vscode.workspace.onDidChangeTextDocument(e => refresh(e.document)),
+    vscode.workspace.onDidCloseTextDocument(doc => collection.delete(doc.uri))
+  );
+
+  // Initialize already-open documents
+  vscode.workspace.textDocuments.forEach(refresh);
+}

--- a/graphene/vscode/src/extension.ts
+++ b/graphene/vscode/src/extension.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { registerSemanticTokens } from './semanticTokens';
+import { activateDiagnostics } from './diagnostics';
+
+export function activate(context: vscode.ExtensionContext) {
+  const selector: vscode.DocumentSelector = [
+    { language: 'gql', scheme: 'file' },
+    { language: 'gql', scheme: 'untitled' },
+    { language: 'gsql', scheme: 'file' },
+    { language: 'gsql', scheme: 'untitled' }
+  ];
+
+  registerSemanticTokens(context, selector);
+  activateDiagnostics(context, selector);
+}
+
+export function deactivate() {
+  // no-op
+}

--- a/graphene/vscode/src/semanticTokens.ts
+++ b/graphene/vscode/src/semanticTokens.ts
@@ -1,0 +1,85 @@
+import * as vscode from 'vscode';
+
+const tokenTypes = [
+  'keyword',
+  'string',
+  'number',
+  'type',
+  'function',
+  'variable',
+  'property',
+  'operator',
+  'comment',
+  'boolean',
+  'enumMember'
+] as const;
+
+type TokenType = typeof tokenTypes[number];
+
+const tokenTypeToIndex: Record<TokenType, number> = Object.fromEntries(
+  tokenTypes.map((t, i) => [t, i])
+) as Record<TokenType, number>;
+
+const legend = new vscode.SemanticTokensLegend(tokenTypes as unknown as string[], []);
+
+// TODO: Replace with real Lezer-based parsing from ../lang once available
+function* scanTokens(document: vscode.TextDocument): Generator<{ line: number; start: number; length: number; type: TokenType }> {
+  const keyword = /\b(type|schema|query|mutation|subscription|scalar|enum|interface|union|input|directive|fragment|on|implements|extend)\b/g;
+  const boolean = /\b(true|false|null)\b/g;
+  const number = /(?<![A-Za-z_])-?\b\d+(?:\.\d+)?\b/g;
+  const string = /"([^"\\]|\\.)*"|'([^'\\]|\\.)*'/g;
+  const comment = /#.*/g;
+  const operator = /[!:=@|&(){}[\],.]/g;
+
+  for (let line = 0; line < document.lineCount; line++) {
+    const text = document.lineAt(line).text;
+
+    comment.lastIndex = 0;
+    for (let m; (m = comment.exec(text)); ) {
+      yield { line, start: m.index, length: m[0].length, type: 'comment' };
+    }
+
+    string.lastIndex = 0;
+    for (let m; (m = string.exec(text)); ) {
+      yield { line, start: m.index, length: m[0].length, type: 'string' };
+    }
+
+    number.lastIndex = 0;
+    for (let m; (m = number.exec(text)); ) {
+      yield { line, start: m.index, length: m[0].length, type: 'number' };
+    }
+
+    keyword.lastIndex = 0;
+    for (let m; (m = keyword.exec(text)); ) {
+      yield { line, start: m.index, length: m[0].length, type: 'keyword' };
+    }
+
+    boolean.lastIndex = 0;
+    for (let m; (m = boolean.exec(text)); ) {
+      yield { line, start: m.index, length: m[0].length, type: 'boolean' };
+    }
+
+    operator.lastIndex = 0;
+    for (let m; (m = operator.exec(text)); ) {
+      yield { line, start: m.index, length: m[0].length, type: 'operator' };
+    }
+  }
+}
+
+class GrapheneSemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
+  async provideDocumentSemanticTokens(document: vscode.TextDocument): Promise<vscode.SemanticTokens> {
+    const builder = new vscode.SemanticTokensBuilder(legend);
+
+    for (const tok of scanTokens(document)) {
+      builder.push(tok.line, tok.start, tok.length, tokenTypeToIndex[tok.type], 0);
+    }
+
+    return builder.build();
+  }
+}
+
+export function registerSemanticTokens(context: vscode.ExtensionContext, selector: vscode.DocumentSelector) {
+  context.subscriptions.push(
+    vscode.languages.registerDocumentSemanticTokensProvider(selector, new GrapheneSemanticTokensProvider(), legend)
+  );
+}

--- a/graphene/vscode/src/semanticTokens.ts
+++ b/graphene/vscode/src/semanticTokens.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type {TreeCursor} from '@lezer/common';
 
 const tokenTypes = [
   'keyword',
@@ -22,56 +23,73 @@ const tokenTypeToIndex: Record<TokenType, number> = Object.fromEntries(
 
 const legend = new vscode.SemanticTokensLegend(tokenTypes as unknown as string[], []);
 
-// TODO: Replace with real Lezer-based parsing from ../lang once available
-function* scanTokens(document: vscode.TextDocument): Generator<{ line: number; start: number; length: number; type: TokenType }> {
-  const keyword = /\b(type|schema|query|mutation|subscription|scalar|enum|interface|union|input|directive|fragment|on|implements|extend)\b/g;
-  const boolean = /\b(true|false|null)\b/g;
-  const number = /(?<![A-Za-z_])-?\b\d+(?:\.\d+)?\b/g;
-  const string = /"([^"\\]|\\.)*"|'([^'\\]|\\.)*'/g;
-  const comment = /#.*/g;
-  const operator = /[!:=@|&(){}[\],.]/g;
+const KEYWORDS = new Set<string>([
+  'select','from','where','group','by','order','limit','join','on','as','having','asc','desc',
+  'true','false','null','not','like','in','is','and','or','case','when','then','else','end',
+  'create','table','exists','offset','inner','left','right','full','cross','integer','int','bigint','smallint','tinyint','real','double','precision','float','decimal','numeric','boolean','bool','date','time','timestamp','varchar','char','text','blob'
+]);
 
-  for (let line = 0; line < document.lineCount; line++) {
-    const text = document.lineAt(line).text;
+function classify(nodeName: string): TokenType | undefined {
+  if (KEYWORDS.has(nodeName)) return 'keyword';
+  switch (nodeName) {
+    case 'Identifier': return 'variable';
+    case 'Number': return 'number';
+    case 'String': return 'string';
+    case 'FunctionCall': return 'function';
+    case 'DataType': return 'type';
+    case 'Comment': return 'comment';
+    default: return undefined;
+  }
+}
 
-    comment.lastIndex = 0;
-    for (let m; (m = comment.exec(text)); ) {
-      yield { line, start: m.index, length: m[0].length, type: 'comment' };
+function pushToken(builder: vscode.SemanticTokensBuilder, document: vscode.TextDocument, from: number, to: number, type: TokenType) {
+  const start = document.positionAt(from);
+  builder.push(start.line, start.character, to - from, tokenTypeToIndex[type], 0);
+}
+
+function walkTree(builder: vscode.SemanticTokensBuilder, document: vscode.TextDocument, cursor: TreeCursor, text: string) {
+  do {
+    const type = classify(cursor.node.type.name);
+    if (type) pushToken(builder, document, cursor.from, cursor.to, type);
+    if (cursor.firstChild()) {
+      walkTree(builder, document, cursor, text);
+      cursor.parent();
     }
+  } while (cursor.nextSibling());
+}
 
-    string.lastIndex = 0;
-    for (let m; (m = string.exec(text)); ) {
-      yield { line, start: m.index, length: m[0].length, type: 'string' };
-    }
-
-    number.lastIndex = 0;
-    for (let m; (m = number.exec(text)); ) {
-      yield { line, start: m.index, length: m[0].length, type: 'number' };
-    }
-
-    keyword.lastIndex = 0;
-    for (let m; (m = keyword.exec(text)); ) {
-      yield { line, start: m.index, length: m[0].length, type: 'keyword' };
-    }
-
-    boolean.lastIndex = 0;
-    for (let m; (m = boolean.exec(text)); ) {
-      yield { line, start: m.index, length: m[0].length, type: 'boolean' };
-    }
-
-    operator.lastIndex = 0;
-    for (let m; (m = operator.exec(text)); ) {
-      yield { line, start: m.index, length: m[0].length, type: 'operator' };
-    }
+async function tryParse(text: string): Promise<{ cursor: TreeCursor } | null> {
+  try {
+    // Dynamic import to avoid hard dependency when developing extension standalone
+    const mod: any = await import('@graphene/lang/parser.js');
+    const tree = mod.parser.parse(text);
+    return { cursor: tree.cursor() };
+  } catch (_) {
+    return null;
   }
 }
 
 class GrapheneSemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
   async provideDocumentSemanticTokens(document: vscode.TextDocument): Promise<vscode.SemanticTokens> {
     const builder = new vscode.SemanticTokensBuilder(legend);
+    const text = document.getText();
 
-    for (const tok of scanTokens(document)) {
-      builder.push(tok.line, tok.start, tok.length, tokenTypeToIndex[tok.type], 0);
+    const parsed = await tryParse(text);
+    if (parsed) {
+      walkTree(builder, document, parsed.cursor, text);
+    } else {
+      // Fallback minimal highlighting when parser isn't available
+      for (let line = 0; line < document.lineCount; line++) {
+        const t = document.lineAt(line).text;
+        const comment = /--.*/g;
+        for (let m; (m = comment.exec(t)); ) {
+          builder.push(line, m.index, m[0].length, tokenTypeToIndex['comment'], 0);
+        }
+        const string = /"([^"\\]|\\.)*"|'([^'\\]|\\.)*'/g;
+        for (let m; (m = string.exec(t)); ) {
+          builder.push(line, m.index, m[0].length, tokenTypeToIndex['string'], 0);
+        }
+      }
     }
 
     return builder.build();

--- a/graphene/vscode/tsconfig.json
+++ b/graphene/vscode/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./out",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["vscode"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Adds a new `/vscode` folder containing a scaffolded VS Code extension for Graphene, providing initial syntax highlighting and diagnostics stubs for `.gql` and `.gsql` files, along with dev instructions.

---
<a href="https://cursor.com/background-agent?bcId=bc-6dd504dd-b49f-4ca3-9c65-887f098b76ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6dd504dd-b49f-4ca3-9c65-887f098b76ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

