### PR TITLE
Fix keywords not being recognized when uppercase

### DIFF
--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -68,6 +68,20 @@ describe('lang', () => {
     updateFile(testTables, 'models.gsql')
   })
 
+
+  it('imports all keywords as tokens', async () => {
+    // Every keyword used via Kw<"..."> in the grammar must be in the specializeIdentifier keyword map in tokens.js.
+    // Without this, those keywords would only parse in lowercase (the inline spec_Identifier table is exact-match).
+    // We have a test because it's easy to add keywords and forget to add them to tokens, causing the parsing to break if you use the uppercase version of a keyword
+    let fs = await import('fs')
+    let grammar = fs.readFileSync(new URL('./lang.grammar', import.meta.url), 'utf8')
+    let tokens = fs.readFileSync(new URL('./tokens.js', import.meta.url), 'utf8')
+    let grammarKeywords = new Set([...grammar.matchAll(/Kw<"(\w+)">/g)].map(m => m[1]))
+    let tokenKeywords = new Set([...tokens.matchAll(/^\s+(\w+):/gm)].map(m => m[1]))
+    let missing = [...grammarKeywords].filter(k => !tokenKeywords.has(k))
+    expect(missing, 'Keywords in grammar but missing from tokens.js specializeIdentifier').toEqual([])
+  })
+
   it('handles basic select query', async () => {
     expect('from users select id, name where id = 1')
       .toRenderSql('SELECT base."id" as "id", base."name" as "name" FROM users as base WHERE base."id"=1')

--- a/lang/tokens.js
+++ b/lang/tokens.js
@@ -33,6 +33,19 @@ import {
   interval,
   date,
   timestamp,
+  _case,
+  when,
+  then,
+  _else,
+  end,
+  count,
+  extract,
+  cast,
+  distinct,
+  having,
+  one,
+  many,
+  extend,
 } from './parser.terms.js'
 
 // Map of lowercase keywords to their token IDs
@@ -70,6 +83,19 @@ const keywords = {
   interval: interval,
   date: date,
   timestamp: timestamp,
+  case: _case,
+  when: when,
+  then: then,
+  else: _else,
+  end: end,
+  count: count,
+  extract: extract,
+  cast: cast,
+  distinct: distinct,
+  having: having,
+  one: one,
+  many: many,
+  extend: extend,
 }
 
 export function specializeIdentifier (value) {


### PR DESCRIPTION
New keywords need to be added to tokens.js, and we were missing some. Add them, and add a test to catch this for any future keywords.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fgraphene-data%2Fgraphene%2Fpull%2F75&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->