### PR TITLE
Add diagnostics for missing table or column

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "editor.acceptSuggestionOnEnter": true,
+    "editor.acceptSuggestionOnEnter": "on",
     "editor.quickSuggestions": {
         "other": false,
         "comments": false,

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -63,6 +63,10 @@ function analyzeQuery (queryNode: SyntaxNode): Query {
     let name = txt(f.getChild('Identifier'))
     let alias = txt(f.getChild('Alias')) || name
     if (f.name == 'TableName') {
+      // validate the table exists
+      if (!TABLE_MAP[name]) {
+        query.diagnostics.push(diag(f.getChild('Identifier') || f, 'error', `Unknown table ${name}`))
+      }
       query.tables[alias || name] = {type: 'join', alias, tableName: name}
       f.sql = alias
     } else if (f.name == 'Subquery') {
@@ -131,11 +135,16 @@ function analyzeExpression (expr:SyntaxNode, query: Query, scope: Join | null): 
       expr.sql = '*'
       break
     case 'ColumnRef':
-      let [newScope, field] = lookup(expr, query, scope)
-      if (field.type == 'computed') {
-        expr.sql = analyzeExpression(field.expression, query, newScope).sql
-      } else if (field.type == 'column') {
-        expr.sql = `${newScope.alias}.${field.name}`
+      try {
+        let [newScope, field] = lookup(expr, query, scope)
+        if (field.type == 'computed') {
+          expr.sql = analyzeExpression(field.expression, query, newScope).sql
+        } else if (field.type == 'column') {
+          expr.sql = `${newScope.alias}.${field.name}`
+        }
+      } catch (e:any) {
+        query.diagnostics.push({from: expr.from, to: expr.to, message: e?.message || 'Unknown reference', severity: 'error'})
+        expr.sql = txt(expr)
       }
       break
     case 'FunctionCall':

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -135,16 +135,17 @@ function analyzeExpression (expr:SyntaxNode, query: Query, scope: Join | null): 
       expr.sql = '*'
       break
     case 'ColumnRef':
-      try {
+      {
         let [newScope, field] = lookup(expr, query, scope)
-        if (field.type == 'computed') {
-          expr.sql = analyzeExpression(field.expression, query, newScope).sql
-        } else if (field.type == 'column') {
-          expr.sql = `${newScope.alias}.${field.name}`
+        if (newScope && field) {
+          if (field.type == 'computed') {
+            expr.sql = analyzeExpression(field.expression, query, newScope).sql
+          } else if (field.type == 'column') {
+            expr.sql = `${newScope.alias}.${field.name}`
+          }
+        } else {
+          expr.sql = txt(expr)
         }
-      } catch (e:any) {
-        query.diagnostics.push({from: expr.from, to: expr.to, message: e?.message || 'Unknown reference', severity: 'error'})
-        expr.sql = txt(expr)
       }
       break
     case 'FunctionCall':

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -122,4 +122,18 @@ describe('lang', () => {
     expect((tables[0].diagnostics?.length || 0)).toBeGreaterThan(0)
     expect(queries[0].sql.toLowerCase()).toContain('from t')
   })
+
+  it('reports diagnostics for unknown table in FROM', () => {
+    let sql = testTables + '\n' + 'from not_a_table select id'
+    let {queries} = analyze(sql)
+    expect(queries[0].diagnostics.length).toBeGreaterThan(0)
+    expect(queries[0].diagnostics[0].message.toLowerCase()).toContain('unknown table')
+  })
+
+  it('reports diagnostics for unknown column', () => {
+    let sql = testTables + '\n' + 'from users select does_not_exist'
+    let {queries} = analyze(sql)
+    expect(queries[0].diagnostics.length).toBeGreaterThan(0)
+    expect(queries[0].diagnostics[0].message.toLowerCase()).toContain("couldn't find column")
+  })
 })

--- a/lang/lookup.ts
+++ b/lang/lookup.ts
@@ -4,6 +4,12 @@ import type {SyntaxNode} from '@lezer/common'
 
 type Field = Column | Join | Computed
 
+type LookupResult = [Join | null, Field | null]
+
+function pushError(query: Query, node: SyntaxNode, message: string) {
+  query.diagnostics.push({ from: node.from, to: node.to, message, severity: 'error' })
+}
+
 // Takes a column ref like `someCol` or `tableA.tableB.otherCol` and finds it.
 // This returns a JoinDef, telling us which table within the query we're pointing to, and the FieldDef.
 // The table name is within the context of the current query, so it might be an alias.
@@ -11,19 +17,25 @@ type Field = Column | Join | Computed
 //
 // Eventually, we also want this to handle model definition scope, where the tables it searchs are constrained
 // by the relative paths where those tables are defined (ie a model in `/marketing` wont be found for a query in `/finance`)
-export function lookup (node:SyntaxNode, query:Query, scope:Join | null): [Join, Field] {
+export function lookup (node:SyntaxNode, query:Query, scope:Join | null): LookupResult {
   let pathSegments = node.getChildren('Identifier').map(i => txt(i))
-  if (pathSegments.length == 0) throw new Error('tried to lookup empty ColumnRef')
+  if (pathSegments.length == 0) {
+    pushError(query, node, 'Tried to lookup empty ColumnRef')
+    return [null, null]
+  }
   let colName = pathSegments.pop()!
 
-  let searchAllTablesInQuery = (name:string): {join: Join, field: Field} => {
+  const searchAllTablesInQuery = (name:string): {join: Join, field: Field} | null => {
     let matches = Object.values(query.tables).map(join => {
       let tablish = join.subquery || TABLE_MAP[join.tableName || '']
       let field = tablish ? tablish.fields[name] : undefined
       return {join, field}
-    }).filter(a => !!a.field)
-    if (matches.length == 0) throw new Error(`Couldn't find ${name}`)
-    if (matches.length > 1) throw new Error(`Ambiguous reference to ${name}`)
+    }).filter(a => !!a.field) as {join: Join, field: Field}[]
+    if (matches.length == 0) return null
+    if (matches.length > 1) {
+      pushError(query, node, `Ambiguous reference to ${name}`)
+      return null
+    }
     return matches[0]
   }
 
@@ -31,17 +43,34 @@ export function lookup (node:SyntaxNode, query:Query, scope:Join | null): [Join,
   // It should always be a namespace, table, or join. We'll walk through them 1 by 1 to get the appropriate scope for this column.
   for (let part of pathSegments) {
     if (scope) { // our lookup is constrained to a single table (ie, you're in the middle of a dot-join or a measure)
-      if (!scope.tableName) throw new Error('Missing tableName in scope')
+      if (!scope.tableName) {
+        pushError(query, node, 'Missing tableName in scope')
+        return [null, null]
+      }
       let table = TABLE_MAP[scope.tableName]
-      if (!table) throw new Error(`Unknown table ${scope.tableName}`)
+      if (!table) {
+        pushError(query, node, `Unknown table ${scope.tableName}`)
+        return [null, null]
+      }
       let field = table.fields[part]
-      if (field.type != 'join') throw new Error("Trying to join on a column that isn't a join.")
+      if (!field) {
+        pushError(query, node, `Could not find ${part} on table ${scope.tableName}`)
+        return [null, null]
+      }
+      if (field.type != 'join') {
+        pushError(query, node, `Expected join '${part}' on table ${scope.tableName}`)
+        return [null, null]
+      }
       scope = query.tables[field.alias] = field
     } else if (query.tables[part]) { // you're referring to a table joined in to the query. It could be a subquery!
       scope = query.tables[part]
     } else { // this must be the name of a JoinDef in an existing table
       let match = searchAllTablesInQuery(part)
-      if (match.field.type != 'join') throw new Error("Trying to join on a column that isn't a join.")
+      if (!match) return [null, null]
+      if (match.field.type != 'join') {
+        pushError(query, node, `Expected join '${part}'`)
+        return [null, null]
+      }
       scope = query.tables[match.field.alias] = match.field
     }
   }
@@ -50,11 +79,21 @@ export function lookup (node:SyntaxNode, query:Query, scope:Join | null): [Join,
   // if we're looking up a column without a path, we need to search all the tables in the query's scope, as well as select aliases
   if (scope) {
     let tablish = scope.subquery || TABLE_MAP[scope.tableName || '']
-    if (!tablish) throw new Error(`Unknown table ${scope.tableName}`)
-    if (!tablish.fields[colName]) throw new Error(`Couldn't find column ${colName} in ${scope.alias}`)
+    if (!tablish) {
+      pushError(query, node, `Unknown table ${scope.tableName}`)
+      return [null, null]
+    }
+    if (!tablish.fields[colName]) {
+      pushError(query, node, `Couldn't find column ${colName} in ${scope.alias}`)
+      return [scope, null]
+    }
     return [scope, tablish.fields[colName]]
   } else {
     let match = searchAllTablesInQuery(colName)
+    if (!match) {
+      pushError(query, node, `Couldn't find column ${colName}`)
+      return [null, null]
+    }
     return [match.join, match.field]
   }
 }

--- a/lang/lookup.ts
+++ b/lang/lookup.ts
@@ -19,7 +19,8 @@ export function lookup (node:SyntaxNode, query:Query, scope:Join | null): [Join,
   let searchAllTablesInQuery = (name:string): {join: Join, field: Field} => {
     let matches = Object.values(query.tables).map(join => {
       let tablish = join.subquery || TABLE_MAP[join.tableName || '']
-      return {join, field: tablish.fields[name]}
+      let field = tablish ? tablish.fields[name] : undefined
+      return {join, field}
     }).filter(a => !!a.field)
     if (matches.length == 0) throw new Error(`Couldn't find ${name}`)
     if (matches.length > 1) throw new Error(`Ambiguous reference to ${name}`)
@@ -31,7 +32,9 @@ export function lookup (node:SyntaxNode, query:Query, scope:Join | null): [Join,
   for (let part of pathSegments) {
     if (scope) { // our lookup is constrained to a single table (ie, you're in the middle of a dot-join or a measure)
       if (!scope.tableName) throw new Error('Missing tableName in scope')
-      let field = TABLE_MAP[scope.tableName].fields[part]
+      let table = TABLE_MAP[scope.tableName]
+      if (!table) throw new Error(`Unknown table ${scope.tableName}`)
+      let field = table.fields[part]
       if (field.type != 'join') throw new Error("Trying to join on a column that isn't a join.")
       scope = query.tables[field.alias] = field
     } else if (query.tables[part]) { // you're referring to a table joined in to the query. It could be a subquery!
@@ -47,6 +50,7 @@ export function lookup (node:SyntaxNode, query:Query, scope:Join | null): [Join,
   // if we're looking up a column without a path, we need to search all the tables in the query's scope, as well as select aliases
   if (scope) {
     let tablish = scope.subquery || TABLE_MAP[scope.tableName || '']
+    if (!tablish) throw new Error(`Unknown table ${scope.tableName}`)
     if (!tablish.fields[colName]) throw new Error(`Couldn't find column ${colName} in ${scope.alias}`)
     return [scope, tablish.fields[colName]]
   } else {


### PR DESCRIPTION
Add diagnostics for unknown table and column references in queries.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9426236-d14b-4128-b770-43846550342b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9426236-d14b-4128-b770-43846550342b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

