### PR TITLE
refactor `check` and `run` commands

### DIFF
--- a/cli/check.ts
+++ b/cli/check.ts
@@ -16,7 +16,13 @@ import {pollFor} from '../lang/util.ts'
 import {FILE_MAP} from '../lang/analyze.ts'
 
 interface CheckOptions {
+  fileArg?: string
   mdArg?: string
+  log?: (...args: any[]) => void
+}
+
+interface RunMdFileOptions {
+  mdArg: string
   chart?: string
   log?: (...args: any[]) => void
 }
@@ -26,21 +32,21 @@ let pendingRequests: Record<string, {response: ServerResponse<IncomingMessage>}>
 
 export async function check (options: CheckOptions): Promise<boolean> {
   let log = options.log || console.log
-  let mdFile = options.mdArg && normalizeMdFile(options.mdArg)
+  let fileArg = options.fileArg || options.mdArg
+  let targetFile = fileArg && normalizeGrapheneFile(fileArg)
 
-  if (options.mdArg && !mdFile) {
-    log(`Couldn't find ${options.mdArg}`)
+  if (fileArg && !targetFile) {
+    log(`Couldn't find ${fileArg}`)
     return false
   }
 
-  // if there's no file arg, check all md files. If there is a file arg, just load that file.
-  await loadWorkspace(config.root, !mdFile)
-  if (mdFile) {
-    if (process.env.NODE_ENV == 'test' && mockFileMap[mdFile]) {
-      updateFile(mockFileMap[mdFile], mdFile)
+  await loadWorkspace(config.root, !targetFile)
+  if (targetFile) {
+    if (process.env.NODE_ENV == 'test' && mockFileMap[targetFile]) {
+      updateFile(mockFileMap[targetFile], targetFile)
     } else {
-      let content = readFileSync(path.resolve(config.root, mdFile), 'utf-8')
-      updateFile(content, mdFile)
+      let content = readFileSync(path.resolve(config.root, targetFile), 'utf-8')
+      updateFile(content, targetFile)
     }
   }
 
@@ -50,19 +56,35 @@ export async function check (options: CheckOptions): Promise<boolean> {
     return false
   }
 
+  log('No errors found 💎')
+  return true
+}
+
+export async function runMdFile (options: RunMdFileOptions): Promise<boolean> {
+  let log = options.log || console.log
+  let mdFile = normalizeMdFile(options.mdArg)
   if (!mdFile) {
-    log('No errors found 💎')
-    return true
+    log(`Couldn't find ${options.mdArg}`)
+    return false
   }
 
-  // in tests, both `check` and the vite server are in the same process, so end up sharing the workspace.
-  // Because of that, we need to clear out the md file we loaded into the workspace (which the usually server never loads).
-  // Otherwise, you'll get `some_table already defined` errors.
-  if (process.env.NODE_ENV == 'test' && mdFile) {
-    delete FILE_MAP[mdFile]
+  await loadWorkspace(config.root, false)
+  if (process.env.NODE_ENV == 'test' && mockFileMap[mdFile]) {
+    updateFile(mockFileMap[mdFile], mdFile)
+  } else {
+    let content = readFileSync(path.resolve(config.root, mdFile), 'utf-8')
+    updateFile(content, mdFile)
   }
 
-  // Remove .md extension if provided and ensure it's just the filename
+  analyze()
+  if (getDiagnostics().length > 0) {
+    printDiagnostics(getDiagnostics(), log)
+    return false
+  }
+
+  // in tests, both the vite server and this method can share workspace state.
+  if (process.env.NODE_ENV == 'test') delete FILE_MAP[mdFile]
+
   let host = `http://localhost:${config.port}`
   let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')
   if (pageUrl === '/index') pageUrl = '/'
@@ -162,6 +184,24 @@ async function sendCheckRequest ({host, pageUrl, chart}) {
     if (err.name === 'AbortError') return {checkError: 'timeout'}
     return {checkError: 'no_server'}
   }
+}
+
+function normalizeGrapheneFile (file: string): string | null {
+  let clean = file.trim()
+  if (!clean) return null
+
+  let hasExt = /\.[^.\\/]+$/.test(clean)
+  let candidates = hasExt ? [clean] : [clean + '.md', clean + '.gsql']
+  for (let candidate of candidates) {
+    if (!candidate.endsWith('.md') && !candidate.endsWith('.gsql')) continue
+    if (process.env.NODE_ENV == 'test' && mockFileMap[candidate]) return candidate
+    let absolute = [
+      path.resolve(process.cwd(), candidate),
+      path.resolve(config.root, candidate),
+    ].find(p => fs.existsSync(p))
+    if (absolute) return path.relative(config.root, absolute)
+  }
+  return null
 }
 
 function normalizeMdFile (mdFile: string): string | null {

--- a/cli/check.ts
+++ b/cli/check.ts
@@ -1,34 +1,15 @@
 import fs from 'fs-extra'
-import os from 'os'
 import path from 'path'
-import {type IncomingMessage, type ServerResponse} from 'http'
-import {WebSocketServer, type WebSocket} from 'ws'
-import {type PluginOption, type ViteDevServer} from 'vite'
-
-import {analyze, config, type Diagnostic, getDiagnostics, loadWorkspace, updateFile} from '../lang/core.ts'
+import {analyze, config, getDiagnostics, loadWorkspace, updateFile} from '../lang/core.ts'
 import {printDiagnostics} from './printer.ts'
 import {readFileSync} from 'node:fs'
 import {mockFileMap} from './mockFiles.ts'
-import {isServerRunning, runServeInBackground} from './background.ts'
-import {openInBrowser} from './auth.ts'
-import {styleText} from 'node:util'
-import {pollFor} from '../lang/util.ts'
-import {FILE_MAP} from '../lang/analyze.ts'
 
 interface CheckOptions {
   fileArg?: string
   mdArg?: string
   log?: (...args: any[]) => void
 }
-
-interface RunMdFileOptions {
-  mdArg: string
-  chart?: string
-  log?: (...args: any[]) => void
-}
-
-let browserConnections: {url: string, socket: WebSocket}[] = []
-let pendingRequests: Record<string, {response: ServerResponse<IncomingMessage>}> = {}
 
 export async function check (options: CheckOptions): Promise<boolean> {
   let log = options.log || console.log
@@ -60,132 +41,6 @@ export async function check (options: CheckOptions): Promise<boolean> {
   return true
 }
 
-export async function runMdFile (options: RunMdFileOptions): Promise<boolean> {
-  let log = options.log || console.log
-  let mdFile = normalizeMdFile(options.mdArg)
-  if (!mdFile) {
-    log(`Couldn't find ${options.mdArg}`)
-    return false
-  }
-
-  await loadWorkspace(config.root, false)
-  if (process.env.NODE_ENV == 'test' && mockFileMap[mdFile]) {
-    updateFile(mockFileMap[mdFile], mdFile)
-  } else {
-    let content = readFileSync(path.resolve(config.root, mdFile), 'utf-8')
-    updateFile(content, mdFile)
-  }
-
-  analyze()
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics(), log)
-    return false
-  }
-
-  // in tests, both the vite server and this method can share workspace state.
-  if (process.env.NODE_ENV == 'test') delete FILE_MAP[mdFile]
-
-  let host = `http://localhost:${config.port}`
-  let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')
-  if (pageUrl === '/index') pageUrl = '/'
-
-  if (process.env.NODE_ENV !== 'test' && !(await isServerRunning())) {
-    log('Starting Graphene server...')
-    await runServeInBackground()
-  }
-
-  let resp = await sendCheckRequest({host, pageUrl, chart: options.chart})
-
-  if (resp.checkError == 'no_server') {
-    log('Failed to start Graphene server')
-    return false
-  }
-
-  if (resp.checkError == 'no_tab' && process.env.NODE_ENV !== 'test') {
-    log(`Opening page ${host}${pageUrl}`)
-    openInBrowser(host + pageUrl)
-    await new Promise(resolve => setTimeout(resolve, 500))
-    resp = await sendCheckRequest({host, pageUrl, chart: options.chart})
-  }
-
-  if (resp.checkError == 'no_tab') {
-    log('Failed to open a new tab')
-    return false
-  }
-
-  if (resp.checkError) {
-    log('Failed to run check: ' + resp.checkError)
-    return false
-  }
-
-  let errors = Array.from(resp.errors || [])
-  if (errors.length) {
-    log(styleText('red', 'Runtime errors') + ` in ${mdFile}:`)
-  } else {
-    log('No errors found 💎')
-  }
-
-  errors.forEach((e: any) => {
-    if (e.type === 'compile') {
-      let file = e.file && path.isAbsolute(e.file) ? path.relative(config.root, e.file) : e.file
-      let msg = e.message.replace(/^.*?:\d+:\d+\s*/, '').replace(/\s*https:\/\/svelte\.dev\/\S+/g, '')
-      log(`${styleText('red', 'ERROR')}: ${file} line ${e.line}: ${msg}`)
-      for (let frameLine of e.frame.split('\n')) log('  ' + frameLine)
-    } else if (e.file && e.from) {
-      printDiagnostics([e as Diagnostic], log)
-    } else if (e.queryId) {
-      log(`${e.queryId}: ${e.message}`)
-    } else {
-      log(e.message)
-    }
-  })
-
-  if (resp?.stillLoading) {
-    log('Warning: Queries were still loading when the screenshot was taken')
-  }
-
-  if (resp?.screenshot) {
-    let filename = `graphene-screenshot-${new Date().toISOString().replace(/[:.]/g, '-')}.png`
-    let screenshotPath = path.join(os.tmpdir(), filename)
-    let base64Data = resp.screenshot.replace(/^data:image\/png;base64,/, '')
-    await fs.writeFile(screenshotPath, base64Data, 'base64')
-    log('Screenshot saved to', screenshotPath)
-  }
-
-  return errors.length == 0
-}
-
-async function sendCheckRequest ({host, pageUrl, chart}) {
-  let abort = new AbortController()
-  let timeout = setTimeout(() => abort.abort(), 30_000)
-  // The browser registers with 'localhost' but we need to fetch via 127.0.0.1 (for IPv6 environments)
-  // So we use 127.0.0.1 for the fetch but send localhost in the pageUrl for WebSocket matching
-  let browserHost = host.replace('127.0.0.1', 'localhost')
-  try {
-    let response = await fetch(`${host}/_api/check`, {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({pageUrl: browserHost + pageUrl, chart}),
-      signal: abort.signal,
-    })
-    clearTimeout(timeout)
-
-    let body = response.headers.get('content-type') == 'application/json' ? await response.json() : {error: await response.text()}
-
-    if (!response.ok) {
-      if (body.error) return {checkError: body.error}
-      console.error(`Unexpected response: ${JSON.stringify(body)}`)
-      return {checkError: 'Unexpected response from Graphene server'}
-    }
-
-    return body
-  } catch (err: any) {
-    clearTimeout(timeout)
-    if (err.name === 'AbortError') return {checkError: 'timeout'}
-    return {checkError: 'no_server'}
-  }
-}
-
 function normalizeGrapheneFile (file: string): string | null {
   let clean = file.trim()
   if (!clean) return null
@@ -202,86 +57,4 @@ function normalizeGrapheneFile (file: string): string | null {
     if (absolute) return path.relative(config.root, absolute)
   }
   return null
-}
-
-function normalizeMdFile (mdFile: string): string | null {
-  let clean = mdFile.trim()
-  if (!clean) return null
-  if (!clean.endsWith('.md')) clean = clean + '.md'
-
-  if (process.env.NODE_ENV == 'test' && mockFileMap[clean]) {
-    return clean
-  }
-
-  let absolute = [
-    path.resolve(process.cwd(), clean),
-    path.resolve(config.root, clean),
-  ].find(p => fs.existsSync(p)) || null
-
-  if (!absolute) return null
-  let relative = path.relative(config.root, absolute)
-  return relative
-}
-
-// A request has come in to the server to check a specific url. We'll load it up, forward along the request, and proxy the response.
-export async function proxyCheckRequest (req: IncomingMessage, res: ServerResponse<IncomingMessage>): Promise<void> {
-  let chunks = [] as any[]
-  for await (let chunk of req) chunks.push(chunk)
-  let {pageUrl, chart} = JSON.parse(Buffer.concat(chunks).toString())
-  let id = Math.random().toString(36).slice(2) // random id string
-  res.setHeader('Content-Type', 'application/json')
-
-  // Check for existing WebSocket connections for the given url
-  let normalizedPageUrl = pageUrl.replace(/\/$/, '')
-  let conn = await pollFor(() => browserConnections.find(conn => conn.url === normalizedPageUrl), 5000, 100)
-  if (!conn) {
-    res.statusCode = 400
-    res.end(JSON.stringify({error: 'no_tab'}))
-    return
-  } else {
-    conn.socket.send(JSON.stringify({type: 'check', chart, requestId: id}))
-    pendingRequests[id] = {response: res}
-  }
-}
-
-// Vite plugin that allows running Graphene pages to connect, and can proxy `check` requests to those pages.
-export function checkVitePlugin (): PluginOption {
-  return {
-    name: 'graphene-check-plugin',
-    configureServer (server: ViteDevServer) {
-      let wss = new WebSocketServer({noServer: true})
-
-      server.httpServer?.on('upgrade', (req, socket, head) => {
-        if (!req.url || (!req.url.includes('/_api/ws') && !req.url.includes('graphene-ws'))) return
-        wss.handleUpgrade(req, socket, head, (ws) => {
-          wss.emit('connection', ws, req)
-        })
-      })
-
-      wss.on('connection', (socket) => {
-        socket.on('message', (data) => {
-          let message = JSON.parse(data.toString())
-          if (message.type === 'register') {
-            let normalizedUrl = message.url.replace(/\/$/, '')
-            browserConnections.push({url: normalizedUrl, socket})
-          }
-          if (message.type === 'checkResponse') {
-            pendingRequests[message.requestId].response.end(JSON.stringify(message))
-            delete pendingRequests[message.requestId]
-          }
-        })
-        socket.on('close', () => {
-          browserConnections = browserConnections.filter(conn => conn.socket !== socket)
-        })
-      })
-
-      server.httpServer?.on('close', () => wss.close())
-
-      server.middlewares.use(async (req, res, next) => {
-        let [pathName] = (req.url || '').split('?')
-        if (pathName === '/_api/check') await proxyCheckRequest(req, res)
-        else next()
-      })
-    },
-  }
 }

--- a/cli/check.ts
+++ b/cli/check.ts
@@ -1,9 +1,9 @@
-import fs from 'fs-extra'
 import path from 'path'
 import {analyze, config, getDiagnostics, loadWorkspace, updateFile} from '../lang/core.ts'
 import {printDiagnostics} from './printer.ts'
 import {readFileSync} from 'node:fs'
 import {mockFileMap} from './mockFiles.ts'
+import {normalizeFile} from './normalizeFile.ts'
 
 interface CheckOptions {
   fileArg?: string
@@ -12,7 +12,7 @@ interface CheckOptions {
 
 export async function check (options: CheckOptions): Promise<boolean> {
   let log = options.log || console.log
-  let targetFile = options.fileArg && normalizeGrapheneFile(options.fileArg)
+  let targetFile = options.fileArg && normalizeFile(options.fileArg)
 
   if (options.fileArg && !targetFile) {
     log(`Couldn't find ${options.fileArg}`)
@@ -37,22 +37,4 @@ export async function check (options: CheckOptions): Promise<boolean> {
 
   log('No errors found 💎')
   return true
-}
-
-function normalizeGrapheneFile (file: string): string | null {
-  let clean = file.trim()
-  if (!clean) return null
-
-  let hasExt = /\.[^.\\/]+$/.test(clean)
-  let candidates = hasExt ? [clean] : [clean + '.md', clean + '.gsql']
-  for (let candidate of candidates) {
-    if (!candidate.endsWith('.md') && !candidate.endsWith('.gsql')) continue
-    if (process.env.NODE_ENV == 'test' && mockFileMap[candidate]) return candidate
-    let absolute = [
-      path.resolve(process.cwd(), candidate),
-      path.resolve(config.root, candidate),
-    ].find(p => fs.existsSync(p))
-    if (absolute) return path.relative(config.root, absolute)
-  }
-  return null
 }

--- a/cli/check.ts
+++ b/cli/check.ts
@@ -7,17 +7,15 @@ import {mockFileMap} from './mockFiles.ts'
 
 interface CheckOptions {
   fileArg?: string
-  mdArg?: string
   log?: (...args: any[]) => void
 }
 
 export async function check (options: CheckOptions): Promise<boolean> {
   let log = options.log || console.log
-  let fileArg = options.fileArg || options.mdArg
-  let targetFile = fileArg && normalizeGrapheneFile(fileArg)
+  let targetFile = options.fileArg && normalizeGrapheneFile(options.fileArg)
 
-  if (fileArg && !targetFile) {
-    log(`Couldn't find ${fileArg}`)
+  if (options.fileArg && !targetFile) {
+    log(`Couldn't find ${options.fileArg}`)
     return false
   }
 

--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -101,5 +101,24 @@ describe('cli run', () => {
     expect(res.code).toBe(1)
     expect(res.stderr.toLowerCase()).toContain('no .duckdb file found')
   })
+
+  it('runs a named query from a markdown file', async () => {
+    let res = await runCli(['run', 'index.md', '--query', 'weekly_trends'], flightDir)
+    expectCliSuccess(res, 'run markdown query')
+    expect(res.stdout.toLowerCase()).toContain('week')
+  })
+
+  it('rejects passing a gsql file path', async () => {
+    let res = await runCli(['run', 'tables/flights.gsql'], flightDir)
+    expect(res.code).toBe(1)
+    expect((res.stdout + res.stderr).toLowerCase()).toContain('running .gsql files is no longer supported')
+  })
 })
 
+describe('cli check', () => {
+  it('checks a single gsql file', async () => {
+    let res = await runCli(['check', 'tables/flights.gsql'], flightDir)
+    expectCliSuccess(res, 'check gsql file')
+    expect(res.stdout).toContain('No errors found')
+  })
+})

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2,14 +2,14 @@
 
 import {Command} from 'commander'
 import {printDiagnostics, printTable} from './printer.ts'
-import {analyze, getDiagnostics, loadWorkspace, toSql, type Query} from '../lang/core.ts'
+import {analyze, getDiagnostics, loadWorkspace, toSql, type Query, updateFile} from '../lang/core.ts'
 import fs from 'fs-extra'
 import path from 'path'
 import {fileURLToPath} from 'url'
 import dotenv from 'dotenv'
 import {config, loadConfig} from '../lang/config.ts'
 import {runServeInBackground, stopGrapheneIfRunning} from './background.ts'
-import {check} from './check.ts'
+import {check, runMdFile} from './check.ts'
 import {getConnection, runQuery} from './connections/index.ts'
 import {loginPkce} from './auth.ts'
 
@@ -38,9 +38,34 @@ program.command('compile')
   })
 
 program.command('run')
-  .description('Run a query against your database')
+  .description('Run a query or screenshot a Graphene page')
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
-  .action(async (input: string | undefined) => {
+  .option('-c, --chart <chartTitle>', 'Title of a specific chart to capture')
+  .option('-q, --query <queryName>', 'Query or table name to run from a markdown page')
+  .action(async (input: string | undefined, options: {chart?: string, query?: string}) => {
+    if (options.chart && options.query) {
+      console.error('Cannot use --chart and --query together')
+      process.exit(1)
+    }
+
+    let inputPath = getExistingPath(input)
+    if (inputPath && inputPath.endsWith('.md')) {
+      let res = options.query
+        ? await runNamedQueryFromMd(inputPath, options.query)
+        : await runMdFile({ mdArg: inputPath, chart: options.chart })
+      process.exit(res ? 0 : 1)
+    }
+
+    if (options.chart || options.query) {
+      console.error('--chart and --query can only be used with a markdown file path')
+      process.exit(1)
+    }
+
+    if (inputPath && inputPath.endsWith('.gsql')) {
+      console.error('Running .gsql files is no longer supported. Pass inline GSQL or use a markdown file path with --query.')
+      process.exit(1)
+    }
+
     await loadWorkspace(process.cwd(), false)
     let gsql = await readInput(input)
     let queries = analyze(gsql)
@@ -109,11 +134,10 @@ program.command('stop')
   .action(async () => { await stopGrapheneIfRunning() })
 
 program.command('check')
-  .description('Check the project for errors, optionally capturing a page screenshot')
-  .argument('[mdFile]', 'Markdown file to check (e.g., index.md)')
-  .option('-c, --chart <chartTitle>', 'Title of a specific chart to capture')
-  .action(async (mdArg: string | undefined, options: {chart?: string}) => {
-    let res = await check({mdArg, chart: options.chart})
+  .description('Check the project for diagnostics')
+  .argument('[file]', 'Optional markdown or gsql file to check')
+  .action(async (fileArg: string | undefined) => {
+    let res = await check({fileArg})
     process.exit(res ? 0 : 1) // import to call `exit`, bc if we started the server in the background, just returning won't actually exit the process.
   })
 
@@ -144,6 +168,43 @@ async function readInput (arg): Promise<string> {
   }
 
   return arg
+}
+
+function getExistingPath (arg: string | undefined): string | null {
+  if (!arg || arg === '-') return null
+  let absolutePath = path.resolve(arg)
+  return fs.existsSync(absolutePath) ? absolutePath : null
+}
+
+async function runNamedQueryFromMd (mdAbsolutePath: string, queryName: string): Promise<boolean> {
+  await loadWorkspace(process.cwd(), false)
+  let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
+  let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
+
+  updateFile(mdContents, mdRelativePath)
+  analyze()
+  if (getDiagnostics().length > 0) {
+    printDiagnostics(getDiagnostics())
+    return false
+  }
+
+  let runQueryFence = [
+    mdContents,
+    '',
+    '```sql',
+    `from ${queryName} select *`,
+    '```',
+  ].join('\n')
+  let queries = analyze(runQueryFence, 'md')
+  if (getDiagnostics().length > 0) {
+    printDiagnostics(getDiagnostics())
+    return false
+  }
+
+  let sql = toSql(queries[queries.length - 1])
+  let res = await runQuery(sql)
+  printTable(res.rows)
+  return true
 }
 
 function validQuery (queries: Query[]): boolean {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2,14 +2,15 @@
 
 import {Command} from 'commander'
 import {printDiagnostics, printTable} from './printer.ts'
-import {analyze, getDiagnostics, loadWorkspace, toSql, type Query, updateFile} from '../lang/core.ts'
+import {analyze, getDiagnostics, loadWorkspace, toSql, type Query} from '../lang/core.ts'
 import fs from 'fs-extra'
 import path from 'path'
 import {fileURLToPath} from 'url'
 import dotenv from 'dotenv'
 import {config, loadConfig} from '../lang/config.ts'
 import {runServeInBackground, stopGrapheneIfRunning} from './background.ts'
-import {check, runMdFile} from './check.ts'
+import {check} from './check.ts'
+import {runMdFile, runNamedQueryFromMd} from './run.ts'
 import {getConnection, runQuery} from './connections/index.ts'
 import {loginPkce} from './auth.ts'
 
@@ -174,37 +175,6 @@ function getExistingPath (arg: string | undefined): string | null {
   if (!arg || arg === '-') return null
   let absolutePath = path.resolve(arg)
   return fs.existsSync(absolutePath) ? absolutePath : null
-}
-
-async function runNamedQueryFromMd (mdAbsolutePath: string, queryName: string): Promise<boolean> {
-  await loadWorkspace(process.cwd(), false)
-  let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
-  let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
-
-  updateFile(mdContents, mdRelativePath)
-  analyze()
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics())
-    return false
-  }
-
-  let runQueryFence = [
-    mdContents,
-    '',
-    '```sql',
-    `from ${queryName} select *`,
-    '```',
-  ].join('\n')
-  let queries = analyze(runQueryFence, 'md')
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics())
-    return false
-  }
-
-  let sql = toSql(queries[queries.length - 1])
-  let res = await runQuery(sql)
-  printTable(res.rows)
-  return true
 }
 
 function validQuery (queries: Query[]): boolean {

--- a/cli/normalizeFile.ts
+++ b/cli/normalizeFile.ts
@@ -1,0 +1,19 @@
+import fs from 'fs-extra'
+import path from 'path'
+import {config} from '../lang/core.ts'
+import {mockFileMap} from './mockFiles.ts'
+
+export function normalizeFile (file: string): string | null {
+  let clean = file.trim()
+  if (!clean) return null
+
+  if (process.env.NODE_ENV == 'test' && mockFileMap[clean]) return clean
+
+  let absolute = [
+    path.resolve(process.cwd(), clean),
+    path.resolve(config.root, clean),
+  ].find(p => fs.existsSync(p)) || null
+
+  if (!absolute) return null
+  return path.relative(config.root, absolute)
+}

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -15,6 +15,7 @@ import {styleText} from 'node:util'
 import {pollFor} from '../lang/util.ts'
 import {FILE_MAP} from '../lang/analyze.ts'
 import {runQuery} from './connections/index.ts'
+import {normalizeFile} from './normalizeFile.ts'
 
 export interface RunMdFileOptions {
   mdArg: string
@@ -27,7 +28,7 @@ let pendingRequests: Record<string, {response: ServerResponse<IncomingMessage>}>
 
 export async function runMdFile (options: RunMdFileOptions): Promise<boolean> {
   let log = options.log || console.log
-  let mdFile = normalizeMdFile(options.mdArg)
+  let mdFile = normalizeFile(options.mdArg)
   if (!mdFile) {
     log(`Couldn't find ${options.mdArg}`)
     return false
@@ -177,22 +178,6 @@ async function sendCheckRequest ({host, pageUrl, chart}) {
     if (err.name === 'AbortError') return {checkError: 'timeout'}
     return {checkError: 'no_server'}
   }
-}
-
-function normalizeMdFile (mdFile: string): string | null {
-  let clean = mdFile.trim()
-  if (!clean) return null
-  if (!clean.endsWith('.md')) clean = clean + '.md'
-
-  if (process.env.NODE_ENV == 'test' && mockFileMap[clean]) return clean
-
-  let absolute = [
-    path.resolve(process.cwd(), clean),
-    path.resolve(config.root, clean),
-  ].find(p => fs.existsSync(p)) || null
-
-  if (!absolute) return null
-  return path.relative(config.root, absolute)
 }
 
 export async function proxyCheckRequest (req: IncomingMessage, res: ServerResponse<IncomingMessage>): Promise<void> {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -59,7 +59,7 @@ export async function runMdFile (options: RunMdFileOptions): Promise<boolean> {
     await runServeInBackground()
   }
 
-  let resp = await sendCheckRequest({host, pageUrl, chart: options.chart})
+  let resp = await sendRunRequest({host, pageUrl, chart: options.chart})
 
   if (resp.checkError == 'no_server') {
     log('Failed to start Graphene server')
@@ -70,7 +70,7 @@ export async function runMdFile (options: RunMdFileOptions): Promise<boolean> {
     log(`Opening page ${host}${pageUrl}`)
     openInBrowser(host + pageUrl)
     await new Promise(resolve => setTimeout(resolve, 500))
-    resp = await sendCheckRequest({host, pageUrl, chart: options.chart})
+    resp = await sendRunRequest({host, pageUrl, chart: options.chart})
   }
 
   if (resp.checkError == 'no_tab') {
@@ -151,7 +151,7 @@ export async function runNamedQueryFromMd (mdAbsolutePath: string, queryName: st
   return true
 }
 
-async function sendCheckRequest ({host, pageUrl, chart}) {
+async function sendRunRequest ({host, pageUrl, chart}) {
   let abort = new AbortController()
   let timeout = setTimeout(() => abort.abort(), 30_000)
   let browserHost = host.replace('127.0.0.1', 'localhost')
@@ -180,7 +180,7 @@ async function sendCheckRequest ({host, pageUrl, chart}) {
   }
 }
 
-export async function proxyCheckRequest (req: IncomingMessage, res: ServerResponse<IncomingMessage>): Promise<void> {
+export async function proxyRunRequest (req: IncomingMessage, res: ServerResponse<IncomingMessage>): Promise<void> {
   let chunks = [] as any[]
   for await (let chunk of req) chunks.push(chunk)
   let {pageUrl, chart} = JSON.parse(Buffer.concat(chunks).toString())
@@ -199,7 +199,7 @@ export async function proxyCheckRequest (req: IncomingMessage, res: ServerRespon
   pendingRequests[id] = {response: res}
 }
 
-export function checkVitePlugin (): PluginOption {
+export function runVitePlugin (): PluginOption {
   return {
     name: 'graphene-check-plugin',
     configureServer (server: ViteDevServer) {
@@ -231,7 +231,7 @@ export function checkVitePlugin (): PluginOption {
 
       server.middlewares.use(async (req, res, next) => {
         let [pathName] = (req.url || '').split('?')
-        if (pathName === '/_api/check') await proxyCheckRequest(req, res)
+        if (pathName === '/_api/check') await proxyRunRequest(req, res)
         else next()
       })
     },

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -1,0 +1,254 @@
+import fs from 'fs-extra'
+import os from 'os'
+import path from 'path'
+import {type IncomingMessage, type ServerResponse} from 'http'
+import {WebSocketServer, type WebSocket} from 'ws'
+import {type PluginOption, type ViteDevServer} from 'vite'
+
+import {analyze, config, type Diagnostic, getDiagnostics, loadWorkspace, toSql, updateFile} from '../lang/core.ts'
+import {printDiagnostics, printTable} from './printer.ts'
+import {readFileSync} from 'node:fs'
+import {mockFileMap} from './mockFiles.ts'
+import {isServerRunning, runServeInBackground} from './background.ts'
+import {openInBrowser} from './auth.ts'
+import {styleText} from 'node:util'
+import {pollFor} from '../lang/util.ts'
+import {FILE_MAP} from '../lang/analyze.ts'
+import {runQuery} from './connections/index.ts'
+
+export interface RunMdFileOptions {
+  mdArg: string
+  chart?: string
+  log?: (...args: any[]) => void
+}
+
+let browserConnections: {url: string, socket: WebSocket}[] = []
+let pendingRequests: Record<string, {response: ServerResponse<IncomingMessage>}> = {}
+
+export async function runMdFile (options: RunMdFileOptions): Promise<boolean> {
+  let log = options.log || console.log
+  let mdFile = normalizeMdFile(options.mdArg)
+  if (!mdFile) {
+    log(`Couldn't find ${options.mdArg}`)
+    return false
+  }
+
+  await loadWorkspace(config.root, false)
+  if (process.env.NODE_ENV == 'test' && mockFileMap[mdFile]) {
+    updateFile(mockFileMap[mdFile], mdFile)
+  } else {
+    let content = readFileSync(path.resolve(config.root, mdFile), 'utf-8')
+    updateFile(content, mdFile)
+  }
+
+  analyze()
+  if (getDiagnostics().length > 0) {
+    printDiagnostics(getDiagnostics(), log)
+    return false
+  }
+
+  if (process.env.NODE_ENV == 'test') delete FILE_MAP[mdFile]
+
+  let host = `http://localhost:${config.port}`
+  let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')
+  if (pageUrl === '/index') pageUrl = '/'
+
+  if (process.env.NODE_ENV !== 'test' && !(await isServerRunning())) {
+    log('Starting Graphene server...')
+    await runServeInBackground()
+  }
+
+  let resp = await sendCheckRequest({host, pageUrl, chart: options.chart})
+
+  if (resp.checkError == 'no_server') {
+    log('Failed to start Graphene server')
+    return false
+  }
+
+  if (resp.checkError == 'no_tab' && process.env.NODE_ENV !== 'test') {
+    log(`Opening page ${host}${pageUrl}`)
+    openInBrowser(host + pageUrl)
+    await new Promise(resolve => setTimeout(resolve, 500))
+    resp = await sendCheckRequest({host, pageUrl, chart: options.chart})
+  }
+
+  if (resp.checkError == 'no_tab') {
+    log('Failed to open a new tab')
+    return false
+  }
+
+  if (resp.checkError) {
+    log('Failed to run check: ' + resp.checkError)
+    return false
+  }
+
+  let errors = Array.from(resp.errors || [])
+  if (errors.length) {
+    log(styleText('red', 'Runtime errors') + ` in ${mdFile}:`)
+  } else {
+    log('No errors found 💎')
+  }
+
+  errors.forEach((e: any) => {
+    if (e.type === 'compile') {
+      let file = e.file && path.isAbsolute(e.file) ? path.relative(config.root, e.file) : e.file
+      let msg = e.message.replace(/^.*?:\d+:\d+\s*/, '').replace(/\s*https:\/\/svelte\.dev\/\S+/g, '')
+      log(`${styleText('red', 'ERROR')}: ${file} line ${e.line}: ${msg}`)
+      for (let frameLine of e.frame.split('\n')) log('  ' + frameLine)
+    } else if (e.file && e.from) {
+      printDiagnostics([e as Diagnostic], log)
+    } else if (e.queryId) {
+      log(`${e.queryId}: ${e.message}`)
+    } else {
+      log(e.message)
+    }
+  })
+
+  if (resp?.stillLoading) {
+    log('Warning: Queries were still loading when the screenshot was taken')
+  }
+
+  if (resp?.screenshot) {
+    let filename = `graphene-screenshot-${new Date().toISOString().replace(/[:.]/g, '-')}.png`
+    let screenshotPath = path.join(os.tmpdir(), filename)
+    let base64Data = resp.screenshot.replace(/^data:image\/png;base64,/, '')
+    await fs.writeFile(screenshotPath, base64Data, 'base64')
+    log('Screenshot saved to', screenshotPath)
+  }
+
+  return errors.length == 0
+}
+
+export async function runNamedQueryFromMd (mdAbsolutePath: string, queryName: string): Promise<boolean> {
+  await loadWorkspace(process.cwd(), false)
+  let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
+  let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
+
+  updateFile(mdContents, mdRelativePath)
+  analyze()
+  if (getDiagnostics().length > 0) {
+    printDiagnostics(getDiagnostics())
+    return false
+  }
+
+  let runQueryFence = [
+    mdContents,
+    '',
+    '```sql',
+    `from ${queryName} select *`,
+    '```',
+  ].join('\n')
+  let queries = analyze(runQueryFence, 'md')
+  if (getDiagnostics().length > 0) {
+    printDiagnostics(getDiagnostics())
+    return false
+  }
+
+  let sql = toSql(queries[queries.length - 1])
+  let res = await runQuery(sql)
+  printTable(res.rows)
+  return true
+}
+
+async function sendCheckRequest ({host, pageUrl, chart}) {
+  let abort = new AbortController()
+  let timeout = setTimeout(() => abort.abort(), 30_000)
+  let browserHost = host.replace('127.0.0.1', 'localhost')
+  try {
+    let response = await fetch(`${host}/_api/check`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({pageUrl: browserHost + pageUrl, chart}),
+      signal: abort.signal,
+    })
+    clearTimeout(timeout)
+
+    let body = response.headers.get('content-type') == 'application/json' ? await response.json() : {error: await response.text()}
+
+    if (!response.ok) {
+      if (body.error) return {checkError: body.error}
+      console.error(`Unexpected response: ${JSON.stringify(body)}`)
+      return {checkError: 'Unexpected response from Graphene server'}
+    }
+
+    return body
+  } catch (err: any) {
+    clearTimeout(timeout)
+    if (err.name === 'AbortError') return {checkError: 'timeout'}
+    return {checkError: 'no_server'}
+  }
+}
+
+function normalizeMdFile (mdFile: string): string | null {
+  let clean = mdFile.trim()
+  if (!clean) return null
+  if (!clean.endsWith('.md')) clean = clean + '.md'
+
+  if (process.env.NODE_ENV == 'test' && mockFileMap[clean]) return clean
+
+  let absolute = [
+    path.resolve(process.cwd(), clean),
+    path.resolve(config.root, clean),
+  ].find(p => fs.existsSync(p)) || null
+
+  if (!absolute) return null
+  return path.relative(config.root, absolute)
+}
+
+export async function proxyCheckRequest (req: IncomingMessage, res: ServerResponse<IncomingMessage>): Promise<void> {
+  let chunks = [] as any[]
+  for await (let chunk of req) chunks.push(chunk)
+  let {pageUrl, chart} = JSON.parse(Buffer.concat(chunks).toString())
+  let id = Math.random().toString(36).slice(2)
+  res.setHeader('Content-Type', 'application/json')
+
+  let normalizedPageUrl = pageUrl.replace(/\/$/, '')
+  let conn = await pollFor(() => browserConnections.find(conn => conn.url === normalizedPageUrl), 5000, 100)
+  if (!conn) {
+    res.statusCode = 400
+    res.end(JSON.stringify({error: 'no_tab'}))
+    return
+  }
+
+  conn.socket.send(JSON.stringify({type: 'check', chart, requestId: id}))
+  pendingRequests[id] = {response: res}
+}
+
+export function checkVitePlugin (): PluginOption {
+  return {
+    name: 'graphene-check-plugin',
+    configureServer (server: ViteDevServer) {
+      let wss = new WebSocketServer({noServer: true})
+
+      server.httpServer?.on('upgrade', (req, socket, head) => {
+        if (!req.url || (!req.url.includes('/_api/ws') && !req.url.includes('graphene-ws'))) return
+        wss.handleUpgrade(req, socket, head, ws => wss.emit('connection', ws, req))
+      })
+
+      wss.on('connection', socket => {
+        socket.on('message', data => {
+          let message = JSON.parse(data.toString())
+          if (message.type === 'register') {
+            let normalizedUrl = message.url.replace(/\/$/, '')
+            browserConnections.push({url: normalizedUrl, socket})
+          }
+          if (message.type === 'checkResponse') {
+            pendingRequests[message.requestId].response.end(JSON.stringify(message))
+            delete pendingRequests[message.requestId]
+          }
+        })
+        socket.on('close', () => {
+          browserConnections = browserConnections.filter(conn => conn.socket !== socket)
+        })
+      })
+
+      server.httpServer?.on('close', () => wss.close())
+
+      server.middlewares.use(async (req, res, next) => {
+        let [pathName] = (req.url || '').split('?')
+        if (pathName === '/_api/check') await proxyCheckRequest(req, res)
+        else next()
+      })
+    },
+  }
+}

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -10,7 +10,7 @@ import path from 'path'
 import {fileURLToPath} from 'url'
 import {runQuery} from './connections/index.ts'
 import {injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
-import {checkVitePlugin} from './run.ts'
+import {runVitePlugin} from './run.ts'
 import {mockFileMap} from './mockFiles.ts'
 
 // Collect Svelte compiler warnings for test assertions
@@ -66,7 +66,7 @@ async function createConfig (): Promise<InlineConfig> {
       }),
       fixSvelteDepsInTests(),
       fixHmrForFailedModules(),
-      checkVitePlugin(),
+      runVitePlugin(),
       handleRequestPlugin,
       updateWorkspacePlugin,
       mockFilesForTests(),

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -10,7 +10,7 @@ import path from 'path'
 import {fileURLToPath} from 'url'
 import {runQuery} from './connections/index.ts'
 import {injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
-import {checkVitePlugin} from './check.ts'
+import {checkVitePlugin} from './run.ts'
 import {mockFileMap} from './mockFiles.ts'
 
 // Collect Svelte compiler warnings for test assertions

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,5 +1,6 @@
 # Best practices
 - Start simple - Get basic query working, then add complexity
-- Use check often - Catches syntax errors and shows visual output
+- Use check often - Catches syntax and analysis errors early
+- Iterate dashboard queries in-file - When tuning a code-fenced query in a markdown dashboard, edit the `.md` file and run `graphene run [mdFile] -q [queryName]` instead of inline CLI GSQL to avoid drift between experimentation and what gets committed
 - Leverage models - Use modeled joins, dimensions, and measures rather than raw SQL
 - Don't format in SQL - Rely on `fmt` instead. Do not multiply percentages by 100.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,18 +1,30 @@
 # CLI
 
-The main command in Graphene is `check`. It takes several options:
+`graphene check` is a diagnostics command.
 
 ```bash
-graphene check # Check syntax for entire project
-graphene check [mdPath] # Check specific markdown file, run queries, and take a screenshot
-graphene check [mdPath] -c [chartTitle] # Check, run, and get a screenshot for one specific chart
+graphene check # Check diagnostics across all .gsql files in the project
+graphene check path/to/file.gsql # Check diagnostics for one specific gsql file
+graphene check path/to/page.md # Check diagnostics for one specific markdown file
 ```
 
-Invoke via your project's package manager (e.g. `pnpm graphene check`, `npm exec graphene check`).
+`graphene run` supports both query execution and markdown page runs.
+
+```bash
+graphene run "from flights select count() as total" # Run inline GSQL and print results
+graphene run - # Read GSQL from stdin and print results
+
+graphene run path/to/page.md # Run the page and save a full-page screenshot
+graphene run path/to/page.md -c "Chart Title" # Run the page and screenshot one chart by title
+graphene run path/to/page.md -q query_name # Run a named query/table from the markdown context and print results
+```
+
+`-q/--query` can target anything usable in a chart `data` prop (for example, a gsql table or a named code-fenced query in the markdown file).
+
+Invoke via your project's package manager (e.g. `pnpm graphene check`, `npm exec graphene run`).
 
 Other commands:
 
 ```bash
-graphene run "[GSQL]" # Run GSQL directly, without creating a .md file
 graphene compile "[GSQL]" # Show the compiled, dialect-specific SQL
 ```

--- a/ui/internal/runSocket.ts
+++ b/ui/internal/runSocket.ts
@@ -1,5 +1,5 @@
-// WebSocket connection for the `graphene check` command.
-// Listens for check requests, waits for queries to finish, captures screenshots, and reports errors.
+// WebSocket connection for the `graphene run` command.
+// Listens for run requests, waits for queries to finish, captures screenshots, and reports errors.
 
 import {getErrors} from './telemetry.ts'
 

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -1,6 +1,6 @@
 import {test, expect} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
-import {check} from '../../cli/check.ts'
+import {check, runMdFile} from '../../cli/check.ts'
 import {updateFile} from '../../lang/core.ts'
 import stripAnsi from 'strip-ansi'
 import {trimIndentation} from '../../lang/util.ts'
@@ -59,7 +59,7 @@ test('check with mdFile reports analysis errors', async ({server, page}) => {
   `.trim())
 })
 
-test('cli check command reports runtime query errors', async ({server, page}) => {
+test('cli run with md file reports runtime query errors', async ({server, page}) => {
   expectConsoleError('Failed to load resource')
   server.mockFile('/index.md', `
     # Runtime Cast Error Page
@@ -70,7 +70,7 @@ test('cli check command reports runtime query errors', async ({server, page}) =>
   `)
 
   await page.goto(server.url())
-  await check({mdArg: 'index.md', log})
+  await runMdFile({mdArg: 'index.md', log})
   expect(outputLines()).toEqual(trimIndentation(`
     Runtime errors in index.md:
     Query (data="runtime_error_query" x="origin" y="explode"): Out of Range Error: cannot take square root of a negative number
@@ -78,7 +78,7 @@ test('cli check command reports runtime query errors', async ({server, page}) =>
   `))
 })
 
-test('check reports runtime chart configuration errors', async ({server, page}) => {
+test('cli run with md file reports runtime chart configuration errors', async ({server, page}) => {
   expectConsoleError('Error in Bar Chart')
   expectConsoleError(/ECharts.*has been disposed/)
   server.mockFile('/index.md', `
@@ -90,7 +90,7 @@ test('check reports runtime chart configuration errors', async ({server, page}) 
   `)
 
   await page.goto(server.url())
-  await check({mdArg: 'index.md', log})
+  await runMdFile({mdArg: 'index.md', log})
   expect(outputLines()).toEqual(trimIndentation(`
     Runtime errors in index.md:
     Runtime Chart Config Error (data="chart_data" x="carrier" y="worst_delay"): Log axis cannot display values less than or equal to zero
@@ -98,7 +98,7 @@ test('check reports runtime chart configuration errors', async ({server, page}) 
 `))
 })
 
-test('check table configuration errors', async ({server, page}) => {
+test('cli run with md file reports table configuration errors', async ({server, page}) => {
   server.mockFile('/index.md', `
     # Runtime Table Config Error
     \`\`\`sql table_data
@@ -108,7 +108,7 @@ test('check table configuration errors', async ({server, page}) => {
   `)
 
   await page.goto(server.url())
-  await check({mdArg: 'index.md', log})
+  await runMdFile({mdArg: 'index.md', log})
   expect(outputLines()).toEqual(trimIndentation(`
     Runtime errors in index.md:
     DataTable: not_a_column is not a column in the dataset. sort should contain one column name and optionally a direction (asc or desc).
@@ -116,7 +116,7 @@ test('check table configuration errors', async ({server, page}) => {
 `))
 })
 
-test('check reports html compilation errors', async ({server, page}) => {
+test('cli run with md file reports html compilation errors', async ({server, page}) => {
   expectConsoleError('Failed to load resource')
   expectConsoleError('Internal Server Error')
   expectConsoleError('Failed to fetch dynamically imported module')
@@ -126,7 +126,7 @@ test('check reports html compilation errors', async ({server, page}) => {
   `)
 
   await page.goto(server.url())
-  let result = await check({mdArg: 'index.md', log})
+  let result = await runMdFile({mdArg: 'index.md', log})
   expect(result).toBe(false)
   let output = outputLines()
   expect(output).toContain('Runtime errors in index.md:')
@@ -135,7 +135,7 @@ test('check reports html compilation errors', async ({server, page}) => {
   expect(output).toContain('^')
 })
 
-test('cli check with --chart captures a single chart screenshot', async ({server, page}) => {
+test('cli run with --chart captures a single chart screenshot', async ({server, page}) => {
   server.mockFile('/index.md', `
     # Chart Screenshot
     \`\`\`sql chart_data
@@ -145,7 +145,7 @@ test('cli check with --chart captures a single chart screenshot', async ({server
   `)
 
   await page.goto(server.url())
-  await check({mdArg: 'index.md', chart: 'Carrier Distance', log})
+  await runMdFile({mdArg: 'index.md', chart: 'Carrier Distance', log})
   expect(outputLines()).toEqual(trimIndentation(`
     No errors found 💎
     Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -52,7 +52,7 @@ test('check with mdFile reports analysis errors', async ({server, page}) => {
   `)
 
   await page.goto(server.url() + '/mock')
-  await check({mdArg: 'mock.md', log})
+  await check({fileArg: 'mock.md', log})
   expect(outputLines()).toEqual(`
     ERROR: mock.md line 3: Unknown function: not_a_function
    | from flights select not_a_function() as explode

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -1,6 +1,7 @@
 import {test, expect} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
-import {check, runMdFile} from '../../cli/check.ts'
+import {check} from '../../cli/check.ts'
+import {runMdFile} from '../../cli/run.ts'
 import {updateFile} from '../../lang/core.ts'
 import stripAnsi from 'strip-ansi'
 import {trimIndentation} from '../../lang/util.ts'

--- a/ui/tests/pack-install.test.ts
+++ b/ui/tests/pack-install.test.ts
@@ -108,10 +108,16 @@ test.skipIf(!shouldRunPackInstallTest)('packs cli and installs it into a user pr
     let checkResult = await run('npm', ['run', 'graphene', '--', 'check', 'index.md'], projectDir, childEnv)
     expectSuccess('npm run graphene check index.md', checkResult)
 
-    let output = stripAnsi(checkResult.stdout + checkResult.stderr)
-    expect(output).toContain('No errors found')
+    let checkOutput = stripAnsi(checkResult.stdout + checkResult.stderr)
+    expect(checkOutput).toContain('No errors found')
 
-    let screenshotPath = parseScreenshotPath(output, projectDir)
+    let runResult = await run('npm', ['run', 'graphene', '--', 'run', 'index.md'], projectDir, childEnv)
+    expectSuccess('npm run graphene run index.md', checkResult)
+
+    let runOutput = stripAnsi(runResult.stdout + runResult.stderr)
+    expect(checkOutput).toContain('No errors found')
+
+    let screenshotPath = parseScreenshotPath(runOutput, projectDir)
     let screenshot = await fsp.readFile(screenshotPath)
     expect(screenshot.length).toBeGreaterThan(20_000)
 

--- a/ui/web.js
+++ b/ui/web.js
@@ -1,6 +1,6 @@
 import './internal/telemetry.ts'
 import './internal/queryEngine.ts'
-import './internal/checkSocket.ts'
+import './internal/runSocket.ts'
 import './app.css'
 import {mount} from 'svelte'
 import LocalApp from './internal/LocalApp.svelte'


### PR DESCRIPTION
This PR refactors the `check` and `run` commands per the discussion in #114. In summary:

- `check` just checks diagnostics, and can be scoped either to a markdown file or a GSQL file
- Taking screenshots is now handled by the `run` command, including the `--chart` flag. Additionally, a `--query` flag can be used to run a code-fenced query from a markdown file.
- **Note**: Contra what was said in #114 I decided _not_ to support `graphene run [ gsqlFile ]`. My reasoning is that it feels counter to the goal of the original issue: The agent should not be iterating on a GSQL query in a separate scratch file, which has the same drift problems. It should ideally iterate on queries in the markdown file/code fence.

Fixes #114.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/136?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->