### PR TITLE
Add initial autocomplete support for Graphene SQL

### DIFF
--- a/lang/autocomplete.ts
+++ b/lang/autocomplete.ts
@@ -1,0 +1,153 @@
+import {parser} from './parser.js'
+import {analyze, getTable} from './analyze.ts'
+import {txt, type Table} from './core.ts'
+
+export type CompletionKind = 'table' | 'column' | 'join'
+
+export interface CompletionItem {
+  label: string
+  kind: CompletionKind
+}
+
+function computeOffset (text: string, line: number, character: number): number {
+  let idx = 0
+  let currLine = 0
+  while (currLine < line && idx < text.length) {
+    let nl = text.indexOf('\n', idx)
+    if (nl === -1) return text.length
+    idx = nl + 1
+    currLine++
+  }
+  return Math.min(idx + character, text.length)
+}
+
+// Extract the base table name from the text prior to the cursor.
+function findBaseTableName (prefix: string): string | undefined {
+  // Match last FROM <table> optionally followed by alias
+  // Keep it simple for first pass; subqueries not handled here
+  let re = /(\bfrom\s+)([a-zA-Z_][\w]*)/gi
+  let m: RegExpExecArray | null
+  let last: string | undefined
+  while ((m = re.exec(prefix))) last = m[2]
+  return last
+}
+
+function isFromContext (prefix: string): {partial?: string} | null {
+  // Detect if cursor is in FROM clause position: "... from <partial>"
+  let m = /(\bfrom\s+)([a-zA-Z_][\w]*)?$/i.exec(prefix)
+  if (!m) return null
+  return {partial: m[2]}
+}
+
+function lastKeyword (prefix: string): 'select' | 'group by' | 'order by' | undefined {
+  let p = prefix.toLowerCase()
+  let idxSelect = p.lastIndexOf('select')
+  let idxGroup = p.lastIndexOf('group by')
+  let idxOrder = p.lastIndexOf('order by')
+  let idx = Math.max(idxSelect, idxGroup, idxOrder)
+  if (idx === -1) return undefined
+  if (idx === idxGroup) return 'group by'
+  if (idx === idxOrder) return 'order by'
+  return 'select'
+}
+
+// Resolve a dotted path (without the trailing segment) to a Table starting from base table
+function resolveEntityTable (baseTableName: string | undefined, parentPath: string[]): Table | undefined {
+  if (!baseTableName) return undefined
+  let base = getTable(baseTableName)
+  if (!base) return undefined
+  let curr = base
+  for (let part of parentPath) {
+    // Find a JoinDef in curr with alias == part or target == part
+    let join = curr.syntaxNode.getChildren('JoinDef').find(jn => {
+      let alias = txt(jn.getChild('Alias'))
+      let target = txt(jn.getChild('Identifier'))
+      return alias === part || target === part
+    })
+    if (!join) return undefined
+    let targetName = txt(join.getChild('Identifier'))
+    curr = getTable(targetName) || curr
+  }
+  return curr
+}
+
+function getTableMembers (table: Table): {columns: string[]; joins: string[]} {
+  // Collect column-like members from ColumnDef and ComputedDef
+  let columns = [
+    ...table.syntaxNode.getChildren('ColumnDef').map(cn => txt(cn.getChild('Identifier'))),
+    ...table.syntaxNode.getChildren('ComputedDef').map(cn => txt(cn.getChild('Identifier'))),
+  ].filter(Boolean)
+  let joins = table.syntaxNode.getChildren('JoinDef').map(jn => txt(jn.getChild('Alias')) || txt(jn.getChild('Identifier'))).filter(Boolean)
+  return {columns, joins}
+}
+
+function parsePathAtCursor (prefix: string): {parentPath: string[]; partial?: string; hasDot: boolean} | null {
+  // Capture something like: users.name, users., users.na, users.friends.
+  let m = /([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*)(\.)?([A-Za-z_][\w]*)?$/.exec(prefix)
+  if (!m) return null
+  let path = m[1]
+  if (!path) return null
+  let hasDot = !!m[2]
+  let parts = path.split('.')
+  // If there is a trailing dot, parent is full parts; otherwise parent is all but last
+  let parentPath = hasDot ? parts : parts.slice(0, -1)
+  let partial = hasDot ? undefined : parts[parts.length - 1]
+  return {parentPath, partial, hasDot}
+}
+
+export function getCompletions (text: string, line: number, character: number): CompletionItem[] {
+  // Ensure tables are registered for this text
+  try { analyze(text) } catch {}
+
+  let offset = computeOffset(text, line, character)
+  let prefix = text.slice(0, offset)
+
+  // FROM context → suggest tables
+  let fromCtx = isFromContext(prefix)
+  if (fromCtx) {
+    let partialLower = (fromCtx.partial || '').toLowerCase()
+    // Suggest all registered tables by scanning declarations in current text (aligns with analyze())
+    let declared = Array.from(text.matchAll(/\btable\s+([A-Za-z_][\w]*)/gi)).map(m => m[1])
+    let unique = Array.from(new Set(declared))
+    return unique
+      .filter(n => n.toLowerCase().startsWith(partialLower))
+      .map(n => ({label: n, kind: 'table' as const}))
+  }
+
+  // Expression context (SELECT/GROUP BY/ORDER BY) → suggest columns (and joins after dot)
+  let last = lastKeyword(prefix)
+  if (!last) return []
+
+  let baseTable = findBaseTableName(prefix)
+  if (!baseTable) return []
+
+  let pathInfo = parsePathAtCursor(prefix)
+  if (pathInfo) {
+    let {parentPath, partial, hasDot} = pathInfo
+    let entity = resolveEntityTable(baseTable, parentPath)
+    if (!entity) return []
+    let {columns, joins} = getTableMembers(entity)
+    let all: CompletionItem[] = []
+    if (hasDot) {
+      all = [
+        ...columns.map(c => ({label: c, kind: 'column' as const})),
+        ...joins.map(j => ({label: j, kind: 'join' as const})),
+      ]
+    } else {
+      // No dot: only suggest columns from the base table
+      all = columns.map(c => ({label: c, kind: 'column' as const}))
+    }
+    if (partial) {
+      let pl = partial.toLowerCase()
+      all = all.filter(i => i.label.toLowerCase().startsWith(pl))
+    }
+    let seen = new Set<string>()
+    return all.filter(i => (seen.has(i.label) ? false : (seen.add(i.label), true)))
+  }
+
+  // Default: suggest base table columns
+  let base = getTable(baseTable)
+  if (!base) return []
+  let {columns} = getTableMembers(base)
+  return columns.map(c => ({label: c, kind: 'column' as const}))
+}

--- a/lang/lang.autocomplete.test.ts
+++ b/lang/lang.autocomplete.test.ts
@@ -1,0 +1,92 @@
+/// <reference types="vitest/globals" />
+import {clearWorkspace} from './analyze.ts'
+import {getCompletions} from './autocomplete.ts'
+import {expect} from 'vitest'
+
+const tables = `
+table users (
+  id int,
+  name text,
+  email text,
+  created_at timestamp,
+  join_one orders on orders.user_id = id
+)
+
+table orders (
+  id int,
+  user_id int,
+  amount int,
+  join_one users on users.id = user_id
+)
+`
+
+function pos (text: string, marker = '▌'): {text: string; line: number; ch: number} {
+  let idx = text.indexOf(marker)
+  if (idx === -1) throw new Error('Missing cursor marker')
+  let pre = text.slice(0, idx)
+  let line = pre.split('\n').length - 1
+  let ch = pre.length - pre.lastIndexOf('\n') - 1
+  let cleaned = text.slice(0, idx) + text.slice(idx + marker.length)
+  return {text: cleaned, line, ch}
+}
+
+describe('autocomplete', () => {
+  beforeEach(() => clearWorkspace())
+
+  it('suggests tables after FROM', () => {
+    let src = tables + `\nselect * from ▌`
+    let {text, line, ch} = pos(src)
+    let items = getCompletions(text, line, ch)
+    let labels = items.map(i => i.label)
+    expect(labels).toContain('users')
+    expect(labels).toContain('orders')
+  })
+
+  it('filters table suggestions by prefix', () => {
+    let src = tables + `\nselect * from us▌`
+    let {text, line, ch} = pos(src)
+    let items = getCompletions(text, line, ch)
+    expect(items.some(i => i.label === 'users')).toBe(true)
+    expect(items.some(i => i.label === 'orders')).toBe(false)
+  })
+
+  it('suggests columns after SELECT', () => {
+    let src = tables + `\nfrom users select ▌`
+    let {text, line, ch} = pos(src)
+    let items = getCompletions(text, line, ch)
+    let labels = items.map(i => i.label)
+    expect(labels).toContain('id')
+    expect(labels).toContain('name')
+    expect(labels).toContain('email')
+  })
+
+  it('suggests join members after dot traversal', () => {
+    let src = tables + `\nfrom orders select users.▌`
+    let {text, line, ch} = pos(src)
+    let items = getCompletions(text, line, ch)
+    let labels = items.map(i => i.label)
+    // From users table
+    expect(labels).toContain('id')
+    expect(labels).toContain('name')
+    expect(labels).toContain('email')
+  })
+
+  it('supports GROUP BY context', () => {
+    let src = tables + `\nfrom users select id group by ▌`
+    let {text, line, ch} = pos(src)
+    let items = getCompletions(text, line, ch)
+    let labels = items.map(i => i.label)
+    expect(labels).toContain('id')
+    expect(labels).toContain('name')
+  })
+
+  it('supports ORDER BY context', () => {
+    let src = tables + `\nfrom users select id order by ▌`
+    let {text, line, ch} = pos(src)
+    let items = getCompletions(text, line, ch)
+    let labels = items.map(i => i.label)
+    expect(labels).toContain('id')
+    expect(labels).toContain('created_at')
+  })
+})
+

--- a/vscode/esbuild.mjs
+++ b/vscode/esbuild.mjs
@@ -14,6 +14,9 @@ const aliasPlugin = {
     b.onResolve({filter: /^@graphene\/lang\/analyze$/}, args => {
       return {path: path.resolve(__dirname, '../lang/analyze.ts')}
     })
+    b.onResolve({filter: /^@graphene\/lang\/autocomplete$/}, args => {
+      return {path: path.resolve(__dirname, '../lang/autocomplete.ts')}
+    })
   },
 }
 

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,5 +1,11 @@
 import * as vscode from 'vscode';
 import { activateDiagnostics } from './diagnostics';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { getCompletions } from '@graphene/lang/autocomplete';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore esbuild alias maps to '../../lang/autocomplete.ts'
+import { getCompletions } from '@graphene/lang/autocomplete';
 
 export function activate(context: vscode.ExtensionContext) {
   const selector: vscode.DocumentSelector = [
@@ -10,6 +16,52 @@ export function activate(context: vscode.ExtensionContext) {
   // If semantic tokens are needed again, import and register here
   // registerSemanticTokens(context, selector);
   activateDiagnostics(context, selector);
+
+  // Register completion provider backed by shared autocomplete
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      selector,
+      {
+        provideCompletionItems(document, position) {
+          const text = document.getText();
+          const items = getCompletions(text, position.line, position.character);
+          return items.map(i => {
+            const kind = i.kind === 'table'
+              ? vscode.CompletionItemKind.Struct
+              : i.kind === 'join'
+                ? vscode.CompletionItemKind.Interface
+                : vscode.CompletionItemKind.Field;
+            const ci = new vscode.CompletionItem(i.label, kind);
+            return ci;
+          });
+        }
+      },
+      '.'
+    )
+  );
+
+  // Register completion provider backed by shared autocomplete
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      selector,
+      {
+        provideCompletionItems(document, position) {
+          const text = document.getText();
+          const items = getCompletions(text, position.line, position.character);
+          return items.map(i => {
+            const kind = i.kind === 'table'
+              ? vscode.CompletionItemKind.Struct
+              : i.kind === 'join'
+                ? vscode.CompletionItemKind.Interface
+                : vscode.CompletionItemKind.Field;
+            const ci = new vscode.CompletionItem(i.label, kind);
+            return ci;
+          });
+        }
+      },
+      '.'
+    )
+  );
 
   console.log('[graphene] Extension activated');
   vscode.window.showInformationMessage('Graphene GSQL extension activated');


### PR DESCRIPTION
Adds initial auto-complete support to the VSCode extension, suggesting tables after FROM and columns/joins in expression contexts.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1c2574a-8f61-4439-8b71-c5b2fbf453de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1c2574a-8f61-4439-8b71-c5b2fbf453de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

