### PR TITLE
Better compile error handling

### DIFF
--- a/cli/check.ts
+++ b/cli/check.ts
@@ -102,10 +102,20 @@ export async function check (options: CheckOptions): Promise<boolean> {
   } else {
     log('No errors found 💎')
   }
-  errors.forEach((e:any) => {
-    if (e.file && e.line) printDiagnostics([e as Diagnostic], log)
-    else if (e.id) log(`${e.id}: ${e.message}`)
-    else log(e.message)
+
+  errors.forEach((e: any) => {
+    if (e.type === 'compile') {
+      let file = e.file && path.isAbsolute(e.file) ? path.relative(config.root, e.file) : e.file
+      let msg = e.message.replace(/^.*?:\d+:\d+\s*/, '').replace(/\s*https:\/\/svelte\.dev\/\S+/g, '')
+      log(`${styleText('red', 'ERROR')}: ${file} line ${e.line}: ${msg}`)
+      for (let frameLine of e.frame.split('\n')) log('  ' + frameLine)
+    } else if (e.file && e.from) {
+      printDiagnostics([e as Diagnostic], log)
+    } else if (e.id) {
+      log(`${e.id}: ${e.message}`)
+    } else {
+      log(e.message)
+    }
   })
 
   if (resp?.stillLoading) {

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -65,6 +65,7 @@ async function createConfig (): Promise<InlineConfig> {
         },
       }),
       fixSvelteDepsInTests(),
+      fixHmrForFailedModules(),
       checkVitePlugin(),
       handleRequestPlugin,
       updateWorkspacePlugin,
@@ -78,6 +79,7 @@ async function createConfig (): Promise<InlineConfig> {
       host,
       fs: {strict: false},
       strictPort: true,
+      hmr: {overlay: false}, // we handle compilation errors ourselves (see handlePage catch block)
     },
     resolve: {
       alias: {
@@ -106,6 +108,76 @@ async function createConfig (): Promise<InlineConfig> {
   }
 }
 
+async function handleQuery (req: IncomingMessage, res: ServerResponse<IncomingMessage>) {
+  let chunks = [] as any[]
+  for await (let chunk of req) chunks.push(chunk)
+  let {gsql, params, hashes} = JSON.parse(Buffer.concat(chunks).toString())
+  res.setHeader('Content-Type', 'application/json')
+
+  await workspaceLoadPromise
+  let queries = analyze(gsql)
+
+  if (getDiagnostics().length) {
+    res.statusCode = 400
+    res.end(JSON.stringify(getDiagnostics()))
+    return
+  }
+
+  if (queries.length > 1) throw new Error('Found multiple queries, which could be a parsing error')
+  let sql = toSql(queries[0], params)
+
+  // If the client already has this data, dont run the query
+  let hash = crypto.createHash('SHA1').update(sql).digest('hex')
+  res.setHeader('ETag', hash)
+  if (hashes.includes(hash) && req.headers['cache-control'] != 'no-cache') {
+    res.statusCode = 304
+    return res.end()
+  }
+
+  let queryResults = await runQuery(sql)
+  let totalRows = queryResults.totalRows ?? queryResults.rows.length
+  if (totalRows > queryResults.rows.length) throw new Error('Query returns too many rows')
+  let fields = queries[0].fields.map(f => ({name: f.name, type: f.type}))
+  res.end(JSON.stringify({rows: queryResults.rows, hash, fields, sql}))
+}
+
+async function handlePage (server: ViteDevServer, res: ServerResponse<IncomingMessage>, filePath: string, mount: boolean) {
+  res.setHeader('Content-Type', 'text/html')
+
+  // Use a dynamic import for the md file so that web.js always loads first (sets up telemetry, nav, websocket).
+  // Without this, a Svelte compilation error in the md file kills the entire module block and web.js never runs,
+  // resulting in a blank page and `check` reporting "Failed to open a new tab".
+  let mdMount = mount ? `
+    window.$GRAPHENE.currentMdFile = ${JSON.stringify(filePath)}
+    import {mount} from 'svelte'
+    let {default: Page} = await import(${JSON.stringify(filePath)})
+    mount(Page, { target: document.getElementById('content'), props: {} })
+  ` : ''
+
+  // Use '/XXX.html' as the URL for transformIndexHtml, not the .md file path.
+  // Vite 7 uses the URL extension to determine which plugins process the content,
+  // and passing an .md path causes the svelte plugin to try to compile our HTML template.
+  let htmlUrl = filePath.replace('.md', '.html')
+  let html = await server.transformIndexHtml(htmlUrl, `<!doctype html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>Graphene</title>
+      <link rel="icon" href="/favicon.ico" />
+    </head>
+    <body>
+      <nav id="nav"></nav>
+      <main id="content"></main>
+      <script type="module">
+        import 'graphene' // do this first so we can track errors caused by importing the md file
+        ${mdMount}
+      </script>
+    </body>
+  </html>`)
+  return res.end(html)
+}
+
 // Runs vite's pre-bundling of dependencies. Used by tests to do this once, instead of for each worker.
 export async function prepareDeps () {
   let cfg = await resolveConfig(await createConfig(), 'serve')
@@ -128,6 +200,28 @@ function fixSvelteDepsInTests () {
   }
   buildStart.sequential = true // force running after other sequential hooks (like svelte's)
   return {name: 'fix-svelte-deps', enforce: 'post' as const, configResolved, buildStart}
+}
+
+// When a module's transform fails (e.g. Svelte compilation error in an md file), Vite's import analysis
+// never runs on it, leaving `isSelfAccepting` as undefined. Vite's `propagateUpdate` silently skips
+// unanalyzed modules, so fixing the file produces no HMR update and the page stays broken.
+// We detect this and send a full-reload instead, since the module was never successfully loaded
+// and can't be hot-swapped.
+function fixHmrForFailedModules () {
+  return {
+    name: 'fix-hmr-for-failed-modules',
+    hotUpdate (this: any, {modules}: {modules: any[]}) {
+      // When a module's last transform failed, its transformResult is null. Vite's normal HMR can't
+      // hot-swap a module that has no valid transform — either because it was never analyzed
+      // (isSelfAccepting === undefined) or because it was previously working but is now broken.
+      // In both cases, force a full page reload so the browser re-requests everything fresh.
+      let hasFailed = modules.some(m => !m.transformResult && m.importers.size)
+      if (hasFailed) {
+        this.environment.hot.send({type: 'full-reload', path: '*'})
+        return []
+      }
+    },
+  }
 }
 
 // Watch for changes to gsql files and reload the workspace.
@@ -196,72 +290,6 @@ const handleRequestPlugin = {
       }
     })
   },
-}
-
-async function handleQuery (req: IncomingMessage, res: ServerResponse<IncomingMessage>) {
-  let chunks = [] as any[]
-  for await (let chunk of req) chunks.push(chunk)
-  let {gsql, params, hashes} = JSON.parse(Buffer.concat(chunks).toString())
-  res.setHeader('Content-Type', 'application/json')
-
-  await workspaceLoadPromise
-  let queries = analyze(gsql)
-
-  if (getDiagnostics().length) {
-    res.statusCode = 400
-    res.end(JSON.stringify(getDiagnostics()))
-    return
-  }
-
-  if (queries.length > 1) throw new Error('Found multiple queries, which could be a parsing error')
-  let sql = toSql(queries[0], params)
-
-  // If the client already has this data, dont run the query
-  let hash = crypto.createHash('SHA1').update(sql).digest('hex')
-  res.setHeader('ETag', hash)
-  if (hashes.includes(hash) && req.headers['cache-control'] != 'no-cache') {
-    res.statusCode = 304
-    return res.end()
-  }
-
-  let queryResults = await runQuery(sql)
-  let totalRows = queryResults.totalRows ?? queryResults.rows.length
-  if (totalRows > queryResults.rows.length) throw new Error('Query returns too many rows')
-  let fields = queries[0].fields.map(f => ({name: f.name, type: f.type}))
-  res.end(JSON.stringify({rows: queryResults.rows, hash, fields, sql}))
-}
-
-async function handlePage (server: ViteDevServer, res: ServerResponse<IncomingMessage>, filePath: string, mount: boolean) {
-  res.setHeader('Content-Type', 'text/html')
-
-  let mdMount = mount ? `
-    import { mount } from 'svelte'
-    import Page from ${JSON.stringify(filePath)}
-    mount(Page, { target: document.getElementById('content'), props: {} })
-  ` : ''
-
-  // Use '/index.html' as the URL for transformIndexHtml, not the .md file path.
-  // Vite 7 uses the URL extension to determine which plugins process the content,
-  // and passing an .md path causes the svelte plugin to try to compile our HTML template.
-  let htmlUrl = filePath.replace('.md', '.html')
-  let html = await server.transformIndexHtml(htmlUrl, `<!doctype html>
-  <html lang="en">
-    <head>
-      <meta charset="UTF-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>Graphene</title>
-      <link rel="icon" href="/favicon.ico" />
-    </head>
-    <body>
-      <nav id="nav"></nav>
-      <main id="content"></main>
-      <script type="module">
-        import 'graphene' // do this first so we can track errors caused by importing the md file
-        ${mdMount}
-      </script>
-    </body>
-  </html>`)
-  return res.end(html)
 }
 
 function mockFilesForTests () {

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -44,6 +44,7 @@ async function createConfig (): Promise<InlineConfig> {
 
   return {
     root: config.root,
+    logLevel: process.env.NODE_ENV == 'test' ? 'silent' : 'info',
     plugins: [
       svelte({
         configFile: false,

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -79,7 +79,7 @@ async function createConfig (): Promise<InlineConfig> {
       host,
       fs: {strict: false},
       strictPort: true,
-      hmr: {overlay: false}, // we handle compilation errors ourselves (see handlePage catch block)
+      hmr: {overlay: false}, // we handle compilation errors ourselves (see LocalApp.svelte)
     },
     resolve: {
       alias: {
@@ -141,24 +141,11 @@ async function handleQuery (req: IncomingMessage, res: ServerResponse<IncomingMe
   res.end(JSON.stringify({rows: queryResults.rows, hash, fields, sql}))
 }
 
-async function handlePage (server: ViteDevServer, res: ServerResponse<IncomingMessage>, filePath: string, mount: boolean) {
+async function handlePage (server: ViteDevServer, res: ServerResponse<IncomingMessage>) {
   res.setHeader('Content-Type', 'text/html')
 
-  // Use a dynamic import for the md file so that web.js always loads first (sets up telemetry, nav, websocket).
-  // Without this, a Svelte compilation error in the md file kills the entire module block and web.js never runs,
-  // resulting in a blank page and `check` reporting "Failed to open a new tab".
-  let mdMount = mount ? `
-    window.$GRAPHENE.currentMdFile = ${JSON.stringify(filePath)}
-    import {mount} from 'svelte'
-    let {default: Page} = await import(${JSON.stringify(filePath)})
-    mount(Page, { target: document.getElementById('content'), props: {} })
-  ` : ''
-
-  // Use '/XXX.html' as the URL for transformIndexHtml, not the .md file path.
-  // Vite 7 uses the URL extension to determine which plugins process the content,
-  // and passing an .md path causes the svelte plugin to try to compile our HTML template.
-  let htmlUrl = filePath.replace('.md', '.html')
-  let html = await server.transformIndexHtml(htmlUrl, `<!doctype html>
+  // Use a .html URL for transformIndexHtml so Vite doesn't run the svelte plugin on our HTML template.
+  let html = await server.transformIndexHtml('/index.html', `<!doctype html>
   <html lang="en">
     <head>
       <meta charset="UTF-8" />
@@ -167,11 +154,8 @@ async function handlePage (server: ViteDevServer, res: ServerResponse<IncomingMe
       <link rel="icon" href="/favicon.ico" />
     </head>
     <body>
-      <nav id="nav"></nav>
-      <main id="content"></main>
       <script type="module">
-        import 'graphene' // do this first so we can track errors caused by importing the md file
-        ${mdMount}
+        import 'graphene'
       </script>
     </body>
   </html>`)
@@ -215,7 +199,7 @@ function fixHmrForFailedModules () {
       // hot-swap a module that has no valid transform — either because it was never analyzed
       // (isSelfAccepting === undefined) or because it was previously working but is now broken.
       // In both cases, force a full page reload so the browser re-requests everything fresh.
-      let hasFailed = modules.some(m => !m.transformResult && m.importers.size)
+      let hasFailed = modules.some(m => !m.transformResult)
       if (hasFailed) {
         this.environment.hot.send({type: 'full-reload', path: '*'})
         return []
@@ -272,14 +256,14 @@ const handleRequestPlugin = {
       try {
         let [pathName] = (req.url || '').split('?')
         if (pathName == '/_api/query') return await handleQuery(req, res)
-        if (pathName == '/__ct') return await handlePage(s, res, '__ct', false)
+        if (pathName == '/__ct') return await handlePage(s, res)
 
         if (!pathName || pathName == '/') pathName = 'index'
         let relativeMdPath = pathName.replace(/^\//, '') + '.md'
         let mdPath = path.join(config.root, relativeMdPath)
 
         if (mockFileMap[relativeMdPath] || await fs.exists(mdPath)) {
-          await handlePage(s, res, mdPath, true)
+          await handlePage(s, res)
         } else {
           next()
         }
@@ -295,16 +279,23 @@ const handleRequestPlugin = {
 function mockFilesForTests () {
   if (process.env.NODE_ENV !== 'test') return null
 
+  function toMockKey (id: string) {
+    // Handle both absolute paths (/wt/.../index.md) and root-relative paths (/index.md)
+    return id.replace(config.root + '/', '').replace(/^\//, '')
+  }
+
   return {
     name: 'mock-files-for-tests',
     enforce: 'pre' as const,
     resolveId (id: any) {
-      if (mockFileMap[id.replace(config.root + '/', '')]) return id + '?mock'
+      if (!mockFileMap[toMockKey(id)]) return
+      // Always resolve to the absolute path so the module graph key matches
+      // what updateMockFile emits via server.watcher (needed for HMR to work).
+      return path.join(config.root, toMockKey(id)) + '?mock'
     },
     load (id: any) {
       if (!id.endsWith('?mock')) return null
-      let content = mockFileMap[id.replace(config.root + '/', '').replace(/\?mock$/, '')]
-      return content
+      return mockFileMap[toMockKey(id.replace(/\?mock$/, ''))]
     },
   }
 }

--- a/ui/internal/LocalApp.svelte
+++ b/ui/internal/LocalApp.svelte
@@ -1,0 +1,40 @@
+<script>
+  import {errorProvider} from './telemetry.ts'
+  import navFiles from 'virtual:nav'
+  import NavSidebar from './NavSidebar.svelte'
+  import PageError from './PageError.svelte'
+
+  // Nav sidebar with HMR support for the virtual file list
+  let navData = $state(navFiles)
+  import.meta.hot?.accept('virtual:nav', mod => navData = mod.default)
+
+  // Track compile errors from both initial load and subsequent HMR failures.
+  // Uses errorProvider so `check` can report compilation errors.
+  let compileError = $state(null)
+  errorProvider('compile', () => compileError ? [compileError] : [])
+  import.meta.hot?.on('vite:error', (payload) => {
+    compileError = payload.err
+    compileError.type = 'compile'
+    compileError.file = payload.err.id
+    Page = null
+  })
+
+  // The md file is dynamically imported, so even if there's a compile error, we'll still load LocalApp and can show the user the issue
+  let Page = $state(null)
+  let pathName = window.location.pathname.replace(/^\//, '') || 'index'
+  if (pathName !== '__ct') {
+    import(/* @vite-ignore */ '/' + pathName + '.md').then(mod => {
+      Page = mod.default
+      compileError = null
+    }).catch(() => {})
+  }
+</script>
+
+<nav id="nav"><NavSidebar files={navData} /></nav>
+<main id="content">
+  {#if compileError}
+    <PageError error={compileError} />
+  {:else if Page}
+    <Page />
+  {/if}
+</main>

--- a/ui/internal/NavSidebarHMR.svelte
+++ b/ui/internal/NavSidebarHMR.svelte
@@ -1,8 +1,0 @@
-<script>
-  import navData from 'virtual:nav'
-  import NavSidebar from './NavSidebar.svelte'
-
-  let {currentFile = ''} = $props()
-</script>
-
-<NavSidebar files={navData} {currentFile} />

--- a/ui/internal/PageError.svelte
+++ b/ui/internal/PageError.svelte
@@ -1,0 +1,23 @@
+<script>
+  let {error} = $props()
+</script>
+
+<h1>Error loading page</h1>
+<p class="message">{error.message}</p>
+{#if error.frame}<pre>{error.frame}</pre>{/if}
+{#if error.file}<p class="file">{error.file}</p>{/if}
+
+<style>
+  h1 { margin-top: 0; }
+  .message { color: var(--red-700); }
+  pre {
+    background: var(--grey-100);
+    border: 1px solid var(--grey-200);
+    border-radius: 4px;
+    padding: 1rem;
+    overflow-x: auto;
+    font-size: 0.875rem;
+    line-height: 1.6;
+  }
+  .file { color: var(--grey-500); font-size: 0.875rem; }
+</style>

--- a/ui/internal/checkSocket.ts
+++ b/ui/internal/checkSocket.ts
@@ -1,0 +1,48 @@
+// WebSocket connection for the `graphene check` command.
+// Listens for check requests, waits for queries to finish, captures screenshots, and reports errors.
+
+import {getErrors} from './telemetry.ts'
+import {isLoading} from './queryEngine.ts'
+
+let socket: WebSocket | null = null
+connect()
+
+function captureChart (chartTitle: string) {
+  let escaped = window.CSS.escape(chartTitle)
+  let canvas = document.querySelector(`[data-chart-title="${escaped}"] canvas`) as HTMLCanvasElement | null
+  return canvas?.toDataURL('image/png')
+}
+
+async function takeScreenshot () {
+  if (!(window as any).html2canvas) {
+    let html2canvas = await import('@graphenedata/html2canvas')
+    ;(window as any).html2canvas = html2canvas.default
+  }
+  let canvas = await (window as any).html2canvas(document.body, {useCORS: true, allowTaint: true, scale: 1, liveDOM: true})
+  return canvas?.toDataURL('image/png')
+}
+
+async function waitForQueriesToFinish () {
+  let startTime = Date.now()
+  while (isLoading() && Date.now() - startTime < 20_000) {
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+}
+
+function connect () {
+  let wsUrl = `ws://${window.location.host}/_api/ws`
+  socket = new WebSocket(wsUrl)
+  socket.onclose = () => setTimeout(connect, 2000)
+  socket.onopen = () => socket!.send(JSON.stringify({type: 'register', url: window.location.href}))
+
+  socket.onmessage = async (event) => {
+    let {type, requestId, chart} = JSON.parse(event.data)
+    if (type !== 'check') return
+
+    await waitForQueriesToFinish()
+    let errors = getErrors().map((e: any) => ({type: e.type, message: e.message, id: e.id, file: e.file, line: e.loc?.line, frame: e.frame, from: e.from, to: e.to}))
+    let stillLoading = isLoading()
+    let screenshot = chart ? captureChart(chart) : await takeScreenshot()
+    socket!.send(JSON.stringify({type: 'checkResponse', requestId, errors, stillLoading, screenshot}))
+  }
+}

--- a/ui/internal/telemetry.ts
+++ b/ui/internal/telemetry.ts
@@ -7,7 +7,7 @@ let staticErrors: Error[] = []
 let errorProviders: Record<string, ErrorProvider> = {}
 
 window.addEventListener('error', (event) => {
-  if ((event.error.message || '').match(/Failed to fetch dynamically imported module.*\.md\?import/)) return
+  if ((event.error?.message || '').match(/Failed to fetch dynamically imported module.*\.md\?import/)) return
   staticErrors.push(event.error)
 })
 window.addEventListener('unhandledrejection', (event) => {

--- a/ui/internal/telemetry.ts
+++ b/ui/internal/telemetry.ts
@@ -7,6 +7,7 @@ let staticErrors: Error[] = []
 let errorProviders: Record<string, ErrorProvider> = {}
 
 window.addEventListener('error', (event) => {
+  if ((event.error.message || '').match(/Failed to fetch dynamically imported module.*\.md\?import/)) return
   staticErrors.push(event.error)
 })
 window.addEventListener('unhandledrejection', (event) => {

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -35,7 +35,7 @@ test('check defaults to analyzing the whole workspace', async () => {
 })
 
 test('check with mdFile reports analysis errors', async ({server, page}) => {
-  expectConsoleError(page, 'Failed to load resource')
+  expectConsoleError(page, 'Failed to load resource', true)
   server.mockFile('/other.md', `
     \`\`\`sql error_query
     from flights select wtfmate() as explode
@@ -114,6 +114,25 @@ test('check table configuration errors', async ({server, page}) => {
     DataTable: not_a_column is not a column in the dataset. sort should contain one column name and optionally a direction (asc or desc).
     Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
 `))
+})
+
+test('check reports html compilation errors', async ({server, page}) => {
+  expectConsoleError(page, 'Failed to load resource')
+  expectConsoleError(page, 'Internal Server Error', true)
+  expectConsoleError(page, 'Failed to fetch dynamically imported module', true)
+  server.mockFile('/index.md', `
+    # Test
+    {#if true}oops{/if}
+  `)
+
+  await page.goto(server.url())
+  let result = await check({mdArg: 'index.md', log})
+  expect(result).toBe(false)
+  let output = outputLines()
+  expect(output).toContain('Runtime errors in index.md:')
+  expect(output).toMatch(/ERROR: .*index\.md line 7: Unexpected block closing tag/)
+  expect(output).toContain('<p>oops{/if}</p>')
+  expect(output).toContain('^')
 })
 
 test('cli check with --chart captures a single chart screenshot', async ({server, page}) => {

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -25,6 +25,8 @@ export interface ChartFixture {
 export interface ServerFixture {
   url: (options?: Config) => string
   mockFile: (path: string, content: string) => void
+  /** Update a mock file and trigger HMR, simulating a real file edit */
+  updateMockFile: (path: string, content: string) => void
 }
 
 export const test = base.extend<{ browser: Browser, page: Page, server: ServerFixture, mount: MountFn, chart: ChartFixture }>({
@@ -77,10 +79,12 @@ export const test = base.extend<{ browser: Browser, page: Page, server: ServerFi
         Object.keys(mockFileMap).forEach((key) => delete mockFileMap[key])
 
         // Vite caches our mocked files, so we need to clear them out after each test.
-        let keys = Array.from(server?.moduleGraph?.idToModuleMap?.keys()) || []
-        keys = Array.from(keys.filter(k => k.endsWith('?mock') || k == '\0virtual:nav'))
-        let mods = keys.map(k => server.moduleGraph.getModuleById(k)).filter(m => !!m)
-        mods.forEach(m => server.moduleGraph.invalidateModule(m))
+        // Vite 7 has separate module graphs for server.moduleGraph and environments.client — invalidate both.
+        for (let graph of [server.moduleGraph, server.environments.client.moduleGraph] as any[]) {
+          let keys: string[] = Array.from(graph?.idToModuleMap?.keys() || [])
+          let mockKeys = keys.filter(k => k.endsWith('?mock') || k == '\0virtual:nav')
+          mockKeys.forEach(k => { let m = graph.getModuleById(k); if (m) graph.invalidateModule(m) })
+        }
       }
 
       await use({
@@ -90,8 +94,15 @@ export const test = base.extend<{ browser: Browser, page: Page, server: ServerFi
           onTestFinished(cleanup)
           return `http://localhost:${port}`
         },
-        mockFile: (path: string, content: string) => {
-          mockFileMap[path.replace(/^\//, '')] = trimIndentation(content)
+        mockFile: (filePath: string, content: string) => {
+          mockFileMap[filePath.replace(/^\//, '')] = trimIndentation(content)
+        },
+        updateMockFile: (filePath: string, content: string) => {
+          let relativePath = filePath.replace(/^\//, '')
+          mockFileMap[relativePath] = trimIndentation(content)
+          let absPath = path.join(viteRoot, relativePath)
+          // Emit a watcher 'change' event so Vite runs the full HMR pipeline (including hotUpdate hooks)
+          server.watcher.emit('change', absPath)
         },
       })
     },

--- a/ui/tests/hmr.test.ts
+++ b/ui/tests/hmr.test.ts
@@ -1,0 +1,80 @@
+import {test, expect} from './fixtures.ts'
+import {expectConsoleError} from './browserConsole.ts'
+
+test('valid → invalid → valid via HMR', async ({server, page}) => {
+  expectConsoleError(page, 'Failed to load resource', true)
+  expectConsoleError(page, 'Internal Server Error', true)
+  expectConsoleError(page, 'Failed to fetch dynamically imported module', true)
+  expectConsoleError(page, 'vite:error', true)
+  server.mockFile('/index.md', '# Working Page')
+
+  await page.goto(server.url())
+  await expect(page.getByRole('heading', {name: 'Working Page'})).toBeVisible()
+
+  // Break the file — should show error
+  await server.updateMockFile('/index.md', '# Broken\n{#if true}oops{/if}')
+  await expect(page.getByRole('heading', {name: 'Error loading page'})).toBeVisible({timeout: 5000})
+
+  // Fix the file — should recover via HMR
+  await server.updateMockFile('/index.md', '# Fixed Page')
+  await expect(page.getByRole('heading', {name: 'Fixed Page'})).toBeVisible({timeout: 5000})
+})
+
+test('load broken page, fix via HMR', async ({server, page}) => {
+  expectConsoleError(page, 'Failed to load resource', true)
+  expectConsoleError(page, 'Internal Server Error', true)
+  expectConsoleError(page, 'Failed to fetch dynamically imported module', true)
+  expectConsoleError(page, 'vite:error', true)
+  server.mockFile('/index.md', '# Broken\n{#if true}oops{/if}')
+
+  await page.goto(server.url())
+  await expect(page.getByRole('heading', {name: 'Error loading page'})).toBeVisible({timeout: 5000})
+
+  // Fix the file — should recover via HMR
+  await server.updateMockFile('/index.md', '# Now Working')
+  await expect(page.getByRole('heading', {name: 'Now Working'})).toBeVisible({timeout: 5000})
+})
+
+test('editing unrelated md does not reload current page', async ({server, page}) => {
+  server.mockFile('/index.md', '# Main Page')
+  server.mockFile('/other.md', '# Other Page')
+
+  await page.goto(server.url())
+  await expect(page.getByRole('heading', {name: 'Main Page'})).toBeVisible()
+
+  // Set a marker on the page that would be cleared by a reload
+  await page.evaluate(() => { (window as any).__hmrMarker = true })
+
+  // Edit an unrelated file
+  await server.updateMockFile('/other.md', '# Other Changed')
+  await new Promise(r => setTimeout(r, 1000)) // give HMR time to fire if it's going to
+
+  // Marker should still be there — page was not reloaded
+  let marker = await page.evaluate(() => (window as any).__hmrMarker)
+  expect(marker).toBe(true)
+  await expect(page.getByRole('heading', {name: 'Main Page'})).toBeVisible()
+})
+
+test('editing unrelated md does not reload broken page', async ({server, page}) => {
+  expectConsoleError(page, 'Failed to load resource', true)
+  expectConsoleError(page, 'Internal Server Error', true)
+  expectConsoleError(page, 'Failed to fetch dynamically imported module', true)
+  expectConsoleError(page, 'vite:error', true)
+  server.mockFile('/index.md', '# Broken\n{#if true}oops{/if}')
+  server.mockFile('/other.md', '# Other Page')
+
+  await page.goto(server.url())
+  await expect(page.getByRole('heading', {name: 'Error loading page'})).toBeVisible({timeout: 5000})
+
+  // Set a marker
+  await page.evaluate(() => { (window as any).__hmrMarker = true })
+
+  // Edit an unrelated file
+  await server.updateMockFile('/other.md', '# Other Changed')
+  await new Promise(r => setTimeout(r, 1000))
+
+  // Marker should still be there — page was not reloaded
+  let marker = await page.evaluate(() => (window as any).__hmrMarker)
+  expect(marker).toBe(true)
+  await expect(page.getByRole('heading', {name: 'Error loading page'})).toBeVisible()
+})

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -74,7 +74,6 @@ test('renders literal less-than characters', async ({server, page}) => {
   `)
 
   await page.goto(server.url() + '/')
-  await page.pause()
   await expect(page.getByRole('heading', {level: 1, name: 'Comparison'})).toBeVisible()
   await expect(page.locator('main')).toHaveText(/1 < 2/)
 })

--- a/ui/tests/snapshots/markdown.test.ts/html-syntax-error.png
+++ b/ui/tests/snapshots/markdown.test.ts/html-syntax-error.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f091e72ba1d827fddaaa87f7009cb5546038232e36b2dd603b53344d7231f92
+size 30331

--- a/ui/tests/snapshots/viz.test.ts/line-chart-dual-axis.png
+++ b/ui/tests/snapshots/viz.test.ts/line-chart-dual-axis.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5da6ab9e9a9a6968741260f3aa3a12d929e6ba5cffbd2bac9d08d800291a071
-size 20299
+oid sha256:b45993af0367756f609c38805e616539f970fb13ef6a53ad408459b29a678396
+size 20444

--- a/ui/web.js
+++ b/ui/web.js
@@ -1,10 +1,8 @@
-import {getErrors, errorProvider} from './internal/telemetry.ts'
+import './internal/telemetry.ts'
+import './internal/checkSocket.ts'
 import './app.css'
-import {isLoading} from './internal/queryEngine.ts'
 import {mount} from 'svelte'
-import navFiles from 'virtual:nav'
-import NavSidebar from './internal/NavSidebar.svelte'
-import PageError from './internal/PageError.svelte'
+import LocalApp from './internal/LocalApp.svelte'
 
 import Area from './components/Area.svelte'
 import AreaChart from './components/AreaChart.svelte'
@@ -70,66 +68,4 @@ window.$GRAPHENE.components = {
   TextInput,
 }
 
-let socket = null
-connectWebSocket()
-
-if (document.getElementById('nav')) {
-  mount(NavSidebar, {target: document.getElementById('nav'), props: {files: navFiles}})
-}
-
-// Capture Vite compilation errors (e.g. broken Svelte syntax in md files) via HMR.
-// Only handle errors for the current page's MD file to avoid cross-page interference.
-// Uses errorProvider so repeated failed saves replace (not accumulate) the error.
-let compileError = null
-errorProvider('compile', () => compileError ? [compileError] : [])
-import.meta.hot?.on('vite:error', (payload) => {
-  compileError = payload.err
-  compileError.type = 'compile'
-  compileError.file = payload.err.id // rewrite from vite's format to what we usually expect
-  mount(PageError, {target: document.getElementById('content'), props: {error: compileError}})
-})
-
-function captureChart (chartTitle) {
-  let escaped = window.CSS.escape(chartTitle)
-  let canvas = document.querySelector(`[data-chart-title="${escaped}"] canvas`)
-  return canvas?.toDataURL('image/png')
-}
-
-async function takeScreenshot () {
-  if (!window.html2canvas) {
-    let html2canvas = await import('@graphenedata/html2canvas')
-    window.html2canvas = html2canvas.default
-  }
-
-  let canvas = await window.html2canvas(document.body, {useCORS: true, allowTaint: true, scale: 1, liveDOM: true})
-  return canvas?.toDataURL('image/png')
-}
-
-async function waitForQueriesToFinish () {
-  let startTime = Date.now()
-  while (isLoading() && Date.now() - startTime < 20_000) {
-    await new Promise(resolve => setTimeout(resolve, 100))
-  }
-}
-
-function connectWebSocket () {
-  let wsUrl = `ws://${window.location.host}/_api/ws`
-  socket = new WebSocket(wsUrl)
-  socket.onclose = () => setTimeout(connectWebSocket, 2000)
-
-  socket.onopen = () => {
-    socket.send(JSON.stringify({type: 'register', url: window.location.href}))
-  }
-
-  socket.onmessage = async (event) => {
-    let {type, requestId, chart} = JSON.parse(event.data)
-
-    if (type === 'check') {
-      await waitForQueriesToFinish()
-      let errors = getErrors().map(e => ({type: e.type, message: e.message, id: e.id, file: e.file, line: e.loc?.line, frame: e.frame, from: e.from, to: e.to}))
-      let stillLoading = isLoading()
-      let screenshot = chart ? captureChart(chart) : await takeScreenshot()
-      socket.send(JSON.stringify({type: 'checkResponse', requestId, errors, stillLoading, screenshot}))
-    }
-  }
-}
+mount(LocalApp, {target: document.body})

--- a/ui/web.js
+++ b/ui/web.js
@@ -1,8 +1,10 @@
-import {getErrors} from './internal/telemetry.ts'
+import {getErrors, errorProvider} from './internal/telemetry.ts'
 import './app.css'
 import {isLoading} from './internal/queryEngine.ts'
 import {mount} from 'svelte'
-import NavSidebar from './internal/NavSidebarHMR.svelte'
+import navFiles from 'virtual:nav'
+import NavSidebar from './internal/NavSidebar.svelte'
+import PageError from './internal/PageError.svelte'
 
 import Area from './components/Area.svelte'
 import AreaChart from './components/AreaChart.svelte'
@@ -69,12 +71,23 @@ window.$GRAPHENE.components = {
 }
 
 let socket = null
+connectWebSocket()
 
 if (document.getElementById('nav')) {
-  mount(NavSidebar, {target: document.getElementById('nav')})
+  mount(NavSidebar, {target: document.getElementById('nav'), props: {files: navFiles}})
 }
 
-connectWebSocket()
+// Capture Vite compilation errors (e.g. broken Svelte syntax in md files) via HMR.
+// Only handle errors for the current page's MD file to avoid cross-page interference.
+// Uses errorProvider so repeated failed saves replace (not accumulate) the error.
+let compileError = null
+errorProvider('compile', () => compileError ? [compileError] : [])
+import.meta.hot?.on('vite:error', (payload) => {
+  compileError = payload.err
+  compileError.type = 'compile'
+  compileError.file = payload.err.id // rewrite from vite's format to what we usually expect
+  mount(PageError, {target: document.getElementById('content'), props: {error: compileError}})
+})
 
 function captureChart (chartTitle) {
   let escaped = window.CSS.escape(chartTitle)
@@ -113,7 +126,7 @@ function connectWebSocket () {
 
     if (type === 'check') {
       await waitForQueriesToFinish()
-      let errors = getErrors().map(e => ({message: e.message, id: e.id}))
+      let errors = getErrors().map(e => ({type: e.type, message: e.message, id: e.id, file: e.file, line: e.loc?.line, frame: e.frame, from: e.from, to: e.to}))
       let stillLoading = isLoading()
       let screenshot = chart ? captureChart(chart) : await takeScreenshot()
       socket.send(JSON.stringify({type: 'checkResponse', requestId, errors, stillLoading, screenshot}))

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,8 +12,10 @@ export default defineConfig({
     reporters: ['default', 'json'],
     outputFile: 'node_modules/.testResults.json',
     slowTestThreshold: 5_000,
-    onConsoleLog (log) {
+    onConsoleLog (log, type) {
       if (log.startsWith('Server running at http://')) return false
+      if (log.startsWith('manually calling optimizeDeps is deprecated.')) return false
+      throw new Error(`Unexpected ${type || 'console'} output during tests: ${log}`)
     },
     projects: [
       {


### PR DESCRIPTION
This makes js compile errors (like invalid html syntax in md) appear in the frontend, and the `check` command.

I also fixed up HMR, which wouldn't reliably reload the page if the page started out in a broken state.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fgraphene-data%2Fgraphene%2Fpull%2F93&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->