### PR TITLE
fix bug with self-closing tags and remark/rehype pipeline

### DIFF
--- a/cli/mdCompile.test.ts
+++ b/cli/mdCompile.test.ts
@@ -1,0 +1,30 @@
+/// <reference types="vitest/globals" />
+import {compile} from 'mdsvex'
+import {escapeAngles, extractQueries, sanitizeMarkdown} from './mdCompile.ts'
+
+describe('markdown sanitization', () => {
+  it('keeps wrapper components intact across blank lines', async () => {
+    let src = `
+<Row>
+  <BarChart data="x" y="a" />
+
+  <PieChart data="x" value="a" />
+</Row>
+`
+
+    let out = await compile(src, {
+      remarkPlugins: [extractQueries, escapeAngles],
+      rehypePlugins: [sanitizeMarkdown],
+    })
+    if (!out) throw new Error('Expected mdsvex compile output')
+    let code = String(out.code)
+
+    expect(code).toContain('<Row>')
+    expect(code).toContain('<BarChart data="x" y="a"></BarChart>')
+    expect(code).toContain('<PieChart data="x" value="a"></PieChart>')
+    expect(code).toContain('</Row>')
+
+    expect(code.indexOf('<BarChart')).toBeLessThan(code.indexOf('<PieChart'))
+    expect(code.indexOf('<PieChart')).toBeLessThan(code.indexOf('</Row>'))
+  })
+})

--- a/cli/mdCompile.test.ts
+++ b/cli/mdCompile.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest/globals" />
 import {compile} from 'mdsvex'
-import {escapeAngles, extractQueries, mergeAdjacentHtml, sanitizeMarkdown} from './mdCompile.ts'
+import {remarkPlugins, rehypePlugins} from './mdCompile.ts'
 
 describe('markdown sanitization', () => {
   it('keeps wrapper components intact across blank lines', async () => {
@@ -12,10 +12,7 @@ describe('markdown sanitization', () => {
 </Row>
 `
 
-    let out = await compile(src, {
-      remarkPlugins: [extractQueries, escapeAngles, mergeAdjacentHtml],
-      rehypePlugins: [sanitizeMarkdown],
-    })
+    let out = await compile(src, { remarkPlugins, rehypePlugins })
     if (!out) throw new Error('Expected mdsvex compile output')
     let code = String(out.code)
 

--- a/cli/mdCompile.test.ts
+++ b/cli/mdCompile.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest/globals" />
 import {compile} from 'mdsvex'
-import {escapeAngles, extractQueries, sanitizeMarkdown} from './mdCompile.ts'
+import {escapeAngles, extractQueries, mergeAdjacentHtml, sanitizeMarkdown} from './mdCompile.ts'
 
 describe('markdown sanitization', () => {
   it('keeps wrapper components intact across blank lines', async () => {
@@ -13,7 +13,7 @@ describe('markdown sanitization', () => {
 `
 
     let out = await compile(src, {
-      remarkPlugins: [extractQueries, escapeAngles],
+      remarkPlugins: [extractQueries, escapeAngles, mergeAdjacentHtml],
       rehypePlugins: [sanitizeMarkdown],
     })
     if (!out) throw new Error('Expected mdsvex compile output')

--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -30,6 +30,27 @@ export function escapeAngles () {
   }
 }
 
+// remark can split one html block into adjacent html nodes when self-closing tags are involved.
+// Merge those sibling html nodes so downstream rehype/sanitize work on the full block.
+export function mergeAdjacentHtml () {
+  return function transformer (tree: any) {
+    visit(tree, (parent: any) => {
+      if (!Array.isArray(parent?.children)) return
+
+      for (let i = 0; i < parent.children.length; i++) {
+        if (parent.children[i]?.type !== 'html') continue
+
+        let j = i
+        while (j + 1 < parent.children.length && parent.children[j + 1]?.type === 'html') j++
+        if (j == i) continue
+
+        let value = parent.children.slice(i, j + 1).map((node: any) => node.value || '').join('\n')
+        parent.children.splice(i, j - i + 1, {type: 'html', value})
+      }
+    })
+  }
+}
+
 // Restrict allowed components in markdown files to avoid xss issues.
 // This uses sanitize-html rather than rehype-sanitize because the latter had lots of issues with preserving tag casing,
 // as well as allowing all attributes on our allowlisted components.

--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import type {Plugin} from 'unified'
 import {visit} from 'unist-util-visit'
 import sanitizeHtml from 'sanitize-html'
 
@@ -114,3 +115,6 @@ export function componentNames () {
   cachedComponentNames = files.map(f => path.basename(f, '.svelte')).filter(f => !f.startsWith('_'))
   return cachedComponentNames || []
 }
+
+export const remarkPlugins: Array<Plugin> = [extractQueries, escapeAngles, mergeAdjacentHtml];
+export const rehypePlugins: Array<Plugin> = [sanitizeMarkdown];

--- a/cli/package.json
+++ b/cli/package.json
@@ -48,6 +48,7 @@
     "snowflake-sdk": "^2.3.4",
     "ssf": "^0.11.2",
     "svelte": "5.53.3",
+    "unified": "^11.0.5",
     "unist-util-visit": "4.1.2",
     "vite": "7.3.1",
     "ws": "^8.18.0"

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -10,7 +10,7 @@ import {mdsvex} from 'mdsvex'
 import path from 'path'
 import {fileURLToPath} from 'url'
 import {runQuery} from './connections/index.ts'
-import {escapeAngles, extractQueries, injectComponentImports, sanitizeMarkdown} from './mdCompile.ts'
+import {escapeAngles, extractQueries, injectComponentImports, mergeAdjacentHtml, sanitizeMarkdown} from './mdCompile.ts'
 import {checkVitePlugin} from './check.ts'
 import {mockFileMap} from './mockFiles.ts'
 
@@ -53,7 +53,7 @@ async function createConfig (): Promise<InlineConfig> {
           vitePreprocess(),
           mdsvex({
             extensions: ['.md'],
-            remarkPlugins: [extractQueries, escapeAngles],
+            remarkPlugins: [extractQueries, escapeAngles, mergeAdjacentHtml],
             rehypePlugins: [sanitizeMarkdown],
           }) as any,
           injectComponentImports(),

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -10,7 +10,7 @@ import {mdsvex} from 'mdsvex'
 import path from 'path'
 import {fileURLToPath} from 'url'
 import {runQuery} from './connections/index.ts'
-import {escapeAngles, extractQueries, injectComponentImports, mergeAdjacentHtml, sanitizeMarkdown} from './mdCompile.ts'
+import {injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 import {checkVitePlugin} from './check.ts'
 import {mockFileMap} from './mockFiles.ts'
 
@@ -53,8 +53,8 @@ async function createConfig (): Promise<InlineConfig> {
           vitePreprocess(),
           mdsvex({
             extensions: ['.md'],
-            remarkPlugins: [extractQueries, escapeAngles, mergeAdjacentHtml],
-            rehypePlugins: [sanitizeMarkdown],
+            remarkPlugins,
+            rehypePlugins,
           }) as any,
           injectComponentImports(),
         ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       svelte:
         specifier: 5.53.3
         version: 5.53.3
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       unist-util-visit:
         specifier: 4.1.2
         version: 4.1.2
@@ -1655,6 +1658,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1836,12 +1842,19 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   devalue@5.6.3:
     resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2222,6 +2235,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -2795,6 +2812,9 @@ packages:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-toolbelt@8.4.0:
     resolution: {integrity: sha512-hnGJXIgC49ZuF5g5oDthoge8t4cvT0dYg2pYO5C6yV/HmUUy1koooU2U/5K2N+Uw++hcXQpJAToLRa+GRp28Sg==}
 
@@ -2812,6 +2832,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
 
@@ -2820,6 +2843,9 @@ packages:
 
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
   unist-util-visit-parents@3.1.1:
     resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
@@ -2860,6 +2886,12 @@ packages:
 
   vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -4867,6 +4899,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -5028,10 +5062,16 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2:
     optional: true
 
   devalue@5.6.3: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dom-serializer@2.0.0:
     dependencies:
@@ -5512,6 +5552,8 @@ snapshots:
       is-docker: 3.0.0
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-plain-object@5.0.0: {}
 
@@ -6152,6 +6194,8 @@ snapshots:
 
   triple-beam@1.4.1: {}
 
+  trough@2.2.0: {}
+
   ts-toolbelt@8.4.0: {}
 
   tslib@2.3.0: {}
@@ -6162,6 +6206,16 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unist-util-is@4.1.0: {}
 
   unist-util-is@5.2.1:
@@ -6171,6 +6225,10 @@ snapshots:
   unist-util-stringify-position@2.0.3:
     dependencies:
       '@types/unist': 2.0.11
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
 
   unist-util-visit-parents@3.1.1:
     dependencies:
@@ -6219,6 +6277,16 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
       unist-util-stringify-position: 2.0.3
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@6.4.1(@types/node@22.19.10)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1):
     dependencies:


### PR DESCRIPTION
This PR fixes an interaction between self-closing tags/components and the remark/rehype processing pipeline. This manifested as a bug where introducing a newline between two (self-closing) children of a `<Row>` component would result in only the first component ending up inside the row div.

The cause turned out to be an interaction with the self-closing tag handling in `sanitizeMarkdown`, which got confused because the nodes end up with their HTML content broken in the middle (where the self-closing tag is). Instead of tweaking that sanitization logic I opted to add an additional remark processor which merges adjacent `html` nodes so that downstream code gets nodes with combined content and doesn't get confused.

Fixes #56.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/126?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->