### PR TITLE
Fix y-axis duplicate tick labels for integer-valued data

### DIFF
--- a/ui/components/Chart.svelte
+++ b/ui/components/Chart.svelte
@@ -577,6 +577,7 @@
           },
           min: yMin,
           max: yMax,
+          minInterval: yUnitSummary?.maxDecimals === 0 ? 1 : undefined,
           scale: yScale_bool,
           splitLine: {
             show: yGridlines_bool,
@@ -705,8 +706,9 @@
           nameGap: 6,
           min: yMin,
           max: yMax,
+          minInterval: yUnitSummary?.maxDecimals === 0 ? 1 : undefined,
           scale: yScale_bool,
-          boundaryGap: ['0%', '1%'],
+          boundaryGap: yUnitSummary?.maxDecimals === 0 ? false : ['0%', '1%'],
           z: 2,
         }
 
@@ -744,8 +746,9 @@
           nameGap: 6,
           min: y2Min,
           max: y2Max,
+          minInterval: y2UnitSummary?.maxDecimals === 0 ? 1 : undefined,
           scale: y2Scale_bool,
-          boundaryGap: ['0%', '1%'],
+          boundaryGap: y2UnitSummary?.maxDecimals === 0 ? false : ['0%', '1%'],
           z: 2,
         }
 

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-integer-ticks.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-integer-ticks.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb4d75764f1fe06ca026274bc6594276b639d299f71be889485a4969859f00f9
+size 2066

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -91,6 +91,16 @@ test('series colors accepts json string input', async ({mount, chart}) => {
   expect(colors).toContain('#123456')
 })
 
+test('bar chart y-axis uses integer ticks for integer data', async ({mount, chart}) => {
+  // there was a regression where we'd try to render fractional ticks (0, 0.25, 0.5, 0.75, 1), but they got rounded
+  let rows = [{category: 'A', count: 1}, {category: 'B', count: 1}, {category: 'C', count: 1}] as any
+  rows._evidenceColumnTypes = [{name: 'category', evidenceType: 'string'}, {name: 'count', evidenceType: 'number'}]
+  await mount('components/BarChart.svelte', {data: {rows}, x: 'category', y: 'count'})
+  let minInterval = await chart.config(c => (Array.isArray(c.yAxis) ? c.yAxis[0] : c.yAxis).minInterval)
+  expect(minInterval).toBe(1)
+  await expect(chart.el).screenshot('bar-chart-integer-ticks')
+})
+
 test('line chart dual axis shows both y-axis labels', async ({mount, chart}) => {
   let data = timeseries() as any
   let rows = data.rows.map((r: any) => ({...r, profit_usd0k: r.sales_usd0k * 0.1}))


### PR DESCRIPTION
When all y-values are integers, echarts picks fractional tick intervals that get rounded by the integer formatter, producing duplicates like 0, 0, 1, 1. Set minInterval: 1 and disable boundaryGap for integer columns so ticks land on whole numbers only.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fgraphene-data%2Fgraphene%2Fpull%2F80&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->