### PR TITLE
Parse gql comments for metadata

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -24,27 +24,82 @@ export function analyze (source:string): { tables: Table[], queries: Query[] } {
   return {tables, queries}
 }
 
+// Helper to get the raw source for a node
+function getSourceForNode (node: SyntaxNode): string {
+  let top: SyntaxNode = node
+  while (top.parent) top = top.parent
+  return top.tree?.rawText || ''
+}
+
+// Extracts metadata from leading comment lines directly above a node.
+// Supports multi-line description with `--` prefix and key-value pairs with `--# key=value`.
+function extractLeadingMetadata (node: SyntaxNode): Record<string, string> {
+  const src = getSourceForNode(node)
+  if (!src) return {}
+  let pos = node.from
+  // Find start of the current line
+  let currentLineStart = src.lastIndexOf('\n', Math.max(0, pos - 1)) + 1
+  let endOfPrevLine = currentLineStart - 1
+  if (endOfPrevLine < 0) return {}
+
+  const commentLines: string[] = []
+  let cursor = endOfPrevLine
+  while (cursor >= 0) {
+    const startOfLine = src.lastIndexOf('\n', Math.max(0, cursor - 1)) + 1
+    const line = src.slice(startOfLine, cursor).trimEnd()
+    const trimmed = line.trim()
+    if (trimmed.length === 0) break // blank line breaks adjacency
+    if (!trimmed.startsWith('--')) break // non-comment line breaks adjacency
+    commentLines.push(trimmed)
+    cursor = startOfLine - 1
+  }
+  if (commentLines.length === 0) return {}
+
+  commentLines.reverse()
+
+  const metadata: Record<string, string> = {}
+  const descriptionLines: string[] = []
+  for (const raw of commentLines) {
+    const withoutPrefix = raw.slice(2).trimStart() // remove '--'
+    if (withoutPrefix.startsWith('#')) {
+      const kv = withoutPrefix.slice(1).trim()
+      const eqIdx = kv.indexOf('=')
+      if (eqIdx > 0) {
+        const key = kv.slice(0, eqIdx).trim()
+        const value = kv.slice(eqIdx + 1).trim()
+        if (key) metadata[key] = value
+      }
+      continue
+    }
+    if (withoutPrefix) descriptionLines.push(withoutPrefix)
+  }
+  if (descriptionLines.length) metadata.description = descriptionLines.join(' ')
+  return metadata
+}
+
 // Parses a table (model) declaration. Most analysis is done lazily, so this just gets the tables name and fields.
 function analyzeTable (tableNode: SyntaxNode): Table {
   let name = txt(tableNode.firstChild?.nextSibling)
   let diagnostics: Diagnostic[] = getParseErrors(tableNode)
-  let table = TABLE_MAP[name] = {name, fields: {}, diagnostics}
+  let table: Table = TABLE_MAP[name] = {name, fields: {}, diagnostics, metadata: extractLeadingMetadata(tableNode)}
   let fields = [
     ...tableNode.getChildren('ColumnDef').map(cn => ({
       type: 'column',
       name: txt(cn.getChild('Identifier')),
       dataType: txt(cn.getChild('DataType')),
+      metadata: extractLeadingMetadata(cn),
     })) satisfies Column[],
     ...tableNode.getChildren('JoinDef').map(jn => {
       let tableName = txt(jn.getChild('Identifier'))
       let alias = txt(jn.getChild('Alias'))
       let expression = jn.getChild('Expression')
-      return {type: 'join', alias: alias || tableName, tableName, expression}
+      return {type: 'join', alias: alias || tableName, tableName, expression, metadata: extractLeadingMetadata(jn)}
     }) satisfies Join[],
     ...tableNode.getChildren('ComputedDef').map(cn => ({
       type: 'computed',
       name: txt(cn.getChild('Identifier')),
       expression: cn.getChild('Expression')!,
+      metadata: extractLeadingMetadata(cn),
     })) satisfies Computed[],
   ]
   fields.forEach(f => {

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -32,6 +32,7 @@ export interface Column {
   type: 'column'
   name: string
   dataType: string
+  metadata: Record<string, string>
 }
 
 export interface Join {
@@ -40,12 +41,14 @@ export interface Join {
   tableName?: string
   expression?: SyntaxNode | null
   subquery?: Query
+  metadata: Record<string, string>
 }
 
 export interface Computed {
   type: 'computed'
   name: string
   expression: SyntaxNode
+  metadata: Record<string, string>
 }
 
 type Field = Column | Join | Computed
@@ -54,6 +57,7 @@ export interface Table {
   name: string
   fields: Record<string, Field>
   diagnostics: Diagnostic[]
+  metadata: Record<string, string>
 }
 
 export class Query {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -123,3 +123,44 @@ describe('lang', () => {
     expect(queries[0].sql.toLowerCase()).toContain('from t')
   })
 })
+
+describe('metadata from comments', () => {
+  it('extracts description and key=value metadata for tables and fields', () => {
+    const sql = `
+-- A table of flight records
+--# source=etl
+--# owner=data-eng
+ table flights (
+   id bigint,
+
+   -- the total spent on fuel at the start of this flight
+   --# units=usd
+   fuel_cost bigint,
+
+   -- a join to users table
+   --# relation=owner
+   join_one users on users.id = flights.id,
+
+   -- computed value
+   --# quality=derived
+   measure cost_per_unit fuel_cost / 100
+ )
+ from flights select id` // include a dummy query to avoid empty queries
+    const {tables} = analyze(sql)
+    expect(tables.length).toBe(1)
+    const t = tables[0]
+    expect(t.metadata.description.toLowerCase()).toContain('table of flight records')
+    expect(t.metadata.source).toBe('etl')
+    expect(t.metadata.owner).toBe('data-eng')
+
+    const fuel = (t.fields['fuel_cost'] as any)
+    expect(fuel.metadata.description.toLowerCase()).toContain('total spent on fuel')
+    expect(fuel.metadata.units).toBe('usd')
+
+    const j = (t.fields['users'] as any)
+    expect(j.metadata.relation).toBe('owner')
+
+    const m = (t.fields['cost_per_unit'] as any)
+    expect(m.metadata.quality).toBe('derived')
+  })
+})


### PR DESCRIPTION
Add `metadata` property to tables and fields, extracted from leading comments, to support richer schema documentation.

This enables parsing multi-line descriptions and `--# key=value` pairs from comments immediately preceding table and field definitions, providing a structured way to attach additional information. Blank lines break adjacency, and only `--` comments are considered.

---
<a href="https://cursor.com/background-agent?bcId=bc-c64b39b6-02a0-40a0-9cbb-7dcc993a8ce8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c64b39b6-02a0-40a0-9cbb-7dcc993a8ce8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

