### PR TITLE
Better case handling for snowflake

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -145,7 +145,7 @@ function expandColumns (table: Table | null, alias: string, query: Query, scope:
       let expr = analyzeExpr(col.exprNode, {query: scope.query, table, alias, otherTables: scope.otherTables})
       query.fields.push({name: outName, sql: expr.sql, type: expr.type, metadata: col.metadata})
     } else {
-      query.fields.push({name: outName, sql: `${alias}.${quote(col.name)}`, type: col.type, metadata: col.metadata})
+      query.fields.push({name: outName, sql: `${alias}.${quoteColumn(col.name)}`, type: col.type, metadata: col.metadata})
     }
   }
 }
@@ -409,7 +409,7 @@ export function analyzeExpr (node: SyntaxNode, scope: Scope): Expr {
       NODE_ENTITY_MAP.set(fieldNode, {entityType: 'field', field: col, table})
 
       // Simple case: this is just a regular column on a table
-      if (!col.exprNode) return {sql: `${alias}.${quote(col.name)}`, type: col.type}
+      if (!col.exprNode) return {sql: `${alias}.${quoteColumn(col.name)}`, type: col.type}
 
       // Computed column: analyze its expression in the matched table's scope
       if (analysisStack.has(col)) return diag(col.exprNode, 'Cycles are not allowed between computed columns', {sql: 'NULL', type: 'error'})
@@ -672,7 +672,7 @@ function followJoins (pathNodes: SyntaxNode[], scope: Scope): Scope | null {
 
   // If we're analyzing an ON clause, any path nodes must point at the source or target table
   if (scope.joinTarget) {
-    let pointsAtSource = !!scope.table && (name == scope.alias)
+    let pointsAtSource = !!scope.table && name == scope.alias
     let pointsAtTarget = name == scope.joinTarget.alias || name == scope.joinTarget.name
     if (!pointsAtSource && !pointsAtTarget) return diag(pathNodes[0], 'Joins must point at either the source or target table', null)
 
@@ -823,5 +823,11 @@ function convertDataType (dataType: string): FieldType | null {
 // Quote an identifier for the current dialect
 function quote (name: string): string {
   if (config.dialect === 'bigquery') return `\`${name}\``
+  return `"${name}"`
+}
+
+function quoteColumn (name: string): string {
+  if (config.dialect === 'bigquery') return `\`${name}\``
+  if (config.dialect === 'snowflake') return `"${name.toUpperCase()}"`
   return `"${name}"`
 }

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -69,13 +69,8 @@ export function analyze (contents?: string, contentType?: 'gsql' | 'md'): Query[
 
 export function toSql (query: Query, params: Record<string, any> = {}): string {
   query = structuredClone(query)
-  if (config.dialect == 'snowflake') uppercaseQuery(query)
   fillInParams(query, params)
   return query.sql
-}
-
-function uppercaseQuery (query: Query) {
-  query.sql = query.sql.replace(/"([^"]+)"/g, (_, name) => `"${name.toUpperCase()}"`)
 }
 
 export function getHover (path: string, line: number, col: number): string {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -101,12 +101,8 @@ describe('lang', () => {
 
   it('uppercases identifiers for snowflake queries', () => {
     setConfig({dialect: 'snowflake', root: ''})
-    // Column references should be uppercase (to match Snowflake's case-insensitive identifiers),
-    // but aliases are lowercase (quoted) so result sets have the expected original casing.
-    // Note: uppercasing happens in core.ts via uppercaseTable() for table names, but column
-    // names in expressions still use original case. Using case-insensitive comparison for now.
     expect('from users select id, orders.amount as amt order by amt desc')
-      .toRenderSql('SELECT USERS."id" as "id", orders."amount" as "amt" from USERS as USERS LEFT JOIN ORDERS as orders ON orders."user_id"=USERS."id" ORDER BY 2 desc NULLS LAST')
+      .toRenderSql('SELECT users."ID" as "id", orders."AMOUNT" as "amt" FROM USERS as users LEFT JOIN ORDERS as orders ON orders."USER_ID"=users."ID" ORDER BY 2 desc NULLS LAST')
   })
 
   it('applies defaultNamespace to unqualified table paths', () => {


### PR DESCRIPTION
This converts table/column refs into uppercase when generating sql, but leaves them alone during the rest of analysis.

This won't let you mix casing in gsql, but I think that's ok. This also doesn't really handle cases where the table is lower or mixed case in the db, but iirc we decided that was rare and to punt on it.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/133?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->