### PR TITLE
Remove date_trunc() from documentation examples

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -49,11 +49,11 @@ Graphene dashboards extend Markdown with the following:
 - Visualization components reference query names
 
 ````md
-```sql monthly_sales
-select date_trunc(created_at, month) as month, revenue from orders
+```sql sales_by_category
+select category, revenue from orders
 ```
-<LineChart data="monthly_sales" x="month" y="revenue" />
-<BigValue data="monthly_sales" value="revenue" />
+<BarChart data="sales_by_category" x="category" y="revenue" />
+<BigValue data="sales_by_category" value="revenue" />
 ````
 
 Queries can be referenced by other queries in the `from` or `join` to form DAGs of data transformations within the dashboard.

--- a/docs/references/gsql.md
+++ b/docs/references/gsql.md
@@ -252,9 +252,9 @@ You can see that invoking a stored expression is like using a macro: the definit
 The macro concept is important to understand when invoking stored expressions that are **aggregative** (ie. contain agg functions), which can also be called "measures." Here's an example.
 
 ```sql
--- Profit by month
+-- Profit by status
 select
-  date_trunc(created_at, month) as month,
+  status,
   profit
 from orders
 group by 1
@@ -265,7 +265,7 @@ Note that, while `profit` looks like a column here, it is _not_ a column. That's
 
 ```sql
 select
-  date_trunc(created_at, month) as month,
+  status,
   sum(case when revenue_recognized then amount else 0 end) - sum(case when revenue_recognized then cost else 0 end) as profit -- Profit is defined as revenue - cogs, which respectively expands out to these two filtered sums
 from orders
 group by 1
@@ -342,9 +342,9 @@ table user_facts as (
 For example, if we have a `table X as` statement that creates a daily summary of orders:
 
 ```sql
-table daily_orders as (
+table regional_orders as (
   select
-    date_trunc(created_at, day) as day,
+    region,
     count(*) as num_orders,
     sum(amount) as total_revenue
   from orders
@@ -355,8 +355,8 @@ table daily_orders as (
 We can extend this table to add measures or joins:
 
 ```sql
-extend daily_orders (
-  join one calendar on day = calendar.date
+extend regional_orders (
+  join one regions on region = regions.name
 
   avg_order_value: total_revenue / num_orders
 )


### PR DESCRIPTION
## Summary
- Removes all `date_trunc()` usage from docs, since the argument order varies across databases and confuses agents
- Replaces time-based grouping examples with categorical grouping (by category, status, region)
- Fixes the dashboard example in `base.md` to correctly use `revenue` as a measure without wrapping in `sum()` or adding an unnecessary `group by`

## Test plan
- [x] Review that replacement examples are idiomatic gsql
- [x] Verify no remaining `date_trunc` references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/141?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->