### PR TITLE
Build cli compile and run tests

### DIFF
--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -1,0 +1,74 @@
+/// <reference types="vitest/globals" />
+import {expect} from 'vitest'
+import {spawn} from 'node:child_process'
+import * as fs from 'node:fs'
+import * as fsp from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+interface RunResult {
+	code: number
+	stdout: string
+	stderr: string
+}
+
+function runCli (args: string[], cwd?: string): Promise<RunResult> {
+	return new Promise((resolve) => {
+		const cliEntry = '/workspace/cli/cli.ts'
+		const child = spawn('node', ['--experimental-strip-types', cliEntry, ...args], {cwd, env: process.env})
+		let stdout = ''
+		let stderr = ''
+		child.stdout.on('data', (d) => (stdout += d.toString()))
+		child.stderr.on('data', (d) => (stderr += d.toString()))
+		child.on('close', (code) => resolve({code: code ?? 0, stdout, stderr}))
+	})
+}
+
+async function ensureFlightsDb (): Promise<void> {
+	const dbPath = '/workspace/examples/flights/flights.duckdb'
+	if (fs.existsSync(dbPath)) return
+	const setupScript = '/workspace/examples/flights/setup.sh'
+	await fsp.chmod(setupScript, 0o755)
+	await new Promise<void>((resolve, reject) => {
+		const child = spawn('bash', [setupScript], {cwd: path.dirname(setupScript)})
+		child.on('exit', (code) => (code === 0 ? resolve() : reject(new Error('setup.sh failed'))))
+	})
+}
+
+describe('cli compile', () => {
+	it('compiles a basic query (happy path)', async () => {
+		const res = await runCli(['compile', 'from flights select carrier'], '/workspace/examples/flights')
+		expect(res.code).toBe(0)
+		expect(res.stdout.toLowerCase()).toContain('from flights')
+		expect(res.stdout.toLowerCase()).toContain('select')
+	})
+
+	it('errors on invalid function (error path)', async () => {
+		const res = await runCli(['compile', 'from flights select not_a_function()'], '/workspace/examples/flights')
+		expect(res.code).not.toBe(0)
+		expect(res.stderr.toLowerCase()).toContain('unknown function')
+	})
+})
+
+describe('cli run', () => {
+	beforeAll(async () => {
+		await ensureFlightsDb()
+	})
+
+	it('runs a query against flights.duckdb (happy path)', async () => {
+		const res = await runCli(['run', 'from flights select count() as total'], '/workspace/examples/flights')
+		expect(res.code).toBe(0)
+		expect(res.stdout.toLowerCase()).toContain('total')
+	})
+
+	it('shows an error when no .duckdb is present (error path)', async () => {
+		const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-cli-'))
+		const input = [
+			'table t (a int)',
+			'from t select a',
+		].join('\n')
+		const res = await runCli(['run', input], tmpDir)
+		expect(res.code).toBe(0) // command handles the error and exits without throwing
+		expect(res.stderr.toLowerCase()).toContain('no .duckdb file found')
+	})
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -812,35 +812,35 @@
       }
     },
     "node_modules/@duckdb/node-api": {
-      "version": "1.3.2-alpha.24",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.3.2-alpha.24.tgz",
-      "integrity": "sha512-m1gXrG5HyzfJA1uFtw2jwvcfm2sG6vY6uQrE2L9bQJPfHRbAuxse+mkZXxmm7SVi15bNw5RXHzuHOJyT6uB8dQ==",
+      "version": "1.3.2-alpha.25",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.3.2-alpha.25.tgz",
+      "integrity": "sha512-AzDyyjTtnYUxoy/MHDFRwfOggDOkS8RBgGA82OI6nla8B9NDNZeAYJ97T3PvCL8cx7y00EtGVN3g03aoW4fRmw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@duckdb/node-bindings": "1.3.2-alpha.24"
+        "@duckdb/node-bindings": "1.3.2-alpha.25"
       }
     },
     "node_modules/@duckdb/node-bindings": {
-      "version": "1.3.2-alpha.24",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.3.2-alpha.24.tgz",
-      "integrity": "sha512-JUnbqADokfDwIKYnhb8WygZLQdpqoxkHyux00qzeERfPEnekuPGirq7CitF4SuSqZAMScNmC+r/pOviDtEKNGA==",
+      "version": "1.3.2-alpha.25",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.3.2-alpha.25.tgz",
+      "integrity": "sha512-FkoSaoeRAi6Em0hs0qzr3SN04ykN99R+Qap5kLwhi6GNPnHzWMU1VrNpK9cE4eBj0n+RWlNK0TiO712dn44QzQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "optionalDependencies": {
-        "@duckdb/node-bindings-darwin-arm64": "1.3.2-alpha.24",
-        "@duckdb/node-bindings-darwin-x64": "1.3.2-alpha.24",
-        "@duckdb/node-bindings-linux-arm64": "1.3.2-alpha.24",
-        "@duckdb/node-bindings-linux-x64": "1.3.2-alpha.24",
-        "@duckdb/node-bindings-win32-x64": "1.3.2-alpha.24"
+        "@duckdb/node-bindings-darwin-arm64": "1.3.2-alpha.25",
+        "@duckdb/node-bindings-darwin-x64": "1.3.2-alpha.25",
+        "@duckdb/node-bindings-linux-arm64": "1.3.2-alpha.25",
+        "@duckdb/node-bindings-linux-x64": "1.3.2-alpha.25",
+        "@duckdb/node-bindings-win32-x64": "1.3.2-alpha.25"
       }
     },
     "node_modules/@duckdb/node-bindings-darwin-arm64": {
-      "version": "1.3.2-alpha.24",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.3.2-alpha.24.tgz",
-      "integrity": "sha512-0znVE4wQHgMy6PlEyC3cxfJATEhdi24CEtu8e/5FKgBrzTjpzLQ1BM9qSsvdVaF2IAQxk1PNpuj60k9iMEKm4w==",
+      "version": "1.3.2-alpha.25",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.3.2-alpha.25.tgz",
+      "integrity": "sha512-vRjzNgkz2TAYW5c2rzPwcHBctBWr0lxQ4blFASAv0DdeGPOeuCMXJUA3982X7iPNwAppH0VMII6cYzON0GA+RA==",
       "cpu": [
         "arm64"
       ],
@@ -852,9 +852,9 @@
       "peer": true
     },
     "node_modules/@duckdb/node-bindings-darwin-x64": {
-      "version": "1.3.2-alpha.24",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.3.2-alpha.24.tgz",
-      "integrity": "sha512-RsqAKNYT2UA2tVirplzNO6+r20PNCf8CEK0+FSt8ULaTqtCP9TAzMI6vcP0+3lUWYHCH59XOS7XgDbNHL9zQxA==",
+      "version": "1.3.2-alpha.25",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.3.2-alpha.25.tgz",
+      "integrity": "sha512-BSg/DZjT25QZe87+pmdMfE1XlHdi2WxtAO+F2PEXN6VnPeLyTdl5bYlnhOGrDKquKDmUEqok5OwF7mR4QfU+Aw==",
       "cpu": [
         "x64"
       ],
@@ -866,9 +866,9 @@
       "peer": true
     },
     "node_modules/@duckdb/node-bindings-linux-arm64": {
-      "version": "1.3.2-alpha.24",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.3.2-alpha.24.tgz",
-      "integrity": "sha512-v63F51a6M5NYDD+08uwP+3sfZe9wvlV30OxPi95GOudn5cDONStWrQ6OSMEYTL6F08s1iFgnUy+/W+w8ANTgNQ==",
+      "version": "1.3.2-alpha.25",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.3.2-alpha.25.tgz",
+      "integrity": "sha512-VhjUH/AvolZWDX/URqiIh58JbAB1vYbDgSmQ0wvqhS9jzJ9Sj88urGDw+XWXw49Rr4BhIgDtX70SoARhO2i/Gg==",
       "cpu": [
         "arm64"
       ],
@@ -880,9 +880,9 @@
       "peer": true
     },
     "node_modules/@duckdb/node-bindings-linux-x64": {
-      "version": "1.3.2-alpha.24",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.3.2-alpha.24.tgz",
-      "integrity": "sha512-waHoC4iMT1seCdu1zRGpBnwUG7uPhasVF7EdVlgKUKOK0h0rHAbuisTwFCs4cx6lbEM/2zd8Zn4UzZI8YoOWbg==",
+      "version": "1.3.2-alpha.25",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.3.2-alpha.25.tgz",
+      "integrity": "sha512-raav2ypBiV4TlpnKU9hocsuFDO4ipwIcQQmkMIh20/Qd9vkv35QcQYNqStiZVJh2LAaVoQffNvcKMlclblYqUQ==",
       "cpu": [
         "x64"
       ],
@@ -894,9 +894,9 @@
       "peer": true
     },
     "node_modules/@duckdb/node-bindings-win32-x64": {
-      "version": "1.3.2-alpha.24",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.3.2-alpha.24.tgz",
-      "integrity": "sha512-MTGOIFC1T+5VR8bt6L7tfB/n3lzCHeMSbdo0RrsEux1lrdCdU4yDb4+VAC38iXyPrnB8/PwAbSLZSP047vymNg==",
+      "version": "1.3.2-alpha.25",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.3.2-alpha.25.tgz",
+      "integrity": "sha512-/fAKax+xYkdRhkUl3PkL3HfFd1ZsezG1yiOkL0StHBdD3xB80Njm1JGHxx1fO3WWE5XTbE1MTJ5I0xjEzPwsfQ==",
       "cpu": [
         "x64"
       ],


### PR DESCRIPTION
Add a minimal test suite for `cli` commands `compile` and `run`, including setup for `examples/flights.duckdb`.

---
<a href="https://cursor.com/background-agent?bcId=bc-70ae6ad8-83bf-4818-8586-04aeec81e7bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70ae6ad8-83bf-4818-8586-04aeec81e7bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

