### PR TITLE
Change `namespace` to `defaultNamespace`

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -66,7 +66,7 @@ program.command('schema')
     let dsToList: string | null = null
     let parts = tableArg ? tableArg.split('.') : []
     if (datasets.includes(tableArg)) dsToList = tableArg // you gave the name of a dataset
-    else if (!tableArg && config.namespace) dsToList = config.namespace // default namespace configured
+    else if (!tableArg && config.defaultNamespace) dsToList = config.defaultNamespace // default namespace configured
     else if (!tableArg && datasets.length == 1) dsToList = datasets[0] // only one dataset, and no args
     else if (!tableArg && config.dialect == 'duckdb') dsToList = '<default>'
     else if (tableArg && config.dialect == 'snowflake' && parts.length == 2) dsToList = tableArg

--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -17,7 +17,7 @@ export class BigQueryConnection implements QueryConnection {
     if (!options.projectId) throw new Error('projectId must be set in config or provided in service account credentials')
     this.projectId = options.projectId
     this.client = new BigQuery({...options, userAgent: 'Graphene'})
-    this.defaultNamespace = config.namespace
+    this.defaultNamespace = config.defaultNamespace
   }
 
   async runQuery (sql: string, params?: QueryParams): Promise<QueryResult> {

--- a/examples/ecomm/package.json
+++ b/examples/ecomm/package.json
@@ -18,7 +18,7 @@
     "svelte": "5.48.0"
   },
   "graphene": {
-    "namespace": "bigquery-public-data.thelook_ecommerce",
+    "defaultNamespace": "bigquery-public-data.thelook_ecommerce",
     "bigquery": {
       "projectId": "intense-acumen-470417-u5"
     },

--- a/examples/snowflake/package.json
+++ b/examples/snowflake/package.json
@@ -18,7 +18,7 @@
   },
   "graphene": {
     "dialect": "snowflake",
-    "namespace": "FOOD__BEVERAGE_ESTABLISHMENT__MENU_DATA.V02",
+    "defaultNamespace": "FOOD__BEVERAGE_ESTABLISHMENT__MENU_DATA.V02",
     "snowflake": {
       "account": "adarjvr-ve40413",
       "username": "demouser"

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -39,7 +39,8 @@ export function findTables (fi: FileInfo) {
     })
     if (existing) diag(syntaxNode.getChild('Ref')!, `Table "${name}" is already defined`)
 
-    let tablePath = config.namespace ? `${config.namespace}.${name}` : name
+    let hasNamespace = name.includes('.')
+    let tablePath = !hasNamespace && config.defaultNamespace ? `${config.defaultNamespace}.${name}` : name
     let type = syntaxNode.getChild('QueryStatement') ? 'view' : 'table' as const
     let table = {name, type, tablePath, columns: [], joins: [], metadata: extractLeadingMetadata(syntaxNode), syntaxNode} as Table
 

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -4,7 +4,7 @@ import path from 'path'
 export interface Config {
   root: string
   dialect: string
-  namespace?: string
+  defaultNamespace?: string
   ignoredFiles: string[]
   port?: number
   host?: string
@@ -29,12 +29,14 @@ export interface Config {
 export type ConfigInput = Omit<Config, 'dialect' | 'ignoredFiles' | 'envFile'> & {
   dialect?: Config['dialect'],
   ignoredFiles?: Config['ignoredFiles'],
-  envFile?: string | string[]
+  envFile?: string | string[],
+  namespace?: string
 }
 
 export let config: Config = {dialect: 'duckdb', root: ''} as Config
 
 export function setConfig (cfg: ConfigInput) {
+  if (cfg.namespace && !cfg.defaultNamespace) cfg.defaultNamespace = cfg.namespace
   let dialect = cfg.dialect || 'duckdb'
   if (cfg.bigquery) dialect = 'bigquery'
   else if (cfg.snowflake) dialect = 'snowflake'

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -106,6 +106,17 @@ describe('lang', () => {
       .toRenderSql('SELECT USERS."id" as "id", orders."amount" as "amt" from USERS as USERS LEFT JOIN ORDERS as orders ON orders."user_id"=USERS."id" ORDER BY 2 desc NULLS LAST')
   })
 
+  it('applies defaultNamespace to unqualified table paths', () => {
+    setConfig({root: '', defaultNamespace: 'analytics'})
+    expect('from users select id').toRenderSql('select users."id" as "id" from analytics.users as users')
+  })
+
+  it('does not apply defaultNamespace to already-qualified table paths', () => {
+    setConfig({root: '', defaultNamespace: 'analytics'})
+    updateFile('table raw.users (id int)', 'namespaced.gsql')
+    expect('from raw.users select id').toRenderSql('select users."id" as "id" from raw.users as users')
+  })
+
   // Skipped: this test has issues with join chain resolution that are unrelated to uppercase handling
   // The SQL output doesn't match expectations for nested joins through snowflake tables
   it.skip('uppercases nested join chains and query_source views for snowflake tables', () => {


### PR DESCRIPTION
The former was always applied to every table, the latter is only applied to unqualified tables.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/102?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->