### PR TITLE
Fix parenthetical expressions being stripped during SQL compilation

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -422,8 +422,10 @@ export function analyzeExpr (node: SyntaxNode, scope: Scope): Expr {
     case 'FunctionCall':
       return analyzeFunction(node, scope, analyzeExpr)
 
-    case 'Parenthetical':
-      return analyzeExpr(node.getChild('Expression')!, scope)
+    case 'Parenthetical': {
+      let inner = analyzeExpr(node.getChild('Expression')!, scope)
+      return {sql: `(${inner.sql})`, type: inner.type, isAgg: inner.isAgg}
+    }
 
     case 'Count': {
       let inner = node.getChild('Expression')

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -250,6 +250,27 @@ describe('lang', () => {
       .toReturnRows([2, 40], [1, 30])
   })
 
+  it('preserves parentheses in expressions for correct operator precedence', async () => {
+    expect('from users select (age + age) / (age + age) as result')
+      .toRenderSql('select (users."age"+users."age")/(users."age"+users."age") as "result" from users as users')
+    await expect('from users select (1 + 2) / (1 + 2) as result limit 1')
+      .toReturnRows([1])
+  })
+
+  it('preserves parentheses in measure composition', () => {
+    updateFile(`table orders (
+      id int, user_id int, amount int, status text
+      join one users on users.id = user_id
+      join many order_items on order_items.order_id = id
+      total_revenue: sum(amount)
+      avg_order_value: sum(amount) / count()
+      completed: status = 'completed'
+      rate: (total_revenue + avg_order_value) / (total_revenue + avg_order_value)
+    )`, 'models.gsql')
+    expect('from orders select rate')
+      .toRenderSql('select (((sum(orders."amount"))+(sum(orders."amount")/count(1)))/((sum(orders."amount"))+(sum(orders."amount")/count(1)))) as "rate" from orders as orders')
+  })
+
   it('supports percentile aggregates via pXX shorthand', async () => {
     await expect('from orders select p10(amount) as min_amt, p50(amount) as median_amt, p999(amount) as max_amt')
       .toReturnRows([24, 40, 40])


### PR DESCRIPTION
## Summary

- The `Parenthetical` AST handler in `analyzeExpr` was discarding parentheses — it analyzed the inner expression but never re-wrapped the SQL output in parens
- This caused incorrect operator precedence in generated SQL: `(a + b) / (c + d)` compiled to `a+b/c+d`, which evaluates as `a + (b/c) + d`
- Affects all dialects (duckdb, snowflake, bigquery) since the bug is in dialect-independent code

**Note:** Measure references are already auto-wrapped when expanded (line 419), so users don't need explicit parens when composing measures like `rate: numerator / denominator`. This fix addresses the case where explicit parens appear in expressions — inline queries, measure definitions with mixed-precedence operators, etc.

Closes #128

## Test plan

- [x] Added test for inline expression parentheses (`(age + age) / (age + age)`)
- [x] Added test for measure composition with parentheses
- [x] Verified `(1 + 2) / (1 + 2)` returns `1` (was returning `5`)
- [x] Full lang test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/129?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->