### PR TITLE
Fix VSCode extension crash when no workspace folder is open

### DIFF
--- a/vscode/src/languageServer.ts
+++ b/vscode/src/languageServer.ts
@@ -22,9 +22,11 @@ let initialLoad: Promise<void> | undefined
 connection.onInitialize(params => {
   let dirs = params.workspaceFolders?.map(f => f.uri) || []
   console.log('started Graphene server', dirs)
-  let root = dirs[0].replace('file://', '')
-  loadConfig(root)
-  initialLoad = dirs[0] ? loadWorkspace(root, true) : Promise.resolve()
+  if (dirs[0]) {
+    let root = dirs[0].replace('file://', '')
+    loadConfig(root)
+    initialLoad = loadWorkspace(root, true)
+  }
 
   return {
     capabilities: {


### PR DESCRIPTION
## Summary
- Fix `Cannot read properties of undefined (reading 'replace')` error that crashed the language server on startup when no workspace folder is open
- Guard `dirs[0]` access in `onInitialize` so the server starts cleanly and returns capabilities even without a workspace

## Test plan
- [ ] Install extension and open VS Code without a workspace folder — no error popups
- [ ] Open VS Code with a workspace folder — extension works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/113?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->