### PR TITLE
Fix chart rendering regressions from Svelte 5 migration

### DIFF
--- a/ui/components/Bar.svelte
+++ b/ui/components/Bar.svelte
@@ -333,7 +333,6 @@
           }
           d.xAxis = {...d.xAxis, ...chartOverrides.xAxis}
           if (y2Count > 0 && d.yAxis[1]) {
-            d.yAxis[1] = {...d.yAxis[1], show: true}
             if (['line', 'bar', 'scatter'].includes(y2SeriesType) && d.series) {
               for (let i = 0; i < y2Count; i++) {
                 if (d.series[yCount + i]) {

--- a/ui/components/Chart.svelte
+++ b/ui/components/Chart.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {setContext, type Snippet} from 'svelte'
-  import {type Writable, writable} from 'svelte/store'
+  import {type Writable, writable, get} from 'svelte/store'
   import {propKey, configKey} from '../component-utilities/chartContext.js'
   import ECharts from './ECharts.svelte'
   import getColumnSummary from '../component-utilities/getColumnSummary.js'
@@ -165,12 +165,9 @@
   let heightMultiplier
 
   // Set final chart height:
-  // Note: These are intentionally not $state - they're set imperatively in the effect
-  // and we don't want updates to trigger re-renders.
-  // svelte-ignore non_reactive_update
-  let height
-  // svelte-ignore non_reactive_update
-  let width
+  // Using a separate writable store for dimensions so they're reactive in the template
+  // without causing infinite effect loops (which $state would cause since the effect reads+writes them).
+  let dimensions = writable<{height?: string, width?: string}>({})
 
   let missingCols = []
 
@@ -182,7 +179,6 @@
   let optCols = []
   let i
 
-  // Note: Not $state - set imperatively in effect, we don't want updates to trigger re-renders
   // svelte-ignore non_reactive_update
   let error
 
@@ -663,14 +659,16 @@
       } else {
         let primaryAxisColor = (() => {
           if (!(Array.isArray(y2Local) && y2Local.length)) return undefined
-          if (yAxisColorStore === 'true') return $colorPaletteResolved?.[0]
-          if (yAxisColorStore === 'false') return undefined
-          return yAxisColorStore
+          let yColor = get(yAxisColorStore)
+          if (yColor === 'true') return $colorPaletteResolved?.[0]
+          if (yColor === 'false') return undefined
+          return yColor
         })()
         let secondaryAxisColor = (() => {
-          if (y2AxisColorStore === 'true') return $colorPaletteResolved?.[ySeriesCount]
-          if (y2AxisColorStore === 'false') return undefined
-          return y2AxisColorStore
+          let y2Color = get(y2AxisColorStore)
+          if (y2Color === 'true') return $colorPaletteResolved?.[ySeriesCount]
+          if (y2Color === 'false') return undefined
+          return y2Color
         })()
 
         verticalAxisConfig = {
@@ -713,7 +711,7 @@
 
         secondaryAxis = {
           type: 'value',
-          show: false,
+          show: y2Count > 0,
           alignTicks: true,
           splitLine: {
             show: y2Gridlines_bool,
@@ -803,8 +801,7 @@
       topAxisTitleTop = legendTop + legendHeight + 7
 
       // Set final chart height:
-      height = chartContainerHeight + 'px'
-      width = '100%'
+      dimensions.set({height: chartContainerHeight + 'px', width: '100%'})
 
       // ---------------------------------------------------------------------------------------
       // Set up horizontal axis title (custom graphic)
@@ -838,7 +835,7 @@
           text: title,
           subtext: subtitle,
           subtextStyle: {
-            width: width,
+            width: '100%',
           },
         },
         tooltip: {
@@ -968,12 +965,12 @@
   })
 </script>
 
-{#if !error}
+{#if !$chartProps.error}
   {@render children?.()}
   <ECharts
     config={$config}
-    {height}
-    {width}
+    height={$dimensions.height}
+    width={$dimensions.width}
     {data}
     {queryID}
     chartTitle={title}
@@ -984,5 +981,5 @@
     seriesColors={$seriesColorsResolved}
   />
 {:else}
-  <ErrorChart {error} title={chartType} />
+  <ErrorChart error={$chartProps.error} title={chartType} />
 {/if}

--- a/ui/components/Chart.svelte
+++ b/ui/components/Chart.svelte
@@ -526,6 +526,7 @@
       chartProps.update((d) => {
         return {
           ...d,
+          error: undefined,
           data: dataLocal,
           x: xLocal,
           y: yLocal,

--- a/ui/components/Line.svelte
+++ b/ui/components/Line.svelte
@@ -215,7 +215,6 @@
       if (d.yAxis[0]) d.yAxis[0] = {...d.yAxis[0], ...chartOverrides.yAxis}
       d.xAxis = {...d.xAxis, ...chartOverrides.xAxis}
       if (y2Count > 0 && d.yAxis[1]) {
-        d.yAxis[1] = {...d.yAxis[1], show: true}
         let shouldSetY2Type = y2SeriesType && ['line', 'bar', 'scatter'].includes(y2SeriesType) && d.series
         for (let i = 0; shouldSetY2Type && i < y2Count; i++) {
           if (d.series[yCount + i]) d.series[yCount + i].type = y2SeriesType

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -80,6 +80,7 @@ test('cli check command reports runtime query errors', async ({server, page}) =>
 
 test('check reports runtime chart configuration errors', async ({server, page}) => {
   expectConsoleError(page, 'Error in Bar Chart')
+  expectConsoleError(page, /ECharts.*has been disposed/, true)
   server.mockFile('/index.md', `
     # Runtime Chart Config Error
     \`\`\`sql chart_data

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-multi-y.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-multi-y.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc92400d0557a56678b661efe49b7ff8b78397c7972c097a9f3b03ee8e1774c4
-size 13903
+oid sha256:16faa233992c442a576a8f4af115fb8ec63ce22446bbd9fc2c68be1102eac53f
+size 14055

--- a/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart.png
+++ b/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06c3951b4f8ed825458ee8fdc1fcd48abac7cd0b21db567d5704d2dd3490db77
-size 9803
+oid sha256:863ca56495e2c01123b787ef912510ad6cdd93a916ff5b25984d334bc13c7d66
+size 9834

--- a/ui/tests/snapshots/viz.test.ts/line-chart-dual-axis.png
+++ b/ui/tests/snapshots/viz.test.ts/line-chart-dual-axis.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5da6ab9e9a9a6968741260f3aa3a12d929e6ba5cffbd2bac9d08d800291a071
+size 20299

--- a/ui/tests/snapshots/viz.test.ts/stacked-area-chart.png
+++ b/ui/tests/snapshots/viz.test.ts/stacked-area-chart.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45bfd08f386db4f9a0ac41d1752b351dbbc06b6486ff086d8e305b8862d120c0
-size 24329
+oid sha256:79f34c4c297e807df4d6492b3c3d1de7446c82546fbd4d24bdeae00869d3e6cd
+size 24557

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -91,6 +91,33 @@ test('series colors accepts json string input', async ({mount, chart}) => {
   expect(colors).toContain('#123456')
 })
 
+test('line chart dual axis shows both y-axis labels', async ({mount, chart}) => {
+  let data = timeseries() as any
+  let rows = data.rows.map((r: any) => ({...r, profit_usd0k: r.sales_usd0k * 0.1}))
+  rows._evidenceColumnTypes = [
+    ...data.rows._evidenceColumnTypes,
+    {name: 'profit_usd0k', evidenceType: 'number'},
+  ]
+  data.rows = rows
+
+  await mount('components/LineChart.svelte', {data, x: 'month', y: 'sales_usd0k', y2: 'profit_usd0k'})
+
+  // Verify both y-axes are visible and have labels enabled
+  let yAxisConfig = await chart.config((c) => (c.yAxis ?? []).map((a: any) => ({
+    show: a.show,
+    labelShow: a.axisLabel?.show,
+    // Axis label color must be a string (not a store object) for ECharts to render
+    labelColorType: typeof a.axisLabel?.color,
+  })))
+  expect(yAxisConfig[0]).toMatchObject({show: true, labelShow: true})
+  expect(yAxisConfig[1]).toMatchObject({show: true, labelShow: true})
+  // Ensure colors are properly resolved strings, not store objects
+  for (let axis of yAxisConfig) {
+    expect(axis.labelColorType).not.toBe('object')
+  }
+  await expect(chart.el).screenshot('line-chart-dual-axis')
+})
+
 test('bar chart accepts comma-separated multi y', async ({mount, chart}) => {
   let data = timeseries() as any
   // augment dataset with a second numeric column while preserving metadata


### PR DESCRIPTION
make chart dimensions reactive and fix y-axis color store dereferencing

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fgraphene-data%2Fgraphene%2Fpull%2F74&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->