### PR TITLE
update example AGENTS.md docs links

### DIFF
--- a/examples/ecomm/AGENTS.md
+++ b/examples/ecomm/AGENTS.md
@@ -1,5 +1,5 @@
 # RULES
-- Graphene contains languages and tools you may not already know.
+- Graphene contains languages and tools that you do not already know.
 - Before writing code in this directory, you MUST read `@../../docs/base.md` **in its entirety**.
 - You MUST also read relevant reference docs in `@../../docs/references/*.md` before implementing or editing related functionality.
 - Treat reference docs as required context, not optional reading.

--- a/examples/ecomm/AGENTS.md
+++ b/examples/ecomm/AGENTS.md
@@ -1,5 +1,17 @@
 # RULES
-- Graphene contains languages and tools that you do not already know, so IT IS CRITICAL that you read the Graphene documentation (@../../docs/graphene.md) and agent instructions (@../../docs/agent-instructions.md) **in their entirety** before working in this directory. You will be docked every time you write code here without first reading the documentation.
+- Graphene contains languages and tools you may not already know.
+- Before writing code in this directory, you MUST read `@../../docs/base.md` **in its entirety**.
+- You MUST also read relevant reference docs in `@../../docs/references/*.md` before implementing or editing related functionality.
+- Treat reference docs as required context, not optional reading.
+- If a task touches multiple areas (for example: GSQL + chart components), read all applicable reference files first.
+- If unsure which reference applies, start with `@../../docs/references/gsql.md`, then load additional references based on the components/functions used.
+- You will be docked for writing code here without completing the required documentation reading.
+
+## Reference docs
+- Core overview: `@../../docs/base.md`
+- CLI usage: `@../../docs/cli.md`
+- Best practices: `@../../docs/best-practices.md`
+- Detailed feature/component references: `@../../docs/references/*.md`
 
 # About this data
 This dataset represents a fictitious e-commerce store. The Graphene schema can be found in the ./models directory.

--- a/examples/flights/AGENTS.md
+++ b/examples/flights/AGENTS.md
@@ -1,5 +1,17 @@
 # RULES
-- Graphene contains languages and tools that you do not already know, so IT IS CRITICAL that you read the Graphene documentation (@../../docs/graphene.md) and agent instructions (@../../docs/agent-instructions.md) **in their entirety** before working in this directory. You will be docked every time you write code here without first reading the documentation.
+- Graphene contains languages and tools you may not already know.
+- Before writing code in this directory, you MUST read `@../../docs/base.md` **in its entirety**.
+- You MUST also read relevant reference docs in `@../../docs/references/*.md` before implementing or editing related functionality.
+- Treat reference docs as required context, not optional reading.
+- If a task touches multiple areas (for example: GSQL + chart components), read all applicable reference files first.
+- If unsure which reference applies, start with `@../../docs/references/gsql.md`, then load additional references based on the components/functions used.
+- You will be docked for writing code here without completing the required documentation reading.
+
+## Reference docs
+- Core overview: `@../../docs/base.md`
+- CLI usage: `@../../docs/cli.md`
+- Best practices: `@../../docs/best-practices.md`
+- Detailed feature/component references: `@../../docs/references/*.md`
 
 # About this data
 This is a Graphene project covering FAA flight data from 2000 to 2005. You can find the Graphene tables in @./tables.

--- a/examples/flights/AGENTS.md
+++ b/examples/flights/AGENTS.md
@@ -1,5 +1,5 @@
 # RULES
-- Graphene contains languages and tools you may not already know.
+- Graphene contains languages and tools that you do not already know.
 - Before writing code in this directory, you MUST read `@../../docs/base.md` **in its entirety**.
 - You MUST also read relevant reference docs in `@../../docs/references/*.md` before implementing or editing related functionality.
 - Treat reference docs as required context, not optional reading.

--- a/examples/flights_empty/AGENTS.md
+++ b/examples/flights_empty/AGENTS.md
@@ -1,5 +1,17 @@
 # RULES
-- Graphene contains languages and tools that you do not already know, so IT IS CRITICAL that you read the Graphene documentation (@../../docs/graphene.md) and agent instructions (@../../docs/agent-instructions.md) **in their entirety** before working in this directory. You will be docked every time you write code here without first reading the documentation.
+- Graphene contains languages and tools you may not already know.
+- Before writing code in this directory, you MUST read `@../../docs/base.md` **in its entirety**.
+- You MUST also read relevant reference docs in `@../../docs/references/*.md` before implementing or editing related functionality.
+- Treat reference docs as required context, not optional reading.
+- If a task touches multiple areas (for example: GSQL + chart components), read all applicable reference files first.
+- If unsure which reference applies, start with `@../../docs/references/gsql.md`, then load additional references based on the components/functions used.
+- You will be docked for writing code here without completing the required documentation reading.
+
+## Reference docs
+- Core overview: `@../../docs/base.md`
+- CLI usage: `@../../docs/cli.md`
+- Best practices: `@../../docs/best-practices.md`
+- Detailed feature/component references: `@../../docs/references/*.md`
 
 # About this data
 This is a Graphene project covering FAA flight data from 2000 to 2005. You can find the Graphene tables in @./tables.

--- a/examples/flights_empty/AGENTS.md
+++ b/examples/flights_empty/AGENTS.md
@@ -1,5 +1,5 @@
 # RULES
-- Graphene contains languages and tools you may not already know.
+- Graphene contains languages and tools that you do not already know.
 - Before writing code in this directory, you MUST read `@../../docs/base.md` **in its entirety**.
 - You MUST also read relevant reference docs in `@../../docs/references/*.md` before implementing or editing related functionality.
 - Treat reference docs as required context, not optional reading.

--- a/examples/snowflake/AGENTS.md
+++ b/examples/snowflake/AGENTS.md
@@ -1,5 +1,17 @@
 # RULES
-- Graphene contains languages and tools that you do not already know, so IT IS CRITICAL that you read the Graphene documentation (@../../docs/graphene.md) and agent instructions (@../../docs/agent-instructions.md) **in their entirety** before working in this directory. You will be docked every time you write code here without first reading the documentation.
+- Graphene contains languages and tools you may not already know.
+- Before writing code in this directory, you MUST read `@../../docs/base.md` **in its entirety**.
+- You MUST also read relevant reference docs in `@../../docs/references/*.md` before implementing or editing related functionality.
+- Treat reference docs as required context, not optional reading.
+- If a task touches multiple areas (for example: GSQL + chart components), read all applicable reference files first.
+- If unsure which reference applies, start with `@../../docs/references/gsql.md`, then load additional references based on the components/functions used.
+- You will be docked for writing code here without completing the required documentation reading.
+
+## Reference docs
+- Core overview: `@../../docs/base.md`
+- CLI usage: `@../../docs/cli.md`
+- Best practices: `@../../docs/best-practices.md`
+- Detailed feature/component references: `@../../docs/references/*.md`
 
 # About this data
 This is a Graphene project covering restaurant and food service market data across North America, Europe, and Oceania. You can find the Graphene tables in @./tables.

--- a/examples/snowflake/AGENTS.md
+++ b/examples/snowflake/AGENTS.md
@@ -1,5 +1,5 @@
 # RULES
-- Graphene contains languages and tools you may not already know.
+- Graphene contains languages and tools that you do not already know.
 - Before writing code in this directory, you MUST read `@../../docs/base.md` **in its entirety**.
 - You MUST also read relevant reference docs in `@../../docs/references/*.md` before implementing or editing related functionality.
 - Treat reference docs as required context, not optional reading.


### PR DESCRIPTION
I noticed that the examples' AGENTS.md files were pointing to non-existent docs after the refactor in #121. I'm not sure how relevant these are but I asked Codex how it would suggest referencing the refactored docs and this is what it came up with.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/127?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->