### PR TITLE
Better handling for compile and query errors

### DIFF
--- a/ui/components/Chart.svelte
+++ b/ui/components/Chart.svelte
@@ -937,7 +937,7 @@
         xAxis: horizAxisConfig,
         yAxis: verticalAxisConfig,
         series: [],
-        animation: true,
+        animation: false,
         graphic: horizAxisTitleConfig,
         color: $colorPaletteResolved,
       }

--- a/ui/components/ErrorChart.svelte
+++ b/ui/components/ErrorChart.svelte
@@ -1,26 +1,81 @@
 <script lang="ts">
+  type GrapheneError = {
+    type?: string
+    id?: string
+    file?: string
+    message?: string
+    stack?: string
+    from?: {line?: number, col?: number, lineText?: string}
+    loc?: {line?: number, column?: number}
+    line?: number
+    column?: number
+    codeFrame?: string
+    frame?: string
+  }
+
   interface Props {
     error: unknown
-    title: string
+    title?: string
     height?: number
   }
 
-  let {error, title, height = 200}: Props = $props()
+  let {error, title: _title, height = 200}: Props = $props()
 
-  let message = $derived((() => {
-    if (error instanceof Error) return error.message
-    if (typeof error === 'string') return error
-    try {
-      return JSON.stringify(error, null, 2)
-    } catch {
-      return String(error)
-    }
-  })())
+  function parseError (raw: unknown): GrapheneError {
+    if (raw instanceof Error) return {message: raw.message, stack: raw.stack}
+    if (typeof raw === 'string') return {message: raw}
+    if (raw && typeof raw === 'object') return raw as GrapheneError
+    return {message: String(raw)}
+  }
+
+  function lineDetails (e: GrapheneError) {
+    let line = e.from?.line ?? e.loc?.line ?? e.line
+    let column = e.from?.col ?? e.loc?.column ?? e.column
+    let lineText = e.from?.lineText
+    let pointer = Number.isFinite(column) ? `${' '.repeat(Math.max(0, (column || 1) - 1))}^` : ''
+    return {line, lineText, pointer}
+  }
+
+  function classifyError (e: GrapheneError) {
+    if (e.type === 'analysis' || e.from || e.loc || e.codeFrame || e.frame) return `GSQL error - ${e.message || 'Unknown query error'}`
+    if (e.type === 'database') return 'Database query failed'
+    if (e.type === 'server') return 'Server error while running query'
+    return 'Query failed'
+  }
+
+  let parsed = $derived.by(() => {
+    let e = parseError(error)
+    let heading = classifyError(e)
+    let message = e.message || 'An unknown error occurred'
+    let details: string[] = []
+    let line = lineDetails(e)
+    // Query errors can be analyzed from generated wrapper gsql (`table <name> as (...)`).
+    // When that happens, line numbers are often for synthetic sql and can be misleading,
+    // but the captured source line text and caret are still accurate and useful to users.
+    // So we show file + line only when the diagnostic has a reliable line.
+    let fileLine = e.file && e.file !== 'input' ? `${e.file}${line.line ? `:${line.line}` : ''}` : undefined
+
+    if (e.id) details.push(e.id)
+    if (fileLine) details.push(fileLine)
+    else if (line.line) details.push(`Line ${line.line}`)
+    if (line.lineText) details.push(line.lineText)
+    if (line.pointer) details.push(line.pointer)
+    if (e.codeFrame) details.push(e.codeFrame)
+    if (e.frame) details.push(e.frame)
+
+    if (heading.startsWith('GSQL error - ')) message = ''
+    return {heading, message, details}
+  })
 </script>
 
 <div class="error-chart" style={`min-height:${height}px`} role="alert">
-  <div class="error-chart__title">{title}</div>
-  <pre class="error-chart__message">{message}</pre>
+  <div class="error-chart__heading">{parsed.heading}</div>
+  {#if parsed.message}
+    <div class="error-chart__message">{parsed.message}</div>
+  {/if}
+  {#if parsed.details.length}
+    <pre class="error-chart__details">{parsed.details.join('\n')}</pre>
+  {/if}
 </div>
 
 <style>
@@ -37,14 +92,21 @@
     box-sizing: border-box;
   }
 
-  .error-chart__title {
-    font-weight: 600;
-    font-size: 16px;
-    margin-bottom: 8px;
+  .error-chart__heading {
+    font-weight: 700;
+    margin-bottom: 4px;
+    text-align: center;
   }
 
   .error-chart__message {
     margin: 0;
+    text-align: center;
+    max-width: 72ch;
+    line-height: 1.4;
+  }
+
+  .error-chart__details {
+    margin: 10px 0 0;
     font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
     font-size: 12px;
     white-space: pre-wrap;

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -48,7 +48,7 @@ test('allows collapsing and expanding folders', async ({server, page}) => {
 })
 
 
-test('reports query errors', async ({server, page}) => {
+test('renders gsql query errors clearly with file context', async ({server, page}) => {
   expectConsoleError(page, 'Failed to load resource')
   server.mockFile('/index.md', `
     # Broken Dashboard
@@ -64,7 +64,59 @@ test('reports query errors', async ({server, page}) => {
   await page.goto(server.url() + '/')
   await waitForGrapheneQueries(page)
   await expect(page.getByRole('heading', {level: 1, name: 'Broken Dashboard'})).toBeVisible()
-  await expect(page).screenshot('reports-query-errors')
+  await expect(page.getByText('GSQL error - Unknown function: not_a_function')).toBeVisible()
+  let details = page.locator('.error-chart__details').first()
+  await expect(details).not.toContainText('input')
+  await expect(details).toContainText('Query (data="broken_query" x="origin" y="boom")')
+  await expect(details).toContainText('^')
+  await expect(details).not.toContainText('"message"')
+  await expect(page).screenshot('reports-analysis-query-errors')
+})
+
+test('renders database query failures clearly', async ({server, page}) => {
+  expectConsoleError(page, 'Failed to load resource')
+  server.mockFile('/index.md', `
+    # Database Failure
+
+    \`\`\`sql broken_query
+    from flights select origin, sqrt(dep_delay) as boom
+    \`\`\`
+
+    <BarChart data="broken_query" x="origin" y="boom" />
+  `)
+
+  await page.goto(server.url() + '/')
+  await waitForGrapheneQueries(page)
+  await expect(page.getByText(/(Database query failed|Server error while running query|Query failed)/)).toBeVisible()
+  await expect(page.getByText('Out of Range Error')).toBeVisible()
+  await expect(page).screenshot('reports-database-query-errors')
+})
+
+test('renders generic server failures clearly', async ({server, page}) => {
+  expectConsoleError(page, 'Failed to load resource')
+  server.mockFile('/index.md', `
+    # Server Failure
+
+    \`\`\`sql broken_query
+    from flights select origin, dep_delay
+    \`\`\`
+
+    <BarChart data="broken_query" x="origin" y="dep_delay" />
+  `)
+
+  await page.route('**/_api/query', async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify([{type: 'server', message: 'Internal Server Error'}]),
+    })
+  })
+
+  await page.goto(server.url() + '/')
+  await waitForGrapheneQueries(page)
+  await expect(page.getByText('Server error while running query')).toBeVisible()
+  await expect(page.getByText('Internal Server Error')).toBeVisible()
+  await expect(page).screenshot('reports-server-query-errors')
 })
 
 test('renders literal less-than characters', async ({server, page}) => {

--- a/ui/tests/snapshots/markdown.test.ts/reports-analysis-query-errors.png
+++ b/ui/tests/snapshots/markdown.test.ts/reports-analysis-query-errors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4963d1efdbce82dfdbb480953a6357cdf8f4a3cd987473a7be62932c1d47abf4
+size 28880

--- a/ui/tests/snapshots/markdown.test.ts/reports-database-query-errors.png
+++ b/ui/tests/snapshots/markdown.test.ts/reports-database-query-errors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85d36bba9d3fbea2e51c573468f7a395c3c46a07dce8c230ff1e3328f4aa29c3
+size 24001

--- a/ui/tests/snapshots/markdown.test.ts/reports-query-errors.png
+++ b/ui/tests/snapshots/markdown.test.ts/reports-query-errors.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:45190382bf6ebe86848abb88f986bd286de95d34d87f985b6809d779e242381c
-size 47423

--- a/ui/tests/snapshots/markdown.test.ts/reports-server-query-errors.png
+++ b/ui/tests/snapshots/markdown.test.ts/reports-server-query-errors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4603bb9d56b10aeb21c0300fbdc3abd21b15232fdbeb868ba7d0ddda4f16fe65
+size 19352


### PR DESCRIPTION
If an empty file has invalid syntax, then we want to show a nice error to the user, rather than just having a blank page. I also fixed up HMR to do the right thing. When you fix the error, it will actually reload the page properly. 

For query errors, we're just showing the raw JSON, but now we actually show something that looks nicer.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fgraphene-data%2Fgraphene%2Fpull%2F94&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->