### PR TITLE
Build graphene sql query testing helper

### DIFF
--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -54,7 +54,8 @@ const testTables = `
 `
 
 function testQuery (grapheneSql: string, expectedSql: string) {
-  expect(grapheneSql).toRenderSql(expectedSql)
+  expect(grapheneSql)
+    .toRenderSql(expectedSql)
 }
 
 describe('lang', () => {
@@ -187,11 +188,13 @@ describe('lang', () => {
   })
 
   it('reports diagnostics for unknown table in FROM', () => {
-    expect('from not_a_table select id').toHaveDiagnostic(/could not find table not_a_table/i)
+    expect('from not_a_table select id')
+      .toHaveDiagnostic(/could not find table not_a_table/i)
   })
 
   it('reports diagnostics for unknown column', () => {
-    expect('from orders select users.does_not_exist').toHaveDiagnostic(/could not find does_not_exist on users/i)
+    expect('from orders select users.does_not_exist')
+      .toHaveDiagnostic(/could not find does_not_exist on users/i)
   })
 
   it('can create tables from queries', () => {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -53,11 +53,6 @@ const testTables = `
   )
 `
 
-function testQuery (grapheneSql: string, expectedSql: string) {
-  expect(grapheneSql)
-    .toRenderSql(expectedSql)
-}
-
 describe('lang', () => {
   beforeEach(() => {
     clearWorkspace()
@@ -65,82 +60,60 @@ describe('lang', () => {
   })
 
   it('handles basic select query', () => {
-    testQuery(
-      'SELECT id, name from users where id = 1',
-      'SELECT base."id" as "id", base."name" as "name" FROM users as base WHERE base."id"=1',
-    )
+    expect('SELECT id, name from users where id = 1')
+      .toRenderSql('SELECT base."id" as "id", base."name" as "name" FROM users as base WHERE base."id"=1')
   })
 
   it.skip('expands plain wildcard', () => {
-    testQuery(
-      'from users select *',
-      'select base."id" as "id", base."name" as "name", base."email" as "email", base."created_at" as "created_at" from users as base',
-    )
+    expect('from users select *')
+      .toRenderSql('select base."id" as "id", base."name" as "name", base."email" as "email", base."created_at" as "created_at" from users as base')
   })
 
   it.skip('expands wildcards on a specific join', () => {
-    testQuery(
-      'from orders select users.*',
-      'select base."id" as "id", base."name" as "name", base."email" as "email", base."created_at" as "created_at" from orders as base left join users as users_0 on users_0."id"=base."user_id"',
-    )
+    expect('from orders select users.*')
+      .toRenderSql('select base."id" as "id", base."name" as "name", base."email" as "email", base."created_at" as "created_at" from orders as base left join users as users_0 on users_0."id"=base."user_id"')
   })
 
   it('supports from-first syntax', () => {
-    testQuery(
-      "from users select id, name where email like '%@example.com'",
-      "select base.\"id\" as \"id\", base.\"name\" as \"name\" from users as base where base.\"email\" like '%@example.com'",
-    )
+    expect("from users select id, name where email like '%@example.com'")
+      .toRenderSql("select base.\"id\" as \"id\", base.\"name\" as \"name\" from users as base where base.\"email\" like '%@example.com'")
   })
 
   it('expands dot-join syntax', () => {
-    testQuery(
-      'from orders select id, users.name',
-      'select base."id" as "id", users_0."name" as "users_name" from orders as base left join users as users_0 on users_0."id"=base."user_id"',
-    )
+    expect('from orders select id, users.name')
+      .toRenderSql('select base."id" as "id", users_0."name" as "users_name" from orders as base left join users as users_0 on users_0."id"=base."user_id"')
   })
 
   it.skip('handles column naming when mutliple columns have the same name', () => {
-    testQuery(
-      'from orders select users.name, products.name',
-      'SELECT orders.id, users.name, products.name FROM orders LEFT JOIN users ON (users.id = orders.user_id) LEFT JOIN products ON (products.id = orders.product_id)',
-    )
+    expect('from orders select users.name, products.name')
+      .toRenderSql('SELECT orders.id, users.name, products.name FROM orders LEFT JOIN users ON (users.id = orders.user_id) LEFT JOIN products ON (products.id = orders.product_id)')
   })
 
   it('expands measures', () => {
-    testQuery(
-      'from users select name, total_orders',
-      'select base."name" as "name", (count(1)) as "total_orders" from users as base left join orders as orders_0 on orders_0."user_id"=base."id" group by 1,2 order by 1 asc nulls last',
-    )
+    expect('from users select name, total_orders')
+      .toRenderSql('select base."name" as "name", (count(1)) as "total_orders" from users as base left join orders as orders_0 on orders_0."user_id"=base."id" group by 1,2 order by 1 asc nulls last')
   })
 
   it('handles nested measure references', () => {
-    testQuery(
-      'from orders select user_id, avg_order_value',
-      'select base."user_id" as "user_id", (coalesce(sum(base."amount"),0)*1.0/count(1)) as "avg_order_value" from orders as base',
-    )
+    expect('from orders select user_id, avg_order_value')
+      .toRenderSql('select base."user_id" as "user_id", (coalesce(sum(base."amount"),0)*1.0/count(1)) as "avg_order_value" from orders as base')
   })
 
   it.skip('handles complex joins with measures', () => {
-    testQuery(
-      'from products select name, category, total_sold where popular_item',
-      'SELECT products.name, products.category, SUM(orders.amount) FROM products LEFT JOIN orders ON (orders.product_id = products.id) GROUP BY ALL HAVING SUM(orders.amount) > 1000',
-    )
+    expect('from products select name, category, total_sold where popular_item')
+      .toRenderSql('SELECT products.name, products.category, SUM(orders.amount) FROM products LEFT JOIN orders ON (orders.product_id = products.id) GROUP BY ALL HAVING SUM(orders.amount) > 1000')
   })
 
   it('handles subqueries', () => {
-    testQuery(
-      'from (select id, name from users) select id, name',
-      `WITH __stage0 AS ( SELECT base."id" as "id", base."name" as "name" FROM users as base )
-      SELECT base."id" as "id", base."name" as "name" FROM __stage0 as base`,
-    )
+    expect('from (select id, name from users) select id, name')
+      .toRenderSql(`WITH __stage0 AS ( SELECT base."id" as "id", base."name" as "name" FROM users as base )
+      SELECT base."id" as "id", base."name" as "name" FROM __stage0 as base`)
   })
 
   it('handles subqueries with alias', () => {
-    testQuery(
-      'from (select id, name from users) as u select id, name',
-      `WITH __stage0 AS ( SELECT base."id" as "id", base."name" as "name" FROM users as base )
-      SELECT base."id" as "id", base."name" as "name" FROM __stage0 as base`,
-    )
+    expect('from (select id, name from users) as u select id, name')
+      .toRenderSql(`WITH __stage0 AS ( SELECT base."id" as "id", base."name" as "name" FROM users as base )
+      SELECT base."id" as "id", base."name" as "name" FROM __stage0 as base`)
   })
 
   it('reports syntax diagnostics on invalid query and still analyzes others', () => {
@@ -198,9 +171,7 @@ describe('lang', () => {
   })
 
   it('can create tables from queries', () => {
-    testQuery(
-      'from completed_orders select id',
-      'WITH __stage0 AS ( SELECT base."id" as "id" FROM orders as base WHERE base."status"=\'completed\' ) SELECT base."id" as "id" FROM __stage0 as base',
-    )
+    expect('from completed_orders select id')
+      .toRenderSql('WITH __stage0 AS ( SELECT base."id" as "id" FROM orders as base WHERE base."status"=\'completed\' ) SELECT base."id" as "id" FROM __stage0 as base')
   })
 })

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest/globals" />
-import {analyze, clearWorkspace, toSql} from './analyze.ts'
+import {analyze, clearWorkspace} from './analyze.ts'
+import {setTestPrelude} from './testHelpers'
 import {expect} from 'vitest'
 
 const DEBUG = !!process.env.DEBUG
@@ -53,21 +54,13 @@ const testTables = `
 `
 
 function testQuery (grapheneSql: string, expectedSql: string) {
-  let sql = testTables + '\n\n' + grapheneSql
-  if (DEBUG) console.log('Query: ', grapheneSql)
-  let {queries, diagnostics} = analyze(sql)
-  expect(diagnostics).toHaveLength(0)
-  expect(queries).toHaveLength(1)
-
-  let result = toSql(queries[0])
-  if (DEBUG) console.log('Result: ', result)
-  let clean = (s:string) => s.toLowerCase().replace(/\s+/g, ' ').replace(/\s+$/, '')
-  expect(clean(result)).toBe(clean(expectedSql))
+  expect(grapheneSql).toRenderSql(expectedSql)
 }
 
 describe('lang', () => {
   beforeEach(() => {
     clearWorkspace()
+    setTestPrelude(testTables)
   })
 
   it('handles basic select query', () => {
@@ -94,7 +87,7 @@ describe('lang', () => {
   it('supports from-first syntax', () => {
     testQuery(
       "from users select id, name where email like '%@example.com'",
-      'select base."id" as "id", base."name" as "name" from users as base where base."email" like \'%@example.com\'',
+      "select base.\"id\" as \"id\", base.\"name\" as \"name\" from users as base where base.\"email\" like '%@example.com'",
     )
   })
 
@@ -194,17 +187,11 @@ describe('lang', () => {
   })
 
   it('reports diagnostics for unknown table in FROM', () => {
-    let sql = testTables + '\n' + 'from not_a_table select id'
-    let {diagnostics} = analyze(sql)
-    expect(diagnostics.length).toBeGreaterThan(0)
-    expect(diagnostics[0].message.toLowerCase()).toContain('could not find table not_a_table')
+    expect('from not_a_table select id').toHaveDiagnostic(/could not find table not_a_table/i)
   })
 
   it('reports diagnostics for unknown column', () => {
-    let sql = testTables + '\n' + 'from orders select users.does_not_exist'
-    let {diagnostics} = analyze(sql)
-    expect(diagnostics.length).toBeGreaterThan(0)
-    expect(diagnostics[0].message.toLowerCase()).toContain('could not find does_not_exist on users')
+    expect('from orders select users.does_not_exist').toHaveDiagnostic(/could not find does_not_exist on users/i)
   })
 
   it('can create tables from queries', () => {

--- a/lang/testHelpers.ts
+++ b/lang/testHelpers.ts
@@ -1,0 +1,99 @@
+import {analyze, clearWorkspace, toSql} from './analyze.ts'
+
+const DEBUG = !!process.env.DEBUG
+
+let TEST_PRELUDE = ''
+
+export function setTestPrelude (sql: string) {
+	TEST_PRELUDE = sql || ''
+}
+
+function normalizeSql (s: string) {
+	return s.toLowerCase().replace(/\s+/g, ' ').replace(/\s+$/, '')
+}
+
+function codeFrame (source: string, from: number, to: number): string {
+	const lineStart = source.lastIndexOf('\n', Math.max(0, from - 1)) + 1
+	const lineEnd = source.indexOf('\n', to)
+	const end = lineEnd === -1 ? source.length : lineEnd
+	const lineText = source.slice(lineStart, end)
+	const col = Math.max(0, from - lineStart)
+	const width = Math.max(1, to - from)
+	const marker = `${' '.repeat(col)}^${'~'.repeat(Math.max(0, width - 1))}`
+	return `${lineText}\n${marker}`
+}
+
+function formatDiagnostics (source: string, diagnostics: {from:number; to:number; message:string}[]): string {
+	if (!diagnostics.length) return ''
+	return diagnostics.map((d, i) => {
+		const frame = codeFrame(source, d.from, d.to)
+		return `#${i + 1}: ${d.message}\n${frame}`
+	}).join('\n\n')
+}
+
+expect.extend({
+	toRenderSql (received: string, expectedSql: string) {
+		clearWorkspace()
+		const sql = `${TEST_PRELUDE}\n\n${received}`
+		const {queries, diagnostics} = analyze(sql)
+
+		if (DEBUG) console.log('Query:', received)
+
+		if (diagnostics.length > 0) {
+			return {
+				pass: false,
+				message: () => `Expected no diagnostics, but found ${diagnostics.length}:\n\n${formatDiagnostics(sql, diagnostics)}`,
+			}
+		}
+
+		if (queries.length !== 1) {
+			return {
+				pass: false,
+				message: () => `Expected exactly one query, but found ${queries.length}`,
+			}
+		}
+
+		const result = toSql(queries[0])
+		if (DEBUG) console.log('Result:', result)
+
+		const pass = normalizeSql(result) === normalizeSql(expectedSql)
+		return {
+			pass,
+			message: () => pass
+				? 'expected SQL not to match (but it did)'
+				: `Rendered SQL did not match.\n\nExpected:\n${expectedSql}\n\nReceived:\n${result}`,
+			actual: result,
+			expected: expectedSql,
+		}
+	},
+
+	toHaveDiagnostic (received: string, pattern: RegExp | string) {
+		clearWorkspace()
+		const sql = `${TEST_PRELUDE}\n\n${received}`
+		const {diagnostics} = analyze(sql)
+
+		const regex = typeof pattern === 'string' ? new RegExp(pattern, 'i') : pattern
+		const match = diagnostics.find(d => regex.test(d.message))
+
+		const pass = !!match
+		return {
+			pass,
+			message: () => pass
+				? `Expected no diagnostic matching ${regex}, but found one:\n${formatDiagnostics(sql, [match!])}`
+				: `Expected a diagnostic matching ${regex}, but found ${diagnostics.length}.\n\n${formatDiagnostics(sql, diagnostics) || 'No diagnostics.'}`,
+		}
+	},
+})
+
+// Vitest type augmentation
+declare module 'vitest' {
+	interface Assertion<T = any> {
+		toRenderSql (expectedSql: string): void
+		toHaveDiagnostic (pattern: RegExp | string): void
+	}
+
+	interface AsymmetricMatchersContaining {
+		toRenderSql (expectedSql: string): void
+		toHaveDiagnostic (pattern: RegExp | string): void
+	}
+}

--- a/lang/testHelpers.ts
+++ b/lang/testHelpers.ts
@@ -1,4 +1,5 @@
 import {analyze, clearWorkspace, toSql} from './analyze.ts'
+import {expect as vitestExpect} from 'vitest'
 
 const DEBUG = !!process.env.DEBUG
 
@@ -31,7 +32,7 @@ function formatDiagnostics (source: string, diagnostics: {from:number; to:number
 	}).join('\n\n')
 }
 
-expect.extend({
+vitestExpect.extend({
 	toRenderSql (received: string, expectedSql: string) {
 		clearWorkspace()
 		const sql = `${TEST_PRELUDE}\n\n${received}`

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import {defineConfig} from 'vitest/config'
 export default defineConfig({
   test: {
     globals: true,
+    setupFiles: ['./lang/testHelpers.ts'],
   },
 })


### PR DESCRIPTION
Add custom Vitest matchers `toRenderSql` and `toHaveDiagnostic` to simplify query testing and improve diagnostic output.

---
<a href="https://cursor.com/background-agent?bcId=bc-43c17c31-2169-422e-ae41-c4e07c9fac55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43c17c31-2169-422e-ae41-c4e07c9fac55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

