### PR TITLE
Support other Snowflake timestamp types

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -42,6 +42,7 @@ Dimensions and measures are like macros that expand inline when GSQL compiles to
 ### Unsupported
 - Window functions
 - Set operations (`union`, etc.)
+- Semi-structured data types (`VARIANT`, `OBJECT`, `ARRAY`)
 
 # Dashboards
 Graphene dashboards extend Markdown with the following:

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -818,7 +818,7 @@ function convertDataType (dataType: string): FieldType | null {
       return 'boolean'
     case 'DATE':
       return 'date'
-    case 'DATETIME': case 'TIME': case 'TIMESTAMP': case 'TIMESTAMP_NTZ':
+    case 'DATETIME': case 'TIME': case 'TIMESTAMP': case 'TIMESTAMP_NTZ': case 'TIMESTAMP_TZ': case 'TIMESTAMP_LTZ':
       return 'timestamp'
     default:
       return null


### PR DESCRIPTION
## Summary
- Map `TIMESTAMP_TZ` and `TIMESTAMP_LTZ` to `timestamp` in `convertDataType()` (alongside existing `TIMESTAMP_NTZ`)
- ~~Map `OBJECT` to `string` (alongside existing `VARIANT` → `string`)~~
- ~~Map `ARRAY` to `array` so array-typed columns are recognized~~
- ~~Handle `json`, `array`, and `record` in the UI's `evidenceType()` bridge to avoid console warnings~~
- ~~Note in `docs/base.md` that semi-structured accessors (`obj:key`, `arr[0]`) are not yet supported~~

## Test plan
- [x] All 131 lang tests pass
- [x] Verify Snowflake columns with these types show up correctly in dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/132?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->