### PR TITLE
Add check command for diagnostics

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4,6 +4,8 @@ import {Command} from 'commander'
 import {serve} from './serve.ts'
 import {readAndCompile} from './compile.ts'
 import {connectToDuckDB, printTable} from './run.ts'
+import {analyze, getDiagnostics, loadWorkspace} from '@graphene/lang'
+import {printDiagnostics} from './compile.ts'
 
 const program = new Command()
 
@@ -19,7 +21,10 @@ program
   .option('--debug', 'Print the parse tree for the input')
   .action(async (input: string | undefined, opts: { debug?: boolean }) => {
     let sql = await readAndCompile(input, opts.debug)
-    if (!sql) return
+    if (!sql) {
+      process.exitCode = 1
+      return
+    }
     console.log(sql)
   })
 
@@ -35,6 +40,17 @@ program
     if (!db) return
     let res = await db.query(sql)
     printTable(res.rows)
+  })
+
+program
+  .command('check')
+  .description('Load the workspace and print diagnostics')
+  .action(async () => {
+    await loadWorkspace(process.cwd())
+    analyze()
+    let diags = getDiagnostics()
+    printDiagnostics(diags)
+    if (diags.length) process.exitCode = 1
   })
 
 program


### PR DESCRIPTION
Add a `check` command to the CLI to load the workspace and print diagnostics, and ensure `compile` exits with a non-zero code on diagnostics.

---
<a href="https://cursor.com/background-agent?bcId=bc-c58fedcb-03c4-4d2c-beef-382335dc35e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c58fedcb-03c4-4d2c-beef-382335dc35e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

