### PR TITLE
Better envFile configuration

### DIFF
--- a/cli/check.ts
+++ b/cli/check.ts
@@ -1,7 +1,6 @@
 import fs from 'fs-extra'
 import os from 'os'
 import path from 'path'
-import {spawn} from 'child_process'
 import {type IncomingMessage, type ServerResponse} from 'http'
 import {WebSocketServer, type WebSocket} from 'ws'
 import {type PluginOption, type ViteDevServer} from 'vite'
@@ -11,6 +10,7 @@ import {printDiagnostics} from './printer.ts'
 import {readFileSync} from 'node:fs'
 import {mockFileMap} from './mockFiles.ts'
 import {isServerRunning, runServeInBackground} from './background.ts'
+import {openInBrowser} from './auth.ts'
 import {styleText} from 'node:util'
 import {pollFor} from '../lang/util.ts'
 import {FILE_MAP} from '../lang/analyze.ts'
@@ -63,7 +63,7 @@ export async function check (options: CheckOptions): Promise<boolean> {
   }
 
   // Remove .md extension if provided and ensure it's just the filename
-  let host = `http://localhost:${config.port || Number(process.env.GRAPHENE_PORT) || 4000}`
+  let host = `http://localhost:${config.port}`
   let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')
   if (pageUrl === '/index') pageUrl = '/'
 
@@ -81,7 +81,7 @@ export async function check (options: CheckOptions): Promise<boolean> {
 
   if (resp.checkError == 'no_tab' && process.env.NODE_ENV !== 'test') {
     log(`Opening page ${host}${pageUrl}`)
-    spawn('open', [host + pageUrl])
+    openInBrowser(host + pageUrl)
     await new Promise(resolve => setTimeout(resolve, 500))
     resp = await sendCheckRequest({host, pageUrl, chart: options.chart})
   }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -16,17 +16,14 @@ import {loginPkce} from './auth.ts'
 const program = new Command()
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+// Look at the graphene library's package.json (as opposed to the project using graphene) to get the version
 // in dev: cli/cli.ts -> cli/package.json. in dist: cli/dist/cli/cli.js -> cli/package.json
 const pkgPath = fs.existsSync(path.join(__dirname, 'package.json')) ? path.join(__dirname, 'package.json') : path.join(__dirname, '../../package.json')
-const pkg = fs.readJsonSync(pkgPath)
-program.name('graphene').description('Graphene CLI').version(pkg.version, '-v, --version')
+const libPkg = fs.readJsonSync(pkgPath)
+program.name('graphene').description('Graphene CLI').version(libPkg.version, '-v, --version')
 
-program.hook('preAction', async () => {
-  if (process.env.CLI_DELAY) { // useful if you want to attach a debugger
-    await new Promise(r => setTimeout(r, 1000))
-  }
-  loadConfig(process.cwd())
-  dotenv.config({quiet: true, path: config.envFile})
+loadConfig(process.cwd(), envFiles => {
+  dotenv.config({quiet: true, path: envFiles || '.env'})
 })
 
 program.command('compile')

--- a/examples/ecomm/package.json
+++ b/examples/ecomm/package.json
@@ -21,6 +21,7 @@
     "namespace": "bigquery-public-data.thelook_ecommerce",
     "bigquery": {
       "projectId": "intense-acumen-470417-u5"
-    }
+    },
+    "envFile": [".env", "../../.env", "../../../.env"]
   }
 }

--- a/examples/flights/package.json
+++ b/examples/flights/package.json
@@ -18,6 +18,7 @@
     "svelte": "5.48.0"
   },
   "graphene": {
-    "duckdb": {}
+    "duckdb": {},
+    "envFile": [".env", "../../.env", "../../../.env"]
   }
 }

--- a/examples/flights_empty/package.json
+++ b/examples/flights_empty/package.json
@@ -17,6 +17,7 @@
     "@graphenedata/cli": "workspace:*"
   },
   "graphene": {
-    "dialect": "duckdb"
+    "dialect": "duckdb",
+    "envFile": [".env", "../../.env", "../../../.env"]
   }
 }

--- a/examples/snowflake/package.json
+++ b/examples/snowflake/package.json
@@ -2,7 +2,7 @@
   "name": "snowflake-example",
   "version": "0.0.1",
   "scripts": {
-    "graphene": "node --env-file=../../.env ../../cli/cli.ts",
+    "graphene": "node ../../cli/cli.ts",
     "dev": "npm run graphene serve",
     "compile": "npm run graphene compile",
     "run": "npm run graphene run",
@@ -22,6 +22,7 @@
     "snowflake": {
       "account": "adarjvr-ve40413",
       "username": "demouser"
-    }
+    },
+    "envFile": [".env", "../../.env", "../../../.env"]
   }
 }

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -29,11 +29,10 @@ export interface Config {
 export type ConfigInput = Omit<Config, 'dialect' | 'ignoredFiles' | 'envFile'> & {
   dialect?: Config['dialect'],
   ignoredFiles?: Config['ignoredFiles'],
-  envFile?: string
+  envFile?: string | string[]
 }
 
 export let config: Config = {dialect: 'duckdb', root: ''} as Config
-
 
 export function setConfig (cfg: ConfigInput) {
   let dialect = cfg.dialect || 'duckdb'
@@ -44,12 +43,12 @@ export function setConfig (cfg: ConfigInput) {
   Object.assign(config, cfg)
   config.dialect = dialect
   config.root ||= process.cwd()
+  config.port ||= Number(process.env.GRAPHENE_PORT) || 4000
   config.ignoredFiles ||= ['agents.md', 'claude.md']
-  config.envFile = [cfg.envFile, '.env'].filter((x): x is string => !!x).map(p => path.resolve(config.root, p))
 }
 
 // Read graphene config out of package.json
-export function loadConfig (dir:string) {
+export function loadConfig (dir:string, envLoader?: (envFiles: string[] | string) => void) {
   if (config.root) return
 
   let packageJsonObject = {} as any
@@ -59,6 +58,8 @@ export function loadConfig (dir:string) {
   } catch {
     console.warn('No package.json found in current directory')
   }
+
+  if (envLoader) envLoader(packageJsonObject.envFile || [])
 
   setConfig({...packageJsonObject, root: packageJsonObject.root || process.cwd()})
 }


### PR DESCRIPTION
Depending on the context, the env file could be in a few different places, so support an array option.

I also normalized port determination to be part of the config.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fgraphene-data%2Fgraphene%2Fpull%2F89&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->