### PR TITLE
Don't drop type info when we use tidy

### DIFF
--- a/ui/component-utilities/dateParsing.js
+++ b/ui/component-utilities/dateParsing.js
@@ -1,4 +1,5 @@
-import {tidy, mutate} from '@tidyjs/tidy'
+import {mutate} from '@tidyjs/tidy'
+import {tidyWithTypes} from './tidyWithTypes.js'
 
 export function standardizeDateString (date) {
   if (date && typeof date === 'string') {
@@ -33,7 +34,7 @@ export function standardizeDateString (date) {
 export function convertColumnToDate (data, column) {
   // Replaces a date column's string values with JS date objects, using the standardizeDateString function
 
-  let converted = tidy(
+  let converted = tidyWithTypes(
     data,
     mutate({[column]: (d) => (d[column] ? new Date(standardizeDateString(d[column])) : null)}),
   )
@@ -51,7 +52,7 @@ export function standardizeDateColumn (data, column) {
   // Replaces a date column's string values with standardized date strings, using the standardizeDateString function
   // Used in Chart.svelte, where using Date objects leads to errors
 
-  data = tidy(data, mutate({[column]: (d) => standardizeDateString(d[column])}))
+  data = tidyWithTypes(data, mutate({[column]: (d) => standardizeDateString(d[column])}))
 
   return data
 }

--- a/ui/component-utilities/formatting.js
+++ b/ui/component-utilities/formatting.js
@@ -63,7 +63,8 @@ export function getFormatObjectFromString (formatString, valueType = undefined) 
   )
   let newFormat = {}
   if (matchingFormat) {
-    return matchingFormat
+    if (!valueType || matchingFormat.valueType === valueType) return matchingFormat
+    return {...matchingFormat, valueType}
   } else {
     newFormat = {
       formatTag: 'custom',
@@ -198,6 +199,8 @@ function applyFormatting (
         } catch (error) {
           console.warn(`Unexpected error applying auto formatting. Error=${error}`)
         }
+      } else if (columnFormat.valueType === 'number' && typeof typedValue === 'number' && isYearOnlyFormat(formattingCode)) {
+        result = formatNumericYear(typedValue, formattingCode)
       } else {
         result = ssf.format(formattingCode, typedValue)
       }
@@ -210,6 +213,20 @@ function applyFormatting (
   }
   return result
 }
+
+function isYearOnlyFormat (formattingCode) {
+  return typeof formattingCode === 'string' && /^y{2,4}$/i.test(formattingCode.trim())
+}
+
+function formatNumericYear (value, formattingCode) {
+  let year = String(Math.trunc(value))
+  let width = formattingCode.trim().length
+  if (width === 2) {
+    return year.slice(-2).padStart(2, '0')
+  }
+  return year.padStart(width, '0')
+}
+
 function getEffectiveFormattingCode (columnFormat, formattingContext = VALUE_FORMATTING_CONTEXT) {
   if (typeof columnFormat === 'string') {
     // This should only be used by end users, not by components.

--- a/ui/component-utilities/getCompletedData.js
+++ b/ui/component-utilities/getCompletedData.js
@@ -108,7 +108,17 @@ export default function getCompletedData (_data, x, y, series, nullsZero = false
 
     output.push(tidy(value, ...tidyFuncs))
   }
-  if (xIsDate) return output.flat().map((r) => ({...r, [x]: new Date(r[x])}))
+  if (xIsDate) {
+    let converted = output.flat().map((r) => ({...r, [x]: new Date(r[x])}))
+    if (Array.isArray(_data?._evidenceColumnTypes)) {
+      converted._evidenceColumnTypes = _data._evidenceColumnTypes
+    }
+    return converted
+  }
 
-  return output.flat()
+  let flattened = output.flat()
+  if (Array.isArray(_data?._evidenceColumnTypes)) {
+    flattened._evidenceColumnTypes = _data._evidenceColumnTypes
+  }
+  return flattened
 }

--- a/ui/component-utilities/getSortedData.js
+++ b/ui/component-utilities/getSortedData.js
@@ -2,6 +2,8 @@ export default function getSortedData (data, col, isAsc) {
   let res = [...data].sort((a, b) => {
     return (a[col] < b[col] ? -1 : 1) * (isAsc ? 1 : -1)
   })
-  res._evidenceColumnTypes = data._evidenceColumnTypes
+  if (Array.isArray(data?._evidenceColumnTypes)) {
+    res._evidenceColumnTypes = data._evidenceColumnTypes
+  }
   return res
 }

--- a/ui/component-utilities/getStackPercentages.js
+++ b/ui/component-utilities/getStackPercentages.js
@@ -1,9 +1,10 @@
-import {tidy, groupBy, sum, mutateWithSummary, mutate, rate, rename} from '@tidyjs/tidy'
+import {groupBy, sum, mutateWithSummary, mutate, rate, rename} from '@tidyjs/tidy'
+import {tidyWithTypes} from './tidyWithTypes.js'
 
 export default function getStackPercentages (data, groupCol, valueCol) {
   let pctData
   if (typeof valueCol !== 'object') {
-    pctData = tidy(
+    pctData = tidyWithTypes(
       data,
       groupBy(groupCol, mutateWithSummary({xTotal: sum(valueCol)})),
       mutate({percentOfX: rate(valueCol, 'xTotal')}),
@@ -12,7 +13,7 @@ export default function getStackPercentages (data, groupCol, valueCol) {
       }),
     )
   } else {
-    pctData = tidy(
+    pctData = tidyWithTypes(
       data,
       mutate({
         valueSum: 0,
@@ -26,10 +27,10 @@ export default function getStackPercentages (data, groupCol, valueCol) {
       }
     }
 
-    pctData = tidy(pctData, groupBy(groupCol, mutateWithSummary({xTotal: sum('valueSum')})))
+    pctData = tidyWithTypes(pctData, groupBy(groupCol, mutateWithSummary({xTotal: sum('valueSum')})))
 
     for (let i = 0; i < valueCol.length; i++) {
-      pctData = tidy(
+      pctData = tidyWithTypes(
         pctData,
         mutate({percentOfX: rate(valueCol[i], 'xTotal')}),
         rename({

--- a/ui/component-utilities/getStackedData.js
+++ b/ui/component-utilities/getStackedData.js
@@ -1,7 +1,8 @@
-import {tidy, groupBy, summarizeAt, sum} from '@tidyjs/tidy'
+import {groupBy, summarizeAt, sum} from '@tidyjs/tidy'
+import {tidyWithTypes} from './tidyWithTypes.js'
 
 export default function getStackedData (data, groupCol, valueCol) {
-  let stackedData = tidy(data, groupBy(groupCol, [summarizeAt(valueCol, sum)]))
+  let stackedData = tidyWithTypes(data, groupBy(groupCol, [summarizeAt(valueCol, sum)]))
 
   // If multiple y columns, iterate through data and add stack total column for sorting:
   if (typeof valueCol === 'object') {

--- a/ui/component-utilities/replaceNulls.js
+++ b/ui/component-utilities/replaceNulls.js
@@ -1,4 +1,5 @@
-import {tidy, replaceNully} from '@tidyjs/tidy'
+import {replaceNully} from '@tidyjs/tidy'
+import {tidyWithTypes} from './tidyWithTypes.js'
 
 export default function replaceNulls (data, columns) {
   let colObj = {}
@@ -9,6 +10,6 @@ export default function replaceNulls (data, columns) {
   } else {
     colObj[columns] = 0
   }
-  data = tidy(data, replaceNully(colObj))
+  data = tidyWithTypes(data, replaceNully(colObj))
   return data
 }

--- a/ui/component-utilities/tidyWithTypes.js
+++ b/ui/component-utilities/tidyWithTypes.js
@@ -1,0 +1,9 @@
+import {tidy} from '@tidyjs/tidy'
+
+export function tidyWithTypes (data, ...ops) {
+  let result = tidy(data, ...ops)
+  if (Array.isArray(data?._evidenceColumnTypes)) {
+    result._evidenceColumnTypes = data._evidenceColumnTypes
+  }
+  return result
+}

--- a/ui/components/Chart.svelte
+++ b/ui/components/Chart.svelte
@@ -394,7 +394,7 @@
       // Get format codes for axes
       // ---------------------------------------------------------------------------------------
       if (xFmt) {
-        xFormat = getFormatObjectFromString(xFmt, columnSummary[xLocal].format?.valueType)
+        xFormat = getFormatObjectFromString(xFmt, columnSummary[xLocal].type)
       } else {
         xFormat = columnSummary[xLocal].format
       }
@@ -402,18 +402,18 @@
       if (yLocal.length === 0) {
         yFormat = 'str'
       } else {
-        if (yFmt) yFormat = getFormatObjectFromString(yFmt, columnSummary[yLocal[0]].format?.valueType)
+        if (yFmt) yFormat = getFormatObjectFromString(yFmt, columnSummary[yLocal[0]].type)
         else yFormat = columnSummary[yLocal[0]].format
       }
 
       if (y2Local.length) {
-        if (y2Fmt) y2Format = getFormatObjectFromString(y2Fmt, columnSummary[y2Local[0]].format?.valueType)
+        if (y2Fmt) y2Format = getFormatObjectFromString(y2Fmt, columnSummary[y2Local[0]].type)
         else y2Format = columnSummary[y2Local[0]].format
       }
 
       if (size) {
         if (sizeFmt) {
-          sizeFormat = getFormatObjectFromString(sizeFmt, columnSummary[size].format?.valueType)
+          sizeFormat = getFormatObjectFromString(sizeFmt, columnSummary[size].type)
         } else {
           sizeFormat = columnSummary[size].format
         }

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-numeric-year-xfmt.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-numeric-year-xfmt.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed43d237c648cecd5e8d6839d776c6a8b6f6c163cef1e68f1d3c9c8f61b4d462
+size 7310

--- a/ui/tests/snapshots/viz.test.ts/stacked100-date-axis-order.png
+++ b/ui/tests/snapshots/viz.test.ts/stacked100-date-axis-order.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75592e4abd83724fb194079b642592673818a621c833e7d1038ab1bd7d8651ad
+size 13835

--- a/ui/tests/testData.ts
+++ b/ui/tests/testData.ts
@@ -53,6 +53,22 @@ export function timeseriesWithDateSeries (): TableRows {
   return {rows}
 }
 
+export function yearlyCounts (): TableRows {
+  let rows = [
+    {year: 2000, flights: 90},
+    {year: 2001, flights: 80},
+    {year: 2002, flights: 75},
+    {year: 2003, flights: 95},
+    {year: 2004, flights: 110},
+    {year: 2005, flights: 120},
+  ] as any
+  rows._evidenceColumnTypes = [
+    {name: 'year', evidenceType: 'number'},
+    {name: 'flights', evidenceType: 'number'},
+  ]
+  return {rows}
+}
+
 export function tableDataWithDates (): TableRows {
   let rows = [
     {month: '2021-03-01', sales: 50},

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from './fixtures.ts'
-import {singleDim, timeseries, timeseriesGrouped, timeseriesWithDateSeries} from './testData.ts'
+import {singleDim, timeseries, timeseriesGrouped, timeseriesWithDateSeries, yearlyCounts} from './testData.ts'
 
 test.beforeEach(async ({page}) => {
   await page.setViewportSize({width: 680, height: 400})
@@ -23,6 +23,19 @@ test('area chart', async ({mount, chart}) => {
 test('stacked area chart', async ({mount, chart}) => {
   await mount('components/AreaChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', series: 'category', type: 'stacked'})
   await expect(chart.el).screenshot('stacked-area-chart')
+})
+
+test('stacked100 keeps time axis when x values are dates', async ({mount, chart}) => {
+  await mount('components/AreaChart.svelte', {
+    data: timeseriesGrouped(),
+    x: 'month',
+    y: 'sales_usd0k',
+    series: 'category',
+    type: 'stacked100',
+  })
+  let axisType = await chart.config((c) => (Array.isArray(c.xAxis) ? c.xAxis[0] : c.xAxis).type)
+  expect(axisType).toBe('time')
+  await expect(chart.el).screenshot('stacked100-date-axis-order')
 })
 
 test('line chart timeseries', async ({mount, page, chart}) => {
@@ -139,6 +152,21 @@ test('line chart seriesLabelFmt formats date series names', async ({mount, chart
   let names = await chart.config((c) => (c.series ?? []).map((s: any) => s.name).sort())
   expect(names).toEqual(['2021-01', '2021-04', '2021-07'])
   await expect(chart.el).screenshot('line-chart-series-label-fmt')
+})
+
+test('numeric year xFmt=yyyy keeps year labels', async ({mount, chart}) => {
+  await mount('components/BarChart.svelte', {
+    data: yearlyCounts(),
+    x: 'year',
+    y: 'flights',
+    xFmt: 'yyyy',
+  })
+  let axisLabel = await chart.config((c) => {
+    let xAxis = Array.isArray(c.xAxis) ? c.xAxis[0] : c.xAxis
+    return xAxis.axisLabel.formatter(2000)
+  })
+  expect(axisLabel).toBe('2000')
+  await expect(chart.el).screenshot('bar-chart-numeric-year-xfmt')
 })
 
 test('bar chart accepts comma-separated multi y', async ({mount, chart}) => {


### PR DESCRIPTION
This was causing axes to render incorrectly when we used tidy to do certain transforms (like stacked100) because the new array didn't preserve the type info.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/118?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->