### PR TITLE
Configure files to be ignored

### DIFF
--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -1,8 +1,7 @@
-import {loadWorkspace, config, clearWorkspace, analyze, getDiagnostics, toSql} from '../lang/core.ts'
+import {loadWorkspace, config, clearWorkspace, analyze, getDiagnostics, toSql, getFiles} from '../lang/core.ts'
 import {createServer, type InlineConfig, optimizeDeps, resolveConfig, type ViteDevServer} from 'vite'
 import {svelte, vitePreprocess} from '@sveltejs/vite-plugin-svelte'
 import fs from 'fs-extra'
-import {glob} from 'glob'
 import crypto from 'crypto'
 // import sveltePreprocess from 'svelte-preprocess' // this would be nice, but it breaks sourcemaps by default
 import {type IncomingMessage, type ServerResponse} from 'http'
@@ -232,8 +231,9 @@ const updateWorkspacePlugin = {
   configureServer: (s: ViteDevServer) => {
     let refresh = async () => {
       clearWorkspace()
-      workspaceLoadPromise = loadWorkspace(config.root, false)
-      mdFiles = await glob('**/*.md', {cwd: config.root, ignore: ['node_modules/**']})
+      workspaceLoadPromise = loadWorkspace(config.root, true)
+      await workspaceLoadPromise
+      mdFiles = getFiles().filter(f => f.path.endsWith('.md')).map(f => f.path)
       mdFiles = mdFiles.filter(f => !config.ignoredFiles?.includes(path.basename(f).toLowerCase()))
       if (process.env.NODE_ENV == 'test') {
         mdFiles.push(...Object.keys(mockFileMap))

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -19,8 +19,9 @@ export function getFiles () { return Object.values(FILE_MAP) }
 export function getDiagnostics () { return diagnostics }
 
 // Loads and parses all gsql files within a directory
-export async function loadWorkspace (dir: string, includeMd: boolean) {
-  let files = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore: ['node_modules/**'], follow: false})
+export async function loadWorkspace(dir: string, includeMd: boolean) {
+  let ignore = ['node_modules/**', '**/.*/**', ...config.ignoredFiles]
+  let files = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore, follow: false})
   for await (let file of files) {
     try {
       let contents = await readFile(path.join(dir, file), 'utf-8')

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -1,9 +1,12 @@
 /// <reference types="vitest/globals" />
 import {setConfig} from './config.ts'
-import {clearWorkspace, getTable, analyze, toSql, getDiagnostics, updateFile} from './core.ts'
+import {clearWorkspace, getTable, analyze, toSql, getDiagnostics, updateFile, loadWorkspace, getFile} from './core.ts'
 import {prepareEcommerceTables} from './testHelpers.ts'
 import {expect} from 'vitest'
 import {trimIndentation} from './util.ts'
+import {mkdtemp, mkdir, writeFile, rm} from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 
 const testTables = `
   table users (
@@ -115,6 +118,28 @@ describe('lang', () => {
     setConfig({root: '', defaultNamespace: 'analytics'})
     updateFile('table raw.users (id int)', 'namespaced.gsql')
     expect('from raw.users select id').toRenderSql('select users."id" as "id" from raw.users as users')
+  })
+
+  it('ignores workspace files matched by ignoredFiles globs', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-workspace-ignore-'))
+
+    try {
+      await writeFile(path.join(root, 'models.gsql'), 'table users (id int)')
+      await mkdir(path.join(root, 'nested'), {recursive: true})
+      await writeFile(path.join(root, 'nested', 'agents.md'), '# hidden nav page')
+      await mkdir(path.join(root, 'dist'), {recursive: true})
+      await writeFile(path.join(root, 'dist', 'ignored.gsql'), 'table hidden (id int)')
+
+      clearWorkspace()
+      setConfig({root, ignoredFiles: ['**/agents.md', 'dist/**']})
+      await loadWorkspace(root, true)
+
+      expect(getFile('models.gsql')).toBeDefined()
+      expect(getFile('nested/agents.md')).toBeUndefined()
+      expect(getFile('dist/ignored.gsql')).toBeUndefined()
+    } finally {
+      await rm(root, {recursive: true, force: true})
+    }
   })
 
   // Skipped: this test has issues with join chain resolution that are unrelated to uppercase handling


### PR DESCRIPTION
Ignore dot-folders by default, and use ignoredFiles for both workspace and nav filtering.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/125?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->