### PR TITLE
Add malloy sql generation and table as query

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -20,7 +20,10 @@ export async function loadWorkspace (dir:string) {
 export function analyze (source:string): { tables: Table[], queries: Query[] } {
   let tree = parser.parse(source)
   tree.rawText = source
-  let tables = tree.topNode.getChildren('TableStatement').map(analyzeTable).filter((t): t is Table => !!t)
+  let tables = [
+    ...tree.topNode.getChildren('TableStatement').map(analyzeTable).filter((t): t is Table => !!t),
+    ...tree.topNode.getChildren('TableAsQuery').map(analyzeTableAsQuery).filter((t): t is Table => !!t),
+  ]
   let queries = tree.topNode.getChildren('QueryStatement').map(analyzeQuery)
   return {tables, queries}
 }
@@ -59,10 +62,25 @@ function analyzeTable (tableNode: SyntaxNode): Table {
   return table
 }
 
+// Parses a `table <name> as (<query>)` statement into a Table with an attached Query
+function analyzeTableAsQuery (node: SyntaxNode): Table {
+  let name = txt(node.getChild('Identifier'))
+  let table = new Table(name)
+  TABLE_MAP[table.name] = table
+  getParseErrors(node).forEach(n => table.diag(n, 'Syntax error'))
+  table.metadata = extractLeadingMetadata(node)
+  let qn = node.getChild('QueryStatement')
+  if (qn) {
+    table.asQuery = analyzeQuery(qn)
+  }
+  return table
+}
+
 // Walks each part of the query checking types, rendering sql
 // NB that this creates a scope for the query, and function like analyzeExpression and lookup operate within that scope, which is crucial for subquery support.
 function analyzeQuery (queryNode: SyntaxNode): Query {
   let query = new Query()
+  query.treeNode = queryNode
   getParseErrors(queryNode).forEach(n => query.diag(n, 'Syntax error'))
 
   let froms = queryNode.getChild('FromClause')?.getChildren('TablePrimary') || []

--- a/lang/malloy.ts
+++ b/lang/malloy.ts
@@ -13,10 +13,13 @@
 import type {Query as GrapheneQuery, Table as GrapheneTable, Column as GrapheneColumn, Join as GrapheneJoin} from './core.ts'
 import {TABLE_MAP, txt} from './core.ts'
 
-// Malloy types are not installed as a dependency here; declare minimal shapes used below based on the PoC
-// If the project later adds Malloy as a dep, replace these with real imports.
+// Prefer the real Malloy QueryModel from the installed package
+// Ensure dialects are registered for compilation
+// These are deep imports which exist in the published package
+import {QueryModel as RealQueryModel} from '@malloydata/malloy/dist/model/malloy_query.js'
+import '@malloydata/malloy/dist/dialect/dialect_map.js'
 
-// Minimal Malloy IR type declarations
+// Minimal Malloy IR type declarations (kept for construction typing)
 namespace malloy {
   export type AtomicType = 'string' | 'number' | 'boolean' | 'date' | 'timestamp'
 
@@ -103,39 +106,23 @@ namespace malloy {
     structRef: string
     pipeline: PipelineStage[]
   }
-
-  export class QueryModel {
-    private model: ModelDef
-    constructor (m: ModelDef) { this.model = m }
-    // Placeholder compileQuery; in real usage, this should call Malloy's compiler
-    compileQuery (_q: Query): {sql: string} {
-      throw new Error('Malloy not installed in this workspace. Install Malloy and replace stubs, or invoke toMalloy() and compile externally.')
-    }
-  }
 }
 
-export type MalloyQueryModel = any // will be malloy.QueryModel once wired to real lib
-export type MalloyQuery = any // will be malloy.Query once wired to real lib
+export type MalloyQueryModel = any
+export type MalloyQuery = any
 
-// Public API: best-effort rendering using Malloy. This relies on Malloy being available at runtime.
+// Public API: rendering using Malloy compiler
 export function renderSql (query: GrapheneQuery): string {
   const [qm, mq] = toMalloy(query)
-  // If the stub QueryModel is still in use, this throws; surface a clear message.
-  try {
-    const compiled = (qm as any).compileQuery(mq)
-    return compiled.sql
-  } catch (err) {
-    throw new Error('Malloy compilation is not available in this environment. Use toMalloy() and compile where Malloy is installed. Original error: ' + (err as Error).message)
-  }
+  const compiled = (qm as any).compileQuery(mq)
+  return compiled.sql
 }
 
 // Translate Graphene Query + TABLE_MAP into Malloy IR
 export function toMalloy (query: GrapheneQuery): [MalloyQueryModel, MalloyQuery] {
-  // Build ModelDef from TABLE_MAP and any table.asQuery
   const contents: Record<string, malloy.StructContent> = {}
   for (const [name, t] of Object.entries(TABLE_MAP)) {
     if (t.asQuery) {
-      // Represent as a query_source with guessed field list (no types known → default number)
       const q = translateQuery(t.asQuery, name)
       const fields = inferFieldsFromQuery(t.asQuery)
       contents[name] = {
@@ -159,7 +146,7 @@ export function toMalloy (query: GrapheneQuery): [MalloyQueryModel, MalloyQuery]
     dependencies: {},
   }
 
-  const qm = new malloy.QueryModel(model)
+  const qm = new RealQueryModel(model)
   const mq = translateQuery(query)
   return [qm as MalloyQueryModel, mq as MalloyQuery]
 }
@@ -176,15 +163,12 @@ function translateTable (t: GrapheneTable): malloy.TableSourceDef {
       if (!target) throw new Error(`Unknown join target table: ${j.tableName}`)
       const joined = translateTable(target) as malloy.JoinFieldDef
       joined.name = j.alias
-      joined.join = 'one' // only join_one in grammar currently
+      joined.join = 'one'
       if (j.expression) {
         joined.onExpression = translateExpressionSql(txt(j.expression))
       }
       fields.push(joined)
     } else {
-      // Computed measures are not yet modeled in Malloy table fields here; skip or could add later
-      // For now, skip with a note
-      // eslint-disable-next-line no-continue
       continue
     }
   }
@@ -199,7 +183,6 @@ function translateTable (t: GrapheneTable): malloy.TableSourceDef {
 }
 
 function translateQuery (q: GrapheneQuery, structNameHint?: string): malloy.Query {
-  // Determine base structRef from q.tables
   const structRef = pickPrimaryStruct(q, structNameHint)
   const selectExprs = collectSelects(q)
   const filter = collectFilter(q)
@@ -216,14 +199,12 @@ function translateQuery (q: GrapheneQuery, structNameHint?: string): malloy.Quer
 
 function pickPrimaryStruct (q: GrapheneQuery, hint?: string): string {
   if (hint) return hint
-  // Choose first FROM table alias
   const first = Object.values(q.tables)[0]
   if (!first) throw new Error('Query has no tables in FROM')
   return first.alias || first.tableName || 'unknown'
 }
 
 function collectSelects (q: GrapheneQuery): (malloy.RefToField | malloy.AtomicFieldDef)[] {
-  // We rely on the parsed/annotated query treeNode to re-walk selects; otherwise we cannot reconstruct expressions.
   const node = q.treeNode
   if (!node) throw new Error('Query.treeNode missing; ensure analyze() sets treeNode on Query')
 
@@ -237,7 +218,6 @@ function collectSelects (q: GrapheneQuery): (malloy.RefToField | malloy.AtomicFi
     const expr = it.getChild('Expression')
     if (!expr) continue
 
-    // If expression is a simple ColumnRef, emit fieldref; otherwise, emit computed AtomicFieldDef with guessed type
     if (expr.name === 'ColumnRef') {
       const path = expr.getChildren('Identifier').map(id => txt(id))
       out.push({type: 'fieldref', path})
@@ -277,12 +257,11 @@ function translateExpr (expr: any, q: GrapheneQuery): malloy.Expression {
       if ((raw.startsWith("'") && raw.endsWith("'")) || (raw.startsWith('"') && raw.endsWith('"'))) {
         return {node: 'stringLiteral', literal: raw.slice(1, -1)}
       }
-      // true/false/null currently not mapped; treat as string literal stub
       return {node: 'stringLiteral', literal: raw}
     }
     case 'ColumnRef':
       return {node: 'field', path: expr.getChildren('Identifier').map((i: any) => txt(i))}
-    case 'FunctionCall': { // map a few common aggregates
+    case 'FunctionCall': {
       const fn = txt(expr.getChild('Identifier')).toLowerCase()
       const args = expr.getChildren('Expression')
       if (['sum', 'avg', 'min', 'max', 'count'].includes(fn)) {
@@ -308,7 +287,6 @@ function translateExpr (expr: any, q: GrapheneQuery): malloy.Expression {
       const u = txt(expr.getChild('UnaryOperator')).toLowerCase()
       if (u === 'not') return {node: 'not', e: inner}
       if (u === '+' || u === '-') {
-        // Represent unary +/- as binary with 0 op for now
         const zero: malloy.Expression = {node: 'numberLiteral', literal: '0'}
         return {node: u === '+' ? '+' : '-', kids: {left: zero, right: inner}}
       }
@@ -322,7 +300,6 @@ function translateExpr (expr: any, q: GrapheneQuery): malloy.Expression {
 }
 
 function translateExpressionSql (sql: string): malloy.Expression {
-  // Extremely limited parser for join ON expressions: expect "a = b"
   const m = sql.match(/\s*([\w\.]+)\s*(=)\s*([\w\.]+)\s*/i)
   if (!m) throw new Error(`Unsupported join expression: ${sql}`)
   const left = {node: 'field', path: m[1].split('.')}
@@ -331,8 +308,6 @@ function translateExpressionSql (sql: string): malloy.Expression {
 }
 
 function inferFieldsFromQuery (_q: GrapheneQuery): malloy.AtomicFieldDef[] {
-  // Without full column lineage, just return empty; Malloy PoC had explicit fields. For now, assume none.
-  // Alternatively, a very rough heuristic: if the query has a SelectClause with ColumnRefs, include them with number type.
   const node = _q.treeNode
   if (!node) return []
   const select = node.getChild('SelectClause')
@@ -343,7 +318,6 @@ function inferFieldsFromQuery (_q: GrapheneQuery): malloy.AtomicFieldDef[] {
     const expr = it.getChild('Expression')
     if (!expr) continue
     const name = it.getChild('Alias') ? txt(it.getChild('Alias')) : deriveExprAlias(expr)
-    // Default to number as requested
     fields.push({type: 'number', name})
   }
   return fields
@@ -356,6 +330,5 @@ function guessType (sqlType: string): malloy.AtomicType {
   if (t.includes('bool')) return 'boolean'
   if (t.includes('date') && !t.includes('time')) return 'date'
   if (t.includes('time')) return 'timestamp'
-  // numeric-ish
   return 'number'
 }

--- a/lang/malloy.ts
+++ b/lang/malloy.ts
@@ -1,0 +1,361 @@
+/*
+  Malloy IR translation layer for Graphene queries.
+  - renderSql(query): returns SQL string using Malloy compiler
+  - toMalloy(query): returns [QueryModel, Query] malloy constructs
+
+  Notes:
+  - We currently assume all scalar fields are type 'number' unless clearly string-like by heuristic.
+  - Many features are stubbed; we throw for unsupported constructs for now.
+*/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type {Query as GrapheneQuery, Table as GrapheneTable, Column as GrapheneColumn, Join as GrapheneJoin} from './core.ts'
+import {TABLE_MAP, txt} from './core.ts'
+
+// Malloy types are not installed as a dependency here; declare minimal shapes used below based on the PoC
+// If the project later adds Malloy as a dep, replace these with real imports.
+
+// Minimal Malloy IR type declarations
+namespace malloy {
+  export type AtomicType = 'string' | 'number' | 'boolean' | 'date' | 'timestamp'
+
+  export interface AtomicFieldDef {
+    type: AtomicType
+    name: string
+    e?: Expression
+  }
+
+  export interface RefToField {
+    type: 'fieldref'
+    path: string[]
+  }
+
+  export interface JoinFieldDef extends TableSourceDef {
+    join: 'one' | 'many'
+    onExpression?: Expression
+  }
+
+  export type FieldDef = AtomicFieldDef | JoinFieldDef | RefToField
+
+  export interface TableSourceDef {
+    type: 'table'
+    name: string
+    fields?: FieldDef[]
+    connection?: string
+    dialect?: string
+    tablePath?: string
+  }
+
+  export interface QuerySourceDef {
+    type: 'query_source'
+    name: string
+    fields: AtomicFieldDef[]
+    connection?: string
+    dialect?: string
+    query: Query
+  }
+
+  export type StructContent = TableSourceDef | QuerySourceDef
+
+  export interface ModelDef {
+    name: string
+    exports: string[]
+    contents: Record<string, StructContent>
+    queryList: Query[]
+    dependencies: Record<string, unknown>
+  }
+
+  export type FilterExpression = {
+    node: 'filterCondition'
+    code: string
+    expressionType: 'scalar'
+    e: Expression
+  }
+
+  export type Expression =
+    | {node: 'field'; path: string[]}
+    | {node: 'numberLiteral'; literal: string}
+    | {node: 'stringLiteral'; literal: string}
+    | {node: 'aggregate'; function: 'sum' | 'avg' | 'min' | 'max' | 'count'; e?: Expression}
+    | {node: '/'; kids: {left: Expression; right: Expression}}
+    | {node: '+' | '-' | '*' | '%'; kids: {left: Expression; right: Expression}}
+    | {node: '=' | '!=' | '<>' | '<' | '>' | '<=' | '>='; kids: {left: Expression; right: Expression}}
+    | {node: 'like'; kids: {left: Expression; right: Expression}}
+    | {node: 'and' | 'or'; kids: {left: Expression; right: Expression}}
+    | {node: 'not'; e: Expression}
+    | {node: 'all'; e: Expression}
+
+  export interface ProjectStage {
+    type: 'project'
+    queryFields: (RefToField | AtomicFieldDef)[]
+  }
+
+  export interface ReduceStage {
+    type: 'reduce'
+    queryFields: (RefToField | AtomicFieldDef)[]
+    filterList?: FilterExpression[]
+  }
+
+  export type PipelineStage = ProjectStage | ReduceStage
+
+  export interface Query {
+    structRef: string
+    pipeline: PipelineStage[]
+  }
+
+  export class QueryModel {
+    private model: ModelDef
+    constructor (m: ModelDef) { this.model = m }
+    // Placeholder compileQuery; in real usage, this should call Malloy's compiler
+    compileQuery (_q: Query): {sql: string} {
+      throw new Error('Malloy not installed in this workspace. Install Malloy and replace stubs, or invoke toMalloy() and compile externally.')
+    }
+  }
+}
+
+export type MalloyQueryModel = any // will be malloy.QueryModel once wired to real lib
+export type MalloyQuery = any // will be malloy.Query once wired to real lib
+
+// Public API: best-effort rendering using Malloy. This relies on Malloy being available at runtime.
+export function renderSql (query: GrapheneQuery): string {
+  const [qm, mq] = toMalloy(query)
+  // If the stub QueryModel is still in use, this throws; surface a clear message.
+  try {
+    const compiled = (qm as any).compileQuery(mq)
+    return compiled.sql
+  } catch (err) {
+    throw new Error('Malloy compilation is not available in this environment. Use toMalloy() and compile where Malloy is installed. Original error: ' + (err as Error).message)
+  }
+}
+
+// Translate Graphene Query + TABLE_MAP into Malloy IR
+export function toMalloy (query: GrapheneQuery): [MalloyQueryModel, MalloyQuery] {
+  // Build ModelDef from TABLE_MAP and any table.asQuery
+  const contents: Record<string, malloy.StructContent> = {}
+  for (const [name, t] of Object.entries(TABLE_MAP)) {
+    if (t.asQuery) {
+      // Represent as a query_source with guessed field list (no types known → default number)
+      const q = translateQuery(t.asQuery, name)
+      const fields = inferFieldsFromQuery(t.asQuery)
+      contents[name] = {
+        type: 'query_source',
+        name,
+        fields,
+        connection: 'duckdb',
+        dialect: 'duckdb',
+        query: q,
+      }
+    } else {
+      contents[name] = translateTable(t)
+    }
+  }
+
+  const model: malloy.ModelDef = {
+    name: 'generated_model',
+    exports: [],
+    contents,
+    queryList: [],
+    dependencies: {},
+  }
+
+  const qm = new malloy.QueryModel(model)
+  const mq = translateQuery(query)
+  return [qm as MalloyQueryModel, mq as MalloyQuery]
+}
+
+function translateTable (t: GrapheneTable): malloy.TableSourceDef {
+  const fields: malloy.FieldDef[] = []
+  for (const f of Object.values(t.fields)) {
+    if ((f as GrapheneColumn).type === 'column') {
+      const col = f as GrapheneColumn
+      fields.push({type: guessType(col.dataType), name: col.name})
+    } else if ((f as GrapheneJoin).type === 'join') {
+      const j = f as GrapheneJoin
+      const target = TABLE_MAP[j.tableName || '']
+      if (!target) throw new Error(`Unknown join target table: ${j.tableName}`)
+      const joined = translateTable(target) as malloy.JoinFieldDef
+      joined.name = j.alias
+      joined.join = 'one' // only join_one in grammar currently
+      if (j.expression) {
+        joined.onExpression = translateExpressionSql(txt(j.expression))
+      }
+      fields.push(joined)
+    } else {
+      // Computed measures are not yet modeled in Malloy table fields here; skip or could add later
+      // For now, skip with a note
+      // eslint-disable-next-line no-continue
+      continue
+    }
+  }
+  return {
+    type: 'table',
+    name: t.name,
+    fields,
+    connection: 'duckdb',
+    dialect: 'duckdb',
+    tablePath: t.name,
+  }
+}
+
+function translateQuery (q: GrapheneQuery, structNameHint?: string): malloy.Query {
+  // Determine base structRef from q.tables
+  const structRef = pickPrimaryStruct(q, structNameHint)
+  const selectExprs = collectSelects(q)
+  const filter = collectFilter(q)
+
+  const queryFields = selectExprs
+  const reduce: malloy.ReduceStage = {
+    type: 'reduce',
+    queryFields,
+    filterList: filter ? [filter] : undefined,
+  }
+
+  return {structRef, pipeline: [reduce]}
+}
+
+function pickPrimaryStruct (q: GrapheneQuery, hint?: string): string {
+  if (hint) return hint
+  // Choose first FROM table alias
+  const first = Object.values(q.tables)[0]
+  if (!first) throw new Error('Query has no tables in FROM')
+  return first.alias || first.tableName || 'unknown'
+}
+
+function collectSelects (q: GrapheneQuery): (malloy.RefToField | malloy.AtomicFieldDef)[] {
+  // We rely on the parsed/annotated query treeNode to re-walk selects; otherwise we cannot reconstruct expressions.
+  const node = q.treeNode
+  if (!node) throw new Error('Query.treeNode missing; ensure analyze() sets treeNode on Query')
+
+  const select = node.getChild('SelectClause')
+  if (!select) return []
+
+  const items = select.getChildren('SelectItem')
+  const out: (malloy.RefToField | malloy.AtomicFieldDef)[] = []
+  for (const it of items) {
+    const alias = it.getChild('Alias')?.toString() ? it.getChild('Alias') : null
+    const expr = it.getChild('Expression')
+    if (!expr) continue
+
+    // If expression is a simple ColumnRef, emit fieldref; otherwise, emit computed AtomicFieldDef with guessed type
+    if (expr.name === 'ColumnRef') {
+      const path = expr.getChildren('Identifier').map(id => txt(id))
+      out.push({type: 'fieldref', path})
+    } else {
+      const name = alias ? txt(alias) : deriveExprAlias(expr)
+      out.push({type: 'number', name, e: translateExpr(expr, q)})
+    }
+  }
+  return out
+}
+
+function collectFilter (q: GrapheneQuery): malloy.FilterExpression | null {
+  const node = q.treeNode
+  if (!node) return null
+  const wc = node.getChild('WhereClause')
+  if (!wc) return null
+  const expr = wc.getChild('Expression')
+  if (!expr) return null
+  return {
+    node: 'filterCondition',
+    code: txt(expr) || 'filter',
+    expressionType: 'scalar',
+    e: translateExpr(expr, q),
+  }
+}
+
+function deriveExprAlias (_expr: any): string {
+  return 'expr'
+}
+
+function translateExpr (expr: any, q: GrapheneQuery): malloy.Expression {
+  switch (expr.name) {
+    case 'Literal': {
+      const raw = txt(expr)
+      if (raw == null) throw new Error('Empty literal')
+      if (/^\d+(\.\d+)?$/.test(raw)) return {node: 'numberLiteral', literal: raw}
+      if ((raw.startsWith("'") && raw.endsWith("'")) || (raw.startsWith('"') && raw.endsWith('"'))) {
+        return {node: 'stringLiteral', literal: raw.slice(1, -1)}
+      }
+      // true/false/null currently not mapped; treat as string literal stub
+      return {node: 'stringLiteral', literal: raw}
+    }
+    case 'ColumnRef':
+      return {node: 'field', path: expr.getChildren('Identifier').map((i: any) => txt(i))}
+    case 'FunctionCall': { // map a few common aggregates
+      const fn = txt(expr.getChild('Identifier')).toLowerCase()
+      const args = expr.getChildren('Expression')
+      if (['sum', 'avg', 'min', 'max', 'count'].includes(fn)) {
+        return {node: 'aggregate', function: fn as any, e: args[0] ? translateExpr(args[0], q) : undefined}
+      }
+      throw new Error(`Unsupported function '${fn}' in Malloy translation`)
+    }
+    case 'Parenthetical':
+      return translateExpr(expr.getChild('Expression'), q)
+    case 'BinaryExpression': {
+      const left = translateExpr(expr.firstChild, q)
+      const right = translateExpr(expr.lastChild, q)
+      const op = txt(expr.firstChild.nextSibling).toLowerCase()
+      const allowed = ['+', '-', '*', '/', '%', '=', '!=', '<>', '<', '>', '<=', '>=', 'like', 'and', 'or']
+      if (!allowed.includes(op)) throw new Error(`Unsupported operator '${op}' in Malloy translation`)
+      if (op === 'and' || op === 'or') return {node: op as any, kids: {left, right}}
+      if (op === 'like') return {node: 'like', kids: {left, right}}
+      if (op === '/' || op === '+' || op === '-' || op === '*' || op === '%') return {node: op as any, kids: {left, right}}
+      return {node: op as any, kids: {left, right}}
+    }
+    case 'UnaryExpression': {
+      const inner = translateExpr(expr.getChild('Expression'), q)
+      const u = txt(expr.getChild('UnaryOperator')).toLowerCase()
+      if (u === 'not') return {node: 'not', e: inner}
+      if (u === '+' || u === '-') {
+        // Represent unary +/- as binary with 0 op for now
+        const zero: malloy.Expression = {node: 'numberLiteral', literal: '0'}
+        return {node: u === '+' ? '+' : '-', kids: {left: zero, right: inner}}
+      }
+      throw new Error(`Unsupported unary operator '${u}'`)
+    }
+    case 'SubqueryExpression':
+      throw new Error('Subquery expression translation is not yet implemented in Malloy IR')
+    default:
+      throw new Error(`Unsupported expression node '${expr.name}' in Malloy translation`)
+  }
+}
+
+function translateExpressionSql (sql: string): malloy.Expression {
+  // Extremely limited parser for join ON expressions: expect "a = b"
+  const m = sql.match(/\s*([\w\.]+)\s*(=)\s*([\w\.]+)\s*/i)
+  if (!m) throw new Error(`Unsupported join expression: ${sql}`)
+  const left = {node: 'field', path: m[1].split('.')}
+  const right = {node: 'field', path: m[3].split('.')}
+  return {node: '=', kids: {left, right}}
+}
+
+function inferFieldsFromQuery (_q: GrapheneQuery): malloy.AtomicFieldDef[] {
+  // Without full column lineage, just return empty; Malloy PoC had explicit fields. For now, assume none.
+  // Alternatively, a very rough heuristic: if the query has a SelectClause with ColumnRefs, include them with number type.
+  const node = _q.treeNode
+  if (!node) return []
+  const select = node.getChild('SelectClause')
+  if (!select) return []
+  const items = select.getChildren('SelectItem')
+  const fields: malloy.AtomicFieldDef[] = []
+  for (const it of items) {
+    const expr = it.getChild('Expression')
+    if (!expr) continue
+    const name = it.getChild('Alias') ? txt(it.getChild('Alias')) : deriveExprAlias(expr)
+    // Default to number as requested
+    fields.push({type: 'number', name})
+  }
+  return fields
+}
+
+function guessType (sqlType: string): malloy.AtomicType {
+  const t = (sqlType || '').toLowerCase()
+  if (!t) return 'number'
+  if (t.includes('char') || t.includes('text') || t.includes('string')) return 'string'
+  if (t.includes('bool')) return 'boolean'
+  if (t.includes('date') && !t.includes('time')) return 'date'
+  if (t.includes('time')) return 'timestamp'
+  // numeric-ish
+  return 'number'
+}

--- a/lang/package.json
+++ b/lang/package.json
@@ -11,6 +11,7 @@
     "@lezer/generator": "^1.8.0"
   },
   "dependencies": {
-    "@lezer/lr": "^1.4.2"
+    "@lezer/lr": "^1.4.2",
+    "@malloydata/malloy": "^5.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,8 @@
         "@lezer/lr": "^1.4.2"
       },
       "devDependencies": {
-        "@lezer/generator": "^1.8.0"
+        "@lezer/generator": "^1.8.0",
+        "@types/node": "^24.2.1"
       }
     },
     "lang/node_modules/@lezer/generator": {
@@ -71,6 +72,23 @@
       "bin": {
         "lezer-generator": "src/lezer-generator.cjs"
       }
+    },
+    "lang/node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "lang/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "eslint": "^9.32.0",
         "eslint-plugin-prefer-let": "^4.0.0",
         "typescript-eslint": "^8.38.0",
-        "vitest": "^3.0.5",
+        "vitest": "^3.2.4",
         "zx": "^8.7.2"
       }
     },
@@ -1852,6 +1852,47 @@
       "resolved": "https://registry.npmjs.org/@uwdata/mosaic-sql/-/mosaic-sql-0.10.0.tgz",
       "integrity": "sha512-tPsgrHO8zTwLFMBR+BiG4fskK9RSbH+nXS9ju8433NDq3qicAq4Z46CnYpCs0vWIR7AUAxMvncqP6YPbiQhOug==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@evidence-dev/sdk/node_modules/@vitest/coverage-v8": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.5.tgz",
+      "integrity": "sha512-zOOWIsj5fHh3jjGwQg+P+J1FW3s4jBu1Zqga0qW60yutsBtqEqNEJKWYh7cYn1yGD+1bdPsPdC/eL4eVK56xMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "debug": "^4.4.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.0.5",
+        "vitest": "3.0.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@evidence-dev/sdk/node_modules/@vitest/coverage-v8/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@evidence-dev/sdk/node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -3759,6 +3800,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/command-line-args": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
@@ -3784,6 +3835,13 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -4637,38 +4695,6 @@
       "integrity": "sha512-/xdasEcxBzBG1O9WyhnsFnbf/GXjKSbl4lcpg3Cawrl3m6EuA9mKm0WStxAlEBRj1CscJbOHi355e1g7bv/zGg==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@vitest/coverage-v8": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.5.tgz",
-      "integrity": "sha512-zOOWIsj5fHh3jjGwQg+P+J1FW3s4jBu1Zqga0qW60yutsBtqEqNEJKWYh7cYn1yGD+1bdPsPdC/eL4eVK56xMg==",
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
-        "@bcoe/v8-coverage": "^1.0.2",
-        "debug": "^4.4.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
-        "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.17",
-        "magicast": "^0.3.5",
-        "std-env": "^3.8.0",
-        "test-exclude": "^7.0.1",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "3.0.5",
-        "vitest": "3.0.5"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
@@ -4721,12 +4747,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.5.tgz",
-      "integrity": "sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.5",
+        "@vitest/spy": "3.2.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -4735,7 +4762,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -4747,15 +4774,26 @@
       }
     },
     "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.5.tgz",
-      "integrity": "sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/pretty-format": {
@@ -4780,22 +4818,25 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.5.tgz",
-      "integrity": "sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.0.5",
-        "pathe": "^2.0.2"
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.5.tgz",
-      "integrity": "sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -4805,13 +4846,14 @@
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.5.tgz",
-      "integrity": "sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.5",
-        "loupe": "^3.1.2",
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
       "funding": {
@@ -4819,23 +4861,25 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.5.tgz",
-      "integrity": "sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.5",
+        "@vitest/pretty-format": "3.2.4",
         "magic-string": "^0.30.17",
-        "pathe": "^2.0.2"
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.5.tgz",
-      "integrity": "sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -11754,6 +11798,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/style-mod": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
@@ -12193,6 +12257,51 @@
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -12206,6 +12315,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -12963,16 +13073,17 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.5.tgz",
-      "integrity": "sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.4.0",
-        "es-module-lexer": "^1.6.0",
-        "pathe": "^2.0.2",
-        "vite": "^5.0.0 || ^6.0.0"
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
@@ -13406,30 +13517,34 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.5.tgz",
-      "integrity": "sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.0.5",
-        "@vitest/mocker": "3.0.5",
-        "@vitest/pretty-format": "^3.0.5",
-        "@vitest/runner": "3.0.5",
-        "@vitest/snapshot": "3.0.5",
-        "@vitest/spy": "3.0.5",
-        "@vitest/utils": "3.0.5",
-        "chai": "^5.1.2",
-        "debug": "^4.4.0",
-        "expect-type": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
         "magic-string": "^0.30.17",
-        "pathe": "^2.0.2",
-        "std-env": "^3.8.0",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
-        "tinypool": "^1.0.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
         "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.0.5",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -13445,8 +13560,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.0.5",
-        "@vitest/ui": "3.0.5",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -13475,14 +13590,16 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/expect": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.5.tgz",
-      "integrity": "sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.5",
-        "@vitest/utils": "3.0.5",
-        "chai": "^5.1.2",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
       "funding": {
@@ -13493,6 +13610,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
       "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -13502,41 +13620,54 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.5.tgz",
-      "integrity": "sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.5.tgz",
-      "integrity": "sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.5",
-        "loupe": "^3.1.2",
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vitest/node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.5.tgz",
-      "integrity": "sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==",
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://opencollective.com/vitest"
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/void-elements": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,11 @@
     "test": "vitest run",
     "watch": "npm run watch --workspace=vscode"
   },
-  "dependencies": {},
   "devDependencies": {
     "eslint": "^9.32.0",
     "eslint-plugin-prefer-let": "^4.0.0",
     "typescript-eslint": "^8.38.0",
-    "vitest": "^3.0.5",
+    "vitest": "^3.2.4",
     "zx": "^8.7.2"
   }
 }


### PR DESCRIPTION
Adds initial Malloy IR translation and `table <name> as (<query>)` support for SQL generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c64cfbd-6b41-4620-adcb-df21c385430b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c64cfbd-6b41-4620-adcb-df21c385430b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

