### PR TITLE
Change eslint rule to match what oxfmt is going to do

### DIFF
--- a/cli/auth.ts
+++ b/cli/auth.ts
@@ -24,7 +24,7 @@ export interface Cred {
 const cfgDir = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config')
 const credsPath = path.join(cfgDir, 'graphene', 'credentials.json')
 
-async function readStore (): Promise<any> {
+async function readStore(): Promise<any> {
   try {
     let txt = await fs.readFile(credsPath, 'utf8')
     return JSON.parse(txt) || {}
@@ -33,12 +33,12 @@ async function readStore (): Promise<any> {
   }
 }
 
-async function readEntry (): Promise<Cred | null> {
+async function readEntry(): Promise<Cred | null> {
   let store = await readStore()
   return store[config.root]
 }
 
-async function updateEntry (cred: Cred) {
+async function updateEntry(cred: Cred) {
   let store = await readStore()
   cred.refresh_token ||= store[config.root]?.refresh_token
   cred.expires_at = Date.now() + cred.expires_in
@@ -51,7 +51,7 @@ async function updateEntry (cred: Cred) {
   }
 }
 
-export function openInBrowser (url: string) {
+export function openInBrowser(url: string) {
   try {
     let plat = process.platform
     let cmd = 'xdg-open'
@@ -65,17 +65,17 @@ export function openInBrowser (url: string) {
 }
 
 // PKCE login flow (Authorization Code with loopback)
-function base64url (buf: ArrayBuffer | Uint8Array): string {
+function base64url(buf: ArrayBuffer | Uint8Array): string {
   let b64 = Buffer.from(buf as any).toString('base64')
   return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
 }
 
-function randomBytes (len = 32): Uint8Array {
+function randomBytes(len = 32): Uint8Array {
   return crypto.getRandomValues(new Uint8Array(len))
 }
 
 // Temporary local server that listens for the callback url after at the end of oauth.
-async function startLoopback () {
+async function startLoopback() {
   let server = http.createServer()
   await new Promise<void>(r => server.listen(0, '127.0.0.1', () => r()))
   let addr = server.address()
@@ -97,7 +97,7 @@ async function startLoopback () {
   return {url: redirectBase, waitForCode, close: () => server.close()}
 }
 
-export async function loginPkce (opener?: (url: string) => Promise<void>) {
+export async function loginPkce(opener?: (url: string) => Promise<void>) {
   let verifier = base64url(randomBytes(48))
   let data = new TextEncoder().encode(verifier)
   let digest = await crypto.subtle.digest('SHA-256', data)
@@ -140,7 +140,7 @@ export async function loginPkce (opener?: (url: string) => Promise<void>) {
   await updateEntry(tokenResp)
 }
 
-async function refreshAccessToken () {
+async function refreshAccessToken() {
   let refresh_token = (await readEntry())?.refresh_token
   let res = await fetch(new URL('/_api/oauth2/token', config.host).toString(), {
     method: 'POST',
@@ -153,7 +153,7 @@ async function refreshAccessToken () {
 }
 
 // Makes a request to your Graphene cloud server with credentials stored from `graphene login`
-export async function authenticatedFetch (pathOrUrl: string, init: RequestInit = {}): Promise<Response> {
+export async function authenticatedFetch(pathOrUrl: string, init: RequestInit = {}): Promise<Response> {
   let entry = await readEntry()
   if (!entry) throw new Error('Not logged in; run `graphene login`')
 

--- a/cli/background.ts
+++ b/cli/background.ts
@@ -7,7 +7,7 @@ import {config} from '../lang/config.ts'
 
 const execAsync = promisify(exec)
 
-export async function runServeInBackground (): Promise<void> {
+export async function runServeInBackground(): Promise<void> {
   let grapheneCache = getGrapheneCache(config.root)
   let logFile = path.join(grapheneCache, 'serve.log')
   await fs.ensureDir(grapheneCache)
@@ -44,17 +44,17 @@ export async function runServeInBackground (): Promise<void> {
   })
 }
 
-export function getGrapheneCache (root: string): string {
+export function getGrapheneCache(root: string): string {
   return path.join(root, 'node_modules', '.graphene')
 }
 
-function sendSignal (pid: number, signal: NodeJS.Signals): boolean {
+function sendSignal(pid: number, signal: NodeJS.Signals): boolean {
   let pids = process.platform === 'win32' ? [pid] : [pid, -pid]
 
   for (let target of pids) {
     try {
       process.kill(target, signal)
-    } catch (err) {
+    } catch(err) {
       let code = (err as NodeJS.ErrnoException).code
       if (code === 'ESRCH' || code === 'EINVAL') continue
       return false
@@ -63,7 +63,7 @@ function sendSignal (pid: number, signal: NodeJS.Signals): boolean {
   return true
 }
 
-export async function stopGrapheneIfRunning (): Promise<void> {
+export async function stopGrapheneIfRunning(): Promise<void> {
   let port = Number(process.env.GRAPHENE_PORT) || 4000
   let pid = await getPidOnPort(port)
   if (!pid) return
@@ -85,12 +85,12 @@ export async function stopGrapheneIfRunning (): Promise<void> {
   }
 }
 
-export async function isServerRunning (portOverride?: number): Promise<boolean> {
+export async function isServerRunning(portOverride?: number): Promise<boolean> {
   let port = portOverride || Number(process.env.GRAPHENE_PORT) || 4000
   return !!(await getPidOnPort(port))
 }
 
-async function getPidOnPort (port: number): Promise<number | undefined> {
+async function getPidOnPort(port: number): Promise<number | undefined> {
   try {
     if (process.platform === 'win32') {
       let {stdout} = await execAsync(`netstat -ano | findstr :${port}`)
@@ -117,7 +117,7 @@ async function getPidOnPort (port: number): Promise<number | undefined> {
         child.on('error', () => resolve(undefined))
       })
     }
-  } catch (e:any) {
+  } catch(e:any) {
     console.warn('Failed to check for server:', e.message)
     return undefined
   }

--- a/cli/check.ts
+++ b/cli/check.ts
@@ -10,7 +10,7 @@ interface CheckOptions {
   log?: (...args: any[]) => void
 }
 
-export async function check (options: CheckOptions): Promise<boolean> {
+export async function check(options: CheckOptions): Promise<boolean> {
   let log = options.log || console.log
   let targetFile = options.fileArg && normalizeFile(options.fileArg)
 

--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -19,12 +19,12 @@ const TEST_PORT = 4163
 process.env.GRAPHENE_PORT = '4163'
 process.env.NODE_ENV = 'test'
 
-function ensureFlightsDatabaseExists () {
+function ensureFlightsDatabaseExists() {
   let dbPath = path.resolve(flightDir, 'flights.duckdb')
   if (!fs.existsSync(dbPath)) throw new Error('flights.duckdb not found. Run `pnpm run setup` in examples/flights')
 }
 
-function runCli (args: string[], cwd?: string): Promise<RunResult> {
+function runCli(args: string[], cwd?: string): Promise<RunResult> {
   return new Promise((resolve) => {
     let cliEntry = path.resolve(dir, 'cli.ts')
     let child = spawn('node', [cliEntry, ...args], {cwd, env: process.env})
@@ -35,24 +35,24 @@ function runCli (args: string[], cwd?: string): Promise<RunResult> {
   })
 }
 
-function logCliFailure (step: string, res: RunResult) {
+function logCliFailure(step: string, res: RunResult) {
   console.error(`[cli.test] ${step} failed (code ${res.code})\nstdout:\n${res.stdout}\nstderr:\n${res.stderr}`)
 }
 
-function expectCliSuccess (res: RunResult, step: string) {
+function expectCliSuccess(res: RunResult, step: string) {
   if (res.code !== 0) logCliFailure(step, res)
   expect(res.code).toBe(0)
 }
 
 describe('cli compile', () => {
-  it('compiles a basic query (happy path)', async () => {
+  it('compiles a basic query (happy path)', async() => {
     let res = await runCli(['compile', 'from flights select carrier'], flightDir)
     expectCliSuccess(res, 'compile basic query')
     expect(res.stdout.toLowerCase()).toContain('from flights')
     expect(res.stdout.toLowerCase()).toContain('select')
   })
 
-  it('errors on invalid function (error path)', async () => {
+  it('errors on invalid function (error path)', async() => {
     let res = await runCli(['compile', 'from flights select not_a_function()'], flightDir)
     expect(res.code).not.toBe(0)
     expect((res.stdout + res.stderr).toLowerCase()).toContain('unknown function')
@@ -60,10 +60,10 @@ describe('cli compile', () => {
 })
 
 describe('cli serve (background)', () => {
-  beforeEach(async () => { await stopGrapheneIfRunning() })
-  afterEach(async () => { await stopGrapheneIfRunning() })
+  beforeEach(async() => { await stopGrapheneIfRunning() })
+  afterEach(async() => { await stopGrapheneIfRunning() })
 
-  it('starts the server in the background and restarts cleanly', async () => {
+  it('starts the server in the background and restarts cleanly', async() => {
     let first = await runCli(['serve', '--bg'], flightDir)
     expectCliSuccess(first, 'serve start')
     expect(first.stdout).toContain('Server running at')
@@ -85,13 +85,13 @@ describe('cli serve (background)', () => {
 describe('cli run', () => {
   beforeAll(ensureFlightsDatabaseExists)
 
-  it('runs a query against flights.duckdb (happy path)', async () => {
+  it('runs a query against flights.duckdb (happy path)', async() => {
     let res = await runCli(['run', 'from flights select count() as total'], flightDir)
     expectCliSuccess(res, 'run query')
     expect(res.stdout.toLowerCase()).toContain('total')
   })
 
-  it('shows an error when no .duckdb is present (error path)', async () => {
+  it('shows an error when no .duckdb is present (error path)', async() => {
     let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-cli-'))
     let input = [
       'table t (a int)',
@@ -102,13 +102,13 @@ describe('cli run', () => {
     expect(res.stderr.toLowerCase()).toContain('no .duckdb file found')
   })
 
-  it('runs a named query from a markdown file', async () => {
+  it('runs a named query from a markdown file', async() => {
     let res = await runCli(['run', 'index.md', '--query', 'weekly_trends'], flightDir)
     expectCliSuccess(res, 'run markdown query')
     expect(res.stdout.toLowerCase()).toContain('week')
   })
 
-  it('rejects passing a gsql file path', async () => {
+  it('rejects passing a gsql file path', async() => {
     let res = await runCli(['run', 'tables/flights.gsql'], flightDir)
     expect(res.code).toBe(1)
     expect((res.stdout + res.stderr).toLowerCase()).toContain('running .gsql files is no longer supported')
@@ -116,7 +116,7 @@ describe('cli run', () => {
 })
 
 describe('cli check', () => {
-  it('checks a single gsql file', async () => {
+  it('checks a single gsql file', async() => {
     let res = await runCli(['check', 'tables/flights.gsql'], flightDir)
     expectCliSuccess(res, 'check gsql file')
     expect(res.stdout).toContain('No errors found')

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -30,7 +30,7 @@ loadConfig(process.cwd(), envFiles => {
 program.command('compile')
   .description('Translate a query to SQL and print it')
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
-  .action(async (input: string | undefined) => {
+  .action(async(input: string | undefined) => {
     await loadWorkspace(process.cwd(), false)
     let sql = await readInput(input)
     let queries = analyze(sql)
@@ -43,7 +43,7 @@ program.command('run')
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
   .option('-c, --chart <chartTitle>', 'Title of a specific chart to capture')
   .option('-q, --query <queryName>', 'Query or table name to run from a markdown page')
-  .action(async (input: string | undefined, options: {chart?: string, query?: string}) => {
+  .action(async(input: string | undefined, options: {chart?: string, query?: string}) => {
     if (options.chart && options.query) {
       console.error('Cannot use --chart and --query together')
       process.exit(1)
@@ -79,7 +79,7 @@ program.command('run')
 program.command('schema')
   .description('Inspect database tables or describe a table')
   .argument('[schema | table]', 'Optional schema or table name to describe')
-  .action(async (tableArg: string) => {
+  .action(async(tableArg: string) => {
     let connection = await getConnection()
     let datasets = await connection.listDatasets()
 
@@ -119,7 +119,7 @@ program.command('schema')
 program.command('serve')
   .description('Run the local server')
   .option('--bg', 'Run the server in the background')
-  .action(async (options: {bg?: boolean}) => {
+  .action(async(options: {bg?: boolean}) => {
     await stopGrapheneIfRunning()
     if (options.bg) {
       await runServeInBackground()
@@ -132,19 +132,19 @@ program.command('serve')
 
 program.command('stop')
   .description('Stop the local server')
-  .action(async () => { await stopGrapheneIfRunning() })
+  .action(async() => { await stopGrapheneIfRunning() })
 
 program.command('check')
   .description('Check the project for diagnostics')
   .argument('[file]', 'Optional markdown or gsql file to check')
-  .action(async (fileArg: string | undefined) => {
+  .action(async(fileArg: string | undefined) => {
     let res = await check({fileArg})
     process.exit(res ? 0 : 1) // import to call `exit`, bc if we started the server in the background, just returning won't actually exit the process.
   })
 
 program.command('login')
   .description('Log in to Graphene Cloud')
-  .action(async () => {
+  .action(async() => {
     await loginPkce()
     console.log('Successfully logged in')
     process.exit(0)
@@ -152,7 +152,7 @@ program.command('login')
 
 program.parse(process.argv)
 
-async function readInput (arg): Promise<string> {
+async function readInput(arg): Promise<string> {
   if (!arg || arg === '-') {
     return await new Promise<string>((resolve) => {
       let data = ''
@@ -171,13 +171,13 @@ async function readInput (arg): Promise<string> {
   return arg
 }
 
-function getExistingPath (arg: string | undefined): string | null {
+function getExistingPath(arg: string | undefined): string | null {
   if (!arg || arg === '-') return null
   let absolutePath = path.resolve(arg)
   return fs.existsSync(absolutePath) ? absolutePath : null
 }
 
-function validQuery (queries: Query[]): boolean {
+function validQuery(queries: Query[]): boolean {
   if (getDiagnostics().length) {
     printDiagnostics(getDiagnostics())
     process.exit(1)

--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -3,7 +3,7 @@ import {type QueryConnection, type QueryResult, type SchemaColumn, type QueryPar
 import {config} from '../../lang/config.ts'
 
 // BigQuery identifiers can contain letters, numbers, underscores, and hyphens
-function validateBigQueryIdent (ident: string) {
+function validateBigQueryIdent(ident: string) {
   if (!/^[\w.-]+$/.test(ident)) throw new Error(`Invalid BigQuery identifier: ${ident}`)
 }
 
@@ -12,7 +12,7 @@ export class BigQueryConnection implements QueryConnection {
   private readonly projectId: string
   private readonly defaultNamespace?: string
 
-  constructor (options: BigQueryOptions = {}) {
+  constructor(options: BigQueryOptions = {}) {
     options.projectId ||= config.bigquery?.projectId
     if (!options.projectId) throw new Error('projectId must be set in config or provided in service account credentials')
     this.projectId = options.projectId
@@ -20,7 +20,7 @@ export class BigQueryConnection implements QueryConnection {
     this.defaultNamespace = config.defaultNamespace
   }
 
-  async runQuery (sql: string, params?: QueryParams): Promise<QueryResult> {
+  async runQuery(sql: string, params?: QueryParams): Promise<QueryResult> {
     let [job] = await this.client.createQueryJob({query: sql, useLegacySql: false, params})
     let [rows] = await job.getQueryResults({maxResults: 10000})
     let metadata = job.metadata || (await job.getMetadata())[0]
@@ -36,12 +36,12 @@ export class BigQueryConnection implements QueryConnection {
     return {rows, totalRows}
   }
 
-  async listDatasets (): Promise<string[]> {
+  async listDatasets(): Promise<string[]> {
     let [datasets] = await this.client.getDatasets()
     return datasets.map(d => d.id || d.metadata.datasetReference?.datasetId)
   }
 
-  async listTables (dataset?: string): Promise<string[]> {
+  async listTables(dataset?: string): Promise<string[]> {
     if (!dataset) throw new Error('BigQuery requires a dataset')
     validateBigQueryIdent(dataset)
 
@@ -52,7 +52,7 @@ export class BigQueryConnection implements QueryConnection {
     return res.rows.map(r => `${dataset}.${r['table_name']}`)
   }
 
-  async describeTable (target: string): Promise<SchemaColumn[]> {
+  async describeTable(target: string): Promise<SchemaColumn[]> {
     let parts = target.split('.')
     let table = parts.pop() || ''
     let dataset = parts.join('.') || this.defaultNamespace

--- a/cli/connections/duckdb.ts
+++ b/cli/connections/duckdb.ts
@@ -13,12 +13,12 @@ export class DuckDBConnection implements QueryConnection {
   ready: Promise<void>
   connection: InnerConnection | null = null
 
-  constructor (options?: DuckDbOptions) {
+  constructor(options?: DuckDbOptions) {
     this.options = options || {}
     this.ready = this.initialize()
   }
 
-  private async initialize () {
+  private async initialize() {
     let dbPath = this.options.path
     if (!dbPath) {
       let files = await fs.readdir(config.root)
@@ -35,7 +35,7 @@ export class DuckDBConnection implements QueryConnection {
     await this.connection.run('use graphene_cli;')
   }
 
-  async runQuery (sql: string, params?: QueryParams): Promise<QueryResult> {
+  async runQuery(sql: string, params?: QueryParams): Promise<QueryResult> {
     await this.ready
     let reader = params
       ? await this.connection!.runAndReadAll(sql, params as any)
@@ -56,11 +56,11 @@ export class DuckDBConnection implements QueryConnection {
     return {rows}
   }
 
-  async listDatasets (): Promise<string[]> {
+  async listDatasets(): Promise<string[]> {
     return await Promise.resolve([])
   }
 
-  async listTables (): Promise<string[]> {
+  async listTables(): Promise<string[]> {
     let sql = `
       select table_schema as table_schema, table_name as table_name
       from information_schema.tables
@@ -71,7 +71,7 @@ export class DuckDBConnection implements QueryConnection {
     return res.rows.map(row => String(row['table_name']))
   }
 
-  async describeTable (target: string): Promise<SchemaColumn[]> {
+  async describeTable(target: string): Promise<SchemaColumn[]> {
     let parts = target.split('.')
     let table = parts.pop() || ''
     let schema = parts[0]

--- a/cli/connections/index.ts
+++ b/cli/connections/index.ts
@@ -6,7 +6,7 @@ import {type QueryResult, type QueryConnection, type QueryParams} from './types.
 // Reads credentials from environment variables and passes them to the connection constructors.
 // The connection classes themselves have no env-reading logic — this keeps the cloud server
 // from accidentally picking up local env vars instead of database-stored credentials.
-export async function getConnection (): Promise<QueryConnection> {
+export async function getConnection(): Promise<QueryConnection> {
   if (config.dialect === 'bigquery') {
     let mod = await import('./bigQuery.ts')
     let options: any = {}
@@ -34,7 +34,7 @@ export async function getConnection (): Promise<QueryConnection> {
   }
 }
 
-export async function runQuery (sql: string, params?: QueryParams): Promise<QueryResult> {
+export async function runQuery(sql: string, params?: QueryParams): Promise<QueryResult> {
   if (config.host) {
     let resp = await authenticatedFetch('/_api/query', {
       method: 'POST',

--- a/cli/connections/snowflake.ts
+++ b/cli/connections/snowflake.ts
@@ -24,11 +24,11 @@ export class SnowflakeConnection implements QueryConnection {
   private ready: Promise<void>
   private connection!: snowflake.Connection
 
-  constructor (opts: SnowflakeOptions) {
+  constructor(opts: SnowflakeOptions) {
     this.ready = this.initialize(opts || {})
   }
 
-  async initialize (opts: SnowflakeOptions) {
+  async initialize(opts: SnowflakeOptions) {
     let privateKeyPath = opts.privateKeyPath || config.snowflake?.privateKeyPath
 
     let authOptions: any = {}
@@ -55,7 +55,7 @@ export class SnowflakeConnection implements QueryConnection {
     })
   }
 
-  async runQuery (sql: string, params?: QueryParams): Promise<QueryResult> {
+  async runQuery(sql: string, params?: QueryParams): Promise<QueryResult> {
     await this.ready
     return await new Promise<QueryResult>((resolve, reject) => {
       let rows: any[] = []
@@ -71,7 +71,7 @@ export class SnowflakeConnection implements QueryConnection {
 
           let stream = statement.streamRows()
           stream.on('error', err => reject(err))
-          stream.on('readable', function (this: any, row) {
+          stream.on('readable', function(this: any, row) {
             while ((row = this.read()) !== null) {
               rows.push(row)
             }
@@ -85,12 +85,12 @@ export class SnowflakeConnection implements QueryConnection {
     })
   }
 
-  async listDatasets (): Promise<string[]> {
+  async listDatasets(): Promise<string[]> {
     let res = await this.runQuery('show databases')
     return res.rows.map(row => String(row['name'] || ''))
   }
 
-  async listSchemas (database: string): Promise<string[]> {
+  async listSchemas(database: string): Promise<string[]> {
     let res = await this.runQuery(`
       select schema_name as "schema_name"
       from ${snowflakeIdent(database)}.INFORMATION_SCHEMA.SCHEMATA
@@ -100,7 +100,7 @@ export class SnowflakeConnection implements QueryConnection {
     return res.rows.map(row => String(row['schema_name']))
   }
 
-  async listTables (dataset: string): Promise<string[]> {
+  async listTables(dataset: string): Promise<string[]> {
     let parts = dataset.split('.')
     let database = parts.shift() || ''
     let schema = parts.join('.')
@@ -114,7 +114,7 @@ export class SnowflakeConnection implements QueryConnection {
     return res.rows.map(row => `${row['table_schema']}.${row['table_name']}`)
   }
 
-  async describeTable (target: string): Promise<SchemaColumn[]> {
+  async describeTable(target: string): Promise<SchemaColumn[]> {
     let parts = target.split('.')
     let database = parts.shift() || ''
     let table = parts.pop() || ''
@@ -132,7 +132,7 @@ export class SnowflakeConnection implements QueryConnection {
   }
 }
 
-function snowflakeIdent (value: string) {
+function snowflakeIdent(value: string) {
   if (!value) throw new Error('Snowflake identifiers cannot be empty')
   return `"${value.replace(/"/g, '""')}"`
 }

--- a/cli/esbuild.mjs
+++ b/cli/esbuild.mjs
@@ -9,7 +9,7 @@ const __dirname = path.dirname(__filename)
 
 let makeAllPackagesExternalPlugin = {
   name: 'make-all-packages-external',
-  setup (build) {
+  setup(build) {
     let filter = /^[^./]|^\.[^./]|^\.\.[^/]/ // Must not start with "/" or "./" or "../"
     build.onResolve({filter}, args => ({path: args.path, external: true}))
   },

--- a/cli/mdCompile.test.ts
+++ b/cli/mdCompile.test.ts
@@ -3,7 +3,7 @@ import {compile} from 'mdsvex'
 import {remarkPlugins, rehypePlugins} from './mdCompile.ts'
 
 describe('markdown sanitization', () => {
-  it('keeps wrapper components intact across blank lines', async () => {
+  it('keeps wrapper components intact across blank lines', async() => {
     let src = `
 <Row>
   <BarChart data="x" y="a" />

--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -5,12 +5,12 @@ import {visit} from 'unist-util-visit'
 import sanitizeHtml from 'sanitize-html'
 
 
-export function extractQueries () {
-  function escapeHtml (str: string) {
+export function extractQueries() {
+  function escapeHtml(str: string) {
     return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
   }
 
-  return function transformer (tree: any) {
+  return function transformer(tree: any) {
     visit(tree, 'code', (node, index, parent) => {
       if (index === null) return
       let name = typeof node.meta === 'string' ? node.meta : ''
@@ -21,8 +21,8 @@ export function extractQueries () {
 }
 
 // remark will leave less-than and greater-than unescaped, which breaks svelte and prevents the page from loading.
-export function escapeAngles () {
-  return function transformer (tree: any) {
+export function escapeAngles() {
+  return function transformer(tree: any) {
     visit(tree, 'text', (node: any) => {
       if (!node.value || typeof node.value !== 'string') return
       if (!node.value.includes('<')) return
@@ -33,8 +33,8 @@ export function escapeAngles () {
 
 // remark can split one html block into adjacent html nodes when self-closing tags are involved.
 // Merge those sibling html nodes so downstream rehype/sanitize work on the full block.
-export function mergeAdjacentHtml () {
-  return function transformer (tree: any) {
+export function mergeAdjacentHtml() {
+  return function transformer(tree: any) {
     visit(tree, (parent: any) => {
       if (!Array.isArray(parent?.children)) return
 
@@ -55,8 +55,8 @@ export function mergeAdjacentHtml () {
 // Restrict allowed components in markdown files to avoid xss issues.
 // This uses sanitize-html rather than rehype-sanitize because the latter had lots of issues with preserving tag casing,
 // as well as allowing all attributes on our allowlisted components.
-export function sanitizeMarkdown () {
-  return function transformer (tree: any) {
+export function sanitizeMarkdown() {
+  return function transformer(tree: any) {
     visit(tree, 'raw', (node: any) => {
       if (typeof node.value !== 'string') return
 
@@ -88,7 +88,7 @@ export function sanitizeMarkdown () {
 }
 
 // We don't want users to have to manually import components in their md files, so we auto-import them.
-export function injectComponentImports () {
+export function injectComponentImports() {
   let imp = `const {${componentNames().join(', ')}} = window.$GRAPHENE.components`
 
   return {
@@ -108,7 +108,7 @@ export function injectComponentImports () {
 
 // List out the component names from ui/components
 let cachedComponentNames: string[] | null = null
-export function componentNames () {
+export function componentNames() {
   if (cachedComponentNames) return cachedComponentNames
 
   let files = fs.readdirSync(path.join(import.meta.dirname, '../ui/components'))

--- a/cli/normalizeFile.ts
+++ b/cli/normalizeFile.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import {config} from '../lang/core.ts'
 import {mockFileMap} from './mockFiles.ts'
 
-export function normalizeFile (file: string): string | null {
+export function normalizeFile(file: string): string | null {
   let clean = file.trim()
   if (!clean) return null
 

--- a/cli/printer.ts
+++ b/cli/printer.ts
@@ -12,7 +12,7 @@ const styleText = (style: string, text: string) => {
   }
 }
 
-function offsetToLineCol (src: string, offset: number): {line: number; col: number; lineStart: number; lineText: string} {
+function offsetToLineCol(src: string, offset: number): {line: number; col: number; lineStart: number; lineText: string} {
   let lines = src.split(/\r?\n/)
   let acc = 0
   for (let i = 0; i < lines.length; i++) {
@@ -27,7 +27,7 @@ function offsetToLineCol (src: string, offset: number): {line: number; col: numb
   return {line: 1, col: 0, lineStart: 0, lineText: lines[0] || ''}
 }
 
-export function printDiagnostics (diags: Diagnostic[], log?: any) {
+export function printDiagnostics(diags: Diagnostic[], log?: any) {
   log ||= console.log
   let parts: string[] = []
   for (let d of diags) {
@@ -44,7 +44,7 @@ export function printDiagnostics (diags: Diagnostic[], log?: any) {
   if (parts.length) log(parts.join('\n'))
 }
 
-export function printTable (rows: any[]) {
+export function printTable(rows: any[]) {
   if (!rows || rows.length === 0) {
     console.log(chalk.yellow('No results returned'))
     return

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -26,7 +26,7 @@ export interface RunMdFileOptions {
 let browserConnections: {url: string, socket: WebSocket}[] = []
 let pendingRequests: Record<string, {response: ServerResponse<IncomingMessage>}> = {}
 
-export async function runMdFile (options: RunMdFileOptions): Promise<boolean> {
+export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
   let log = options.log || console.log
   let mdFile = normalizeFile(options.mdArg)
   if (!mdFile) {
@@ -120,7 +120,7 @@ export async function runMdFile (options: RunMdFileOptions): Promise<boolean> {
   return errors.length == 0
 }
 
-export async function runNamedQueryFromMd (mdAbsolutePath: string, queryName: string): Promise<boolean> {
+export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string): Promise<boolean> {
   await loadWorkspace(process.cwd(), false)
   let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
   let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
@@ -151,7 +151,7 @@ export async function runNamedQueryFromMd (mdAbsolutePath: string, queryName: st
   return true
 }
 
-async function sendRunRequest ({host, pageUrl, chart}) {
+async function sendRunRequest({host, pageUrl, chart}) {
   let abort = new AbortController()
   let timeout = setTimeout(() => abort.abort(), 30_000)
   let browserHost = host.replace('127.0.0.1', 'localhost')
@@ -173,14 +173,14 @@ async function sendRunRequest ({host, pageUrl, chart}) {
     }
 
     return body
-  } catch (err: any) {
+  } catch(err: any) {
     clearTimeout(timeout)
     if (err.name === 'AbortError') return {checkError: 'timeout'}
     return {checkError: 'no_server'}
   }
 }
 
-export async function proxyRunRequest (req: IncomingMessage, res: ServerResponse<IncomingMessage>): Promise<void> {
+export async function proxyRunRequest(req: IncomingMessage, res: ServerResponse<IncomingMessage>): Promise<void> {
   let chunks = [] as any[]
   for await (let chunk of req) chunks.push(chunk)
   let {pageUrl, chart} = JSON.parse(Buffer.concat(chunks).toString())
@@ -199,10 +199,10 @@ export async function proxyRunRequest (req: IncomingMessage, res: ServerResponse
   pendingRequests[id] = {response: res}
 }
 
-export function runVitePlugin (): PluginOption {
+export function runVitePlugin(): PluginOption {
   return {
     name: 'graphene-check-plugin',
-    configureServer (server: ViteDevServer) {
+    configureServer(server: ViteDevServer) {
       let wss = new WebSocketServer({noServer: true})
 
       server.httpServer?.on('upgrade', (req, socket, head) => {
@@ -229,7 +229,7 @@ export function runVitePlugin (): PluginOption {
 
       server.httpServer?.on('close', () => wss.close())
 
-      server.middlewares.use(async (req, res, next) => {
+      server.middlewares.use(async(req, res, next) => {
         let [pathName] = (req.url || '').split('?')
         if (pathName === '/_api/check') await proxyRunRequest(req, res)
         else next()

--- a/cli/schema.test.ts
+++ b/cli/schema.test.ts
@@ -18,12 +18,12 @@ const ecommDir = path.resolve(dir, '../examples/ecomm')
 const hasSnowflakeAuth = !!process.env.SNOWFLAKE_PRI_KEY_PATH || !!process.env.SNOWFLAKE_PRI_KEY
 const hasBigQueryAuth = !!process.env.GOOGLE_APPLICATION_CREDENTIALS || !!process.env.GOOGLE_CREDENTIALS_CONTENT
 
-function ensureFlightsDatabaseExists () {
+function ensureFlightsDatabaseExists() {
   let dbPath = path.resolve(flightDir, 'flights.duckdb')
   if (!fs.existsSync(dbPath)) throw new Error('flights.duckdb not found. Run `pnpm run setup` in examples/flights')
 }
 
-function runCli (args: string[], cwd?: string): Promise<RunResult> {
+function runCli(args: string[], cwd?: string): Promise<RunResult> {
   return new Promise((resolve) => {
     let cliEntry = path.resolve(dir, 'cli.ts')
     let child = spawn('node', [cliEntry, ...args], {cwd, env: process.env})
@@ -34,16 +34,16 @@ function runCli (args: string[], cwd?: string): Promise<RunResult> {
   })
 }
 
-function logCliFailure (step: string, res: RunResult) {
+function logCliFailure(step: string, res: RunResult) {
   console.error(`[schema.test] ${step} failed (code ${res.code})\nstdout:\n${res.stdout}\nstderr:\n${res.stderr}`)
 }
 
-function expectCliSuccess (res: RunResult, step: string) {
+function expectCliSuccess(res: RunResult, step: string) {
   if (res.code !== 0) logCliFailure(step, res)
   expect(res.code).toBe(0)
 }
 
-function parseSchemaOutput (stdout: string): string[] {
+function parseSchemaOutput(stdout: string): string[] {
   return stdout.trim().split(/\r?\n/)
     .map(line => line.trim())
     .filter(line => line && !line.endsWith(':')) // filter out headers like "Datasets available:"
@@ -52,7 +52,7 @@ function parseSchemaOutput (stdout: string): string[] {
 describe('duckdb', () => {
   beforeAll(ensureFlightsDatabaseExists)
 
-  it('lists available tables when no argument is provided', async () => {
+  it('lists available tables when no argument is provided', async() => {
     let res = await runCli(['schema'], flightDir)
     expectCliSuccess(res, 'schema list tables')
     let lines = res.stdout.trim().split(/\r?\n/).filter(Boolean)
@@ -61,7 +61,7 @@ describe('duckdb', () => {
     expect(normalized.some(line => line === 'flights')).toBe(true)
   })
 
-  it('describes the requested table columns', async () => {
+  it('describes the requested table columns', async() => {
     let res = await runCli(['schema', 'flights'], flightDir)
     expectCliSuccess(res, 'schema describe table')
     let output = res.stdout.toLowerCase()
@@ -79,14 +79,14 @@ describe.skipIf(!hasSnowflakeAuth)('snowflake', () => {
   // Snowflake has a 3-level hierarchy: DATABASE.SCHEMA.TABLE
   // The example is configured with namespace "FOOD__BEVERAGE_ESTABLISHMENT__MENU_DATA.V02"
 
-  it('lists available databases', async () => {
+  it('lists available databases', async() => {
     let res = await runCli(['schema'], snowflakeDir)
     expectCliSuccess(res, 'schema list databases (snowflake)')
     let databases = parseSchemaOutput(res.stdout)
     expect(databases.length).toBeGreaterThan(0)
   })
 
-  it('lists schemas when given a database name', async () => {
+  it('lists schemas when given a database name', async() => {
     let res = await runCli(['schema', 'FOOD__BEVERAGE_ESTABLISHMENT__MENU_DATA'], snowflakeDir)
     expectCliSuccess(res, 'schema list schemas (snowflake)')
     let schemas = parseSchemaOutput(res.stdout)
@@ -94,14 +94,14 @@ describe.skipIf(!hasSnowflakeAuth)('snowflake', () => {
     expect(schemas).toContain('V02')
   })
 
-  it('lists tables in the configured namespace', async () => {
+  it('lists tables in the configured namespace', async() => {
     let res = await runCli(['schema', 'FOOD__BEVERAGE_ESTABLISHMENT__MENU_DATA.V02'], snowflakeDir)
     expectCliSuccess(res, 'schema list tables (snowflake)')
     let tables = parseSchemaOutput(res.stdout)
     expect(tables.length).toBeGreaterThan(0)
   })
 
-  it('describes a table from the namespace', async () => {
+  it('describes a table from the namespace', async() => {
     let res = await runCli(['schema', 'FOOD__BEVERAGE_ESTABLISHMENT__MENU_DATA.V02.MENUS'], snowflakeDir)
     expectCliSuccess(res, 'schema describe table (snowflake)')
     let output = res.stdout.toLowerCase()
@@ -115,14 +115,14 @@ describe.skipIf(!hasBigQueryAuth)('bigquery', () => {
     console.warn('⚠️  Skipping BigQuery schema tests: GOOGLE_APPLICATION_CREDENTIALS not set')
   }
 
-  it('lists available tables in the configured namespace', async () => {
+  it('lists available tables in the configured namespace', async() => {
     let res = await runCli(['schema'], ecommDir)
     expectCliSuccess(res, 'schema list tables (bigquery)')
     let lines = res.stdout.trim().split(/\r?\n/).filter(Boolean)
     expect(lines.length).toBeGreaterThan(0)
   })
 
-  it('describes a table from the namespace', async () => {
+  it('describes a table from the namespace', async() => {
     // First get a table name from the list
     let listRes = await runCli(['schema'], ecommDir)
     expectCliSuccess(listRes, 'schema list for describe')

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -16,11 +16,11 @@ import {mockFileMap} from './mockFiles.ts'
 // Collect Svelte compiler warnings for test assertions
 export type SvelteWarning = {code: string, message: string, filename?: string}
 export const svelteWarnings: SvelteWarning[] = []
-export function clearSvelteWarnings () { svelteWarnings.length = 0 }
+export function clearSvelteWarnings() { svelteWarnings.length = 0 }
 
 let uiRoot: string
 
-export async function serve2 (): Promise<ViteDevServer> {
+export async function serve2(): Promise<ViteDevServer> {
   let server = await createServer(await createConfig())
   // I originally added this to avoid the page refreshing immediately on load.
   // We def don't want to run it in tests, because its not safe to do in parallel.
@@ -32,7 +32,7 @@ export async function serve2 (): Promise<ViteDevServer> {
   return server
 }
 
-async function createConfig (): Promise<InlineConfig> {
+async function createConfig(): Promise<InlineConfig> {
   uiRoot = path.join(fileURLToPath(import.meta.url), '../../ui')
   let port = Number(process.env.GRAPHENE_PORT) || 4000
   await fs.ensureDir(path.resolve(config.root, 'node_modules/.graphene'))
@@ -57,7 +57,7 @@ async function createConfig (): Promise<InlineConfig> {
           }) as any,
           injectComponentImports(),
         ],
-        onwarn (warning, defaultHandler) {
+        onwarn(warning, defaultHandler) {
           if (process.env.NODE_ENV === 'test') {
             svelteWarnings.push({code: warning.code, message: warning.message, filename: warning.filename})
           }
@@ -108,7 +108,7 @@ async function createConfig (): Promise<InlineConfig> {
   }
 }
 
-async function handleQuery (req: IncomingMessage, res: ServerResponse<IncomingMessage>) {
+async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMessage>) {
   let chunks = [] as any[]
   for await (let chunk of req) chunks.push(chunk)
   let {gsql, params, hashes} = JSON.parse(Buffer.concat(chunks).toString())
@@ -141,7 +141,7 @@ async function handleQuery (req: IncomingMessage, res: ServerResponse<IncomingMe
   res.end(JSON.stringify({rows: queryResults.rows, hash, fields, sql}))
 }
 
-async function handlePage (server: ViteDevServer, res: ServerResponse<IncomingMessage>) {
+async function handlePage(server: ViteDevServer, res: ServerResponse<IncomingMessage>) {
   res.setHeader('Content-Type', 'text/html')
 
   // Use a .html URL for transformIndexHtml so Vite doesn't run the svelte plugin on our HTML template.
@@ -163,7 +163,7 @@ async function handlePage (server: ViteDevServer, res: ServerResponse<IncomingMe
 }
 
 // Runs vite's pre-bundling of dependencies. Used by tests to do this once, instead of for each worker.
-export async function prepareDeps () {
+export async function prepareDeps() {
   let cfg = await resolveConfig(await createConfig(), 'serve')
   await optimizeDeps(cfg, true)
 }
@@ -171,14 +171,14 @@ export async function prepareDeps () {
 // Svelte forces optimizeDeps whenever its own metadata has changed.
 // For tests, we already optimizeDeps before any tests start up, so we don't need this, and it causes problems
 // if multiple workers are all trying to optimizeDeps at the same time (vite isn't exactly concurrency-safe).
-function fixSvelteDepsInTests () {
+function fixSvelteDepsInTests() {
   let viteConfig: any
 
-  function configResolved (cfg:any) { viteConfig = cfg }
+  function configResolved(cfg:any) { viteConfig = cfg }
 
   // This must run AFTER Svelte's buildStart which sets force=true based on metadata changes.
   // Using enforce:'post' and sequential:true ensures we run last and can override.
-  function buildStart () {
+  function buildStart() {
     if (process.env.NODE_ENV != 'test') return
     viteConfig.optimizeDeps.force = false
   }
@@ -191,10 +191,10 @@ function fixSvelteDepsInTests () {
 // unanalyzed modules, so fixing the file produces no HMR update and the page stays broken.
 // We detect this and send a full-reload instead, since the module was never successfully loaded
 // and can't be hot-swapped.
-function fixHmrForFailedModules () {
+function fixHmrForFailedModules() {
   return {
     name: 'fix-hmr-for-failed-modules',
-    hotUpdate (this: any, {modules}: {modules: any[]}) {
+    hotUpdate(this: any, {modules}: {modules: any[]}) {
       // When a module's last transform failed, its transformResult is null. Vite's normal HMR can't
       // hot-swap a module that has no valid transform — either because it was never analyzed
       // (isSelfAccepting === undefined) or because it was previously working but is now broken.
@@ -215,10 +215,10 @@ let workspaceLoadPromise: Promise<void> | undefined
 let mdFiles: string[] = []
 const updateWorkspacePlugin = {
   name: 'updateWorkspace',
-  resolveId (id: string) {
+  resolveId(id: string) {
     if (id == 'virtual:nav') return '\0virtual:nav'
   },
-  load (id: string) {
+  load(id: string) {
     if (id != '\0virtual:nav') return
     let allFiles = [...mdFiles]
     if (process.env.NODE_ENV == 'test') {
@@ -229,7 +229,7 @@ const updateWorkspacePlugin = {
     return `export default ${JSON.stringify(allFiles)}`
   },
   configureServer: (s: ViteDevServer) => {
-    let refresh = async () => {
+    let refresh = async() => {
       clearWorkspace()
       workspaceLoadPromise = loadWorkspace(config.root, true)
       await workspaceLoadPromise
@@ -253,7 +253,7 @@ const updateWorkspacePlugin = {
 const handleRequestPlugin = {
   name: 'handleRequest',
   configureServer: (s: ViteDevServer) => {
-    s.middlewares.use(async function handleRequest (req, res, next) {
+    s.middlewares.use(async function handleRequest(req, res, next) {
       try {
         let [pathName] = (req.url || '').split('?')
         if (pathName == '/_api/query') return await handleQuery(req, res)
@@ -268,7 +268,7 @@ const handleRequestPlugin = {
         } else {
           next()
         }
-      } catch (err: any) {
+      } catch(err: any) {
         if (process.env.NODE_ENV != 'test') console.error(err) // ignore in tests because they're noisy, and any unexpected errors should be captured by browserConsole.
         res.statusCode = 500
         res.end(JSON.stringify([{message: err.message, stack: err.stack}]))
@@ -277,10 +277,10 @@ const handleRequestPlugin = {
   },
 }
 
-function mockFilesForTests () {
+function mockFilesForTests() {
   if (process.env.NODE_ENV !== 'test') return null
 
-  function toMockKey (id: string) {
+  function toMockKey(id: string) {
     // Handle both absolute paths (/wt/.../index.md) and root-relative paths (/index.md)
     return id.replace(config.root + '/', '').replace(/^\//, '')
   }
@@ -288,13 +288,13 @@ function mockFilesForTests () {
   return {
     name: 'mock-files-for-tests',
     enforce: 'pre' as const,
-    resolveId (id: any) {
+    resolveId(id: any) {
       if (!mockFileMap[toMockKey(id)]) return
       // Always resolve to the absolute path so the module graph key matches
       // what updateMockFile emits via server.watcher (needed for HMR to work).
       return path.join(config.root, toMockKey(id)) + '?mock'
     },
-    load (id: any) {
+    load(id: any) {
       if (!id.endsWith('?mock')) return null
       return mockFileMap[toMockKey(id.replace(/\?mock$/, ''))]
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,11 +1,11 @@
 import {includeIgnoreFile} from '@eslint/compat'
-import {fileURLToPath} from 'node:url'
-import globals from 'globals'
 import pluginJs from '@eslint/js'
-import tseslint from 'typescript-eslint'
-import svelte from 'eslint-plugin-svelte'
-import pluginPreferLet from 'eslint-plugin-prefer-let'
 import stylistic from '@stylistic/eslint-plugin'
+import pluginPreferLet from 'eslint-plugin-prefer-let'
+import svelte from 'eslint-plugin-svelte'
+import globals from 'globals'
+import {fileURLToPath} from 'node:url'
+import tseslint from 'typescript-eslint'
 import * as zxGlobals from 'zx'
 
 /** @type {import('eslint').Linter.Config[]} */
@@ -27,8 +27,8 @@ export default [
       },
     },
     rules: {
-      'no-console':           'off',  // allow console in scripts
-      'no-unused-expressions':'off',  // permit `$\`…\`` template tags
+      'no-console': 'off', // allow console in scripts
+      'no-unused-expressions': 'off', // permit `$\`…\`` template tags
     },
   },
   {
@@ -84,7 +84,7 @@ export default [
       '@typescript-eslint/no-unused-vars': ['error', {argsIgnorePattern: '^_', varsIgnorePattern: '^_'}],
       '@typescript-eslint/consistent-type-imports': ['error', {prefer: 'type-imports', fixStyle: 'inline-type-imports'}],
       '@stylistic/padded-blocks': ['error', 'never'],
-      '@stylistic/space-before-function-paren': ['error', 'always'],
+      '@stylistic/space-before-function-paren': ['error', 'never'],
       '@stylistic/space-in-parens': ['error', 'never'],
       '@stylistic/object-curly-spacing': ['error', 'never'],
       '@stylistic/space-infix-ops': ['error'],

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -26,7 +26,7 @@ let analysisStack = new Set<Column>() // Track computed columns being analyzed t
 let NODE_ENTITY_MAP = new NodeWeakMap<any>() // Points syntax nodes back to entities for ide hover tips
 
 // Creates tables without analyzing them.
-export function findTables (fi: FileInfo) {
+export function findTables(fi: FileInfo) {
   let tn = fi.tree!.topNode
   fi.tables = []
   let nodes = tn.getChildren('TableStatement').concat(tn.getChildren('ViewStatement'))
@@ -53,7 +53,7 @@ export function findTables (fi: FileInfo) {
 }
 
 // `extend` blocks add columns and joins to existing tables
-export function applyExtends (fi: FileInfo) {
+export function applyExtends(fi: FileInfo) {
   fi.tree!.topNode.getChildren('ExtendStatement').forEach(node => {
     let target = lookupTable(node.getChild('Ref')!)
     if (!target) return
@@ -62,7 +62,7 @@ export function applyExtends (fi: FileInfo) {
   })
 }
 
-function addColumn (table: Table, node: SyntaxNode) {
+function addColumn(table: Table, node: SyntaxNode) {
   let name = txt(node.getChild('ColumnName'))
   let type = convertDataType(txt(node.getChild('DataType')))
   if (!type) return diag(node, `Unsupported data type: ${txt(node.getChild('DataType'))}`)
@@ -71,7 +71,7 @@ function addColumn (table: Table, node: SyntaxNode) {
   table.columns.push(col)
 }
 
-function addJoin (table: Table, node: SyntaxNode) {
+function addJoin(table: Table, node: SyntaxNode) {
   let aliasNode = node.getChild('Alias') || node.getChild('Ref')!.getChildren('Identifier').pop()
   let alias = txt(aliasNode)
 
@@ -88,21 +88,21 @@ function addJoin (table: Table, node: SyntaxNode) {
   table.joins.push(join)
 }
 
-function addComputedColumn (table: Table, node: SyntaxNode) {
+function addComputedColumn(table: Table, node: SyntaxNode) {
   let name = txt(node.getChild('Alias'))
   let col: Column = {name, type: 'string', exprNode: node.getChild('Expression')!, metadata: extractLeadingMetadata(node)}
   if (getField(name, table)) return diag(node, `Table already has a field called "${name}"`)
   table.columns.push(col)
 }
 
-function getField (name: string, table: Table) {
+function getField(name: string, table: Table) {
   return table.columns.find(c => c.name == name) || table.joins.find(j => j.alias == name)
 }
 
 // Analyze a view's underlying query to determine its output columns.
 // Converts a PhysicalTable with a QueryStatement into a ViewTable with a query.
 // Returns true if the table is (or was already) a successfully analyzed view.
-function analyzeView (table: Table) {
+function analyzeView(table: Table) {
   if (table.type != 'view') return
   if (table.query) return // already analyzed
   let query = analyzeQuery(table.syntaxNode!.getChild('QueryStatement')!)
@@ -112,7 +112,7 @@ function analyzeView (table: Table) {
 }
 
 // Analyze everything in a table - used for full project analysis (e.g., `check` command)
-export function analyzeTableFully (table: Table) {
+export function analyzeTableFully(table: Table) {
   if (table.type == 'view') analyzeView(table)
   let scope: Scope = {table, alias: table.name}
   table.columns.forEach(c => {
@@ -126,7 +126,7 @@ export function analyzeTableFully (table: Table) {
 // Expand non-aggregate columns into query fields.
 // When table is provided, expands that single table's columns.
 // When table is null, expands all root-visible query tables (base + ad-hoc joins).
-function expandColumns (table: Table | null, alias: string, query: Query, scope: Scope, namePrefix = '') {
+function expandColumns(table: Table | null, alias: string, query: Query, scope: Scope, namePrefix = '') {
   if (!table) {
     let baseJoin = query.joins.find(j => j.source == 'from')
     if (!baseJoin?.table) return
@@ -151,7 +151,7 @@ function expandColumns (table: Table | null, alias: string, query: Query, scope:
 }
 
 // Main query analysis - analyzes and returns a Query with computed SQL
-export function analyzeQuery (queryNode: SyntaxNode, outerCtes?: Table[]): Query | void {
+export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query | void {
   let query: Query = {sql: '', fields: [], joins: [], filters: [], groupBy: [], orderBy: [], isAggregate: false}
   let ctes = new Map<string, CteTable>()
   let scope: Scope = {query, alias: '', otherTables: outerCtes || []}
@@ -307,13 +307,13 @@ export function analyzeQuery (queryNode: SyntaxNode, outerCtes?: Table[]): Query
 
 // Assemble query parts into final SQL
 // Format a table path for the current dialect
-function formatTablePath (path: string): string {
+function formatTablePath(path: string): string {
   if (config.dialect === 'bigquery') return `\`${path}\``
   if (config.dialect === 'snowflake') return path.toUpperCase()
   return path
 }
 
-function buildSql (query: Query, cteMap: Map<string, CteTable>): string {
+function buildSql(query: Query, cteMap: Map<string, CteTable>): string {
   let ctes: string[] = [...cteMap.values()].map(c => `${quote(c.name)} as ( ${c.query.sql} )`)
   let selectParts = query.fields.map(f => `${f.sql} as ${quote(f.name)}`)
   let baseJoin = query.joins.find(j => j.source == 'from')
@@ -321,7 +321,7 @@ function buildSql (query: Query, cteMap: Map<string, CteTable>): string {
   // No FROM clause (e.g. `select 1`)
   if (!baseJoin?.table) return `SELECT ${selectParts.join(', ')}`
 
-  function renderTableRef (table: Table): string {
+  function renderTableRef(table: Table): string {
     if (table.type === 'view') {
       if (!ctes.some(c => c.startsWith(quote(table.name) + ' '))) {
         ctes.push(`${quote(table.name)} as ( ${table.query.sql} )`)
@@ -359,7 +359,7 @@ function buildSql (query: Query, cteMap: Map<string, CteTable>): string {
 }
 
 // Analyze an expression node and return SQL + type info
-export function analyzeExpr (node: SyntaxNode, scope: Scope): Expr {
+export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
   if (node.type.isError) return diag(node, 'Invalid expression', {sql: 'NULL', type: 'error'})
 
   switch (node.name) {
@@ -641,7 +641,7 @@ export function analyzeExpr (node: SyntaxNode, scope: Scope): Expr {
   }
 }
 
-function analyzeDateArithmetic (op: '+' | '-', left: Expr, right: Expr, node: SyntaxNode): Expr {
+function analyzeDateArithmetic(op: '+' | '-', left: Expr, right: Expr, node: SyntaxNode): Expr {
   // date - date = interval
   if ((left.type == 'date' || left.type == 'timestamp') && (right.type == 'date' || right.type == 'timestamp')) {
     if (op != '-') return diag(node, 'Can only subtract dates', {sql: 'NULL', type: 'error'})
@@ -669,7 +669,7 @@ function analyzeDateArithmetic (op: '+' | '-', left: Expr, right: Expr, node: Sy
   return diag(node, 'Invalid date arithmetic', {sql: 'NULL', type: 'error'})
 }
 
-function coerceToTemporal (expr: Expr, targetType: 'date' | 'timestamp', node: SyntaxNode): Expr {
+function coerceToTemporal(expr: Expr, targetType: 'date' | 'timestamp', node: SyntaxNode): Expr {
   // Extract the string literal value (remove quotes)
   let match = expr.sql.match(/^'(.+)'$/)
   if (!match) return expr
@@ -678,7 +678,7 @@ function coerceToTemporal (expr: Expr, targetType: 'date' | 'timestamp', node: S
   return {sql: `${targetType.toUpperCase()} '${parsed.literal}'`, type: targetType}
 }
 
-function renderOverClause (overClause: SyntaxNode, scope: Scope): string {
+function renderOverClause(overClause: SyntaxNode, scope: Scope): string {
   let spec = overClause.getChild('WindowSpec')
   if (!spec) return ''
   let parts: string[] = []
@@ -705,7 +705,7 @@ function renderOverClause (overClause: SyntaxNode, scope: Scope): string {
   return parts.join(' ')
 }
 
-function renderWindowFrame (frame: SyntaxNode, scope: Scope): string {
+function renderWindowFrame(frame: SyntaxNode, scope: Scope): string {
   let mode = txt(frame.getChildren('Kw')[0]).toUpperCase()
   let between = frame.getChild('WindowFrameBetween')
   if (between) {
@@ -716,7 +716,7 @@ function renderWindowFrame (frame: SyntaxNode, scope: Scope): string {
   return `${mode} ${renderWindowBound(start, scope)}`
 }
 
-function renderWindowBound (bound: SyntaxNode, scope: Scope): string {
+function renderWindowBound(bound: SyntaxNode, scope: Scope): string {
   let kws = bound.getChildren('Kw').map(k => txt(k).toLowerCase())
   if (kws.includes('unbounded')) {
     return `UNBOUNDED ${kws.includes('following') ? 'FOLLOWING' : 'PRECEDING'}`
@@ -727,7 +727,7 @@ function renderWindowBound (bound: SyntaxNode, scope: Scope): string {
 }
 
 // Traverse a join path (like `tableA.tableB.`), returning a new scope pointing to the target table. Adds implied joins to the query as it goes
-function followJoins (pathNodes: SyntaxNode[], scope: Scope): Scope | null {
+function followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
   let part = pathNodes[0]
   let name = txt(part)
 
@@ -795,7 +795,7 @@ function followJoins (pathNodes: SyntaxNode[], scope: Scope): Scope | null {
 }
 
 // Find a table by Ref node, failing if it doesn't exist
-function lookupTable (node: SyntaxNode, scope?: Scope): Table | undefined {
+function lookupTable(node: SyntaxNode, scope?: Scope): Table | undefined {
   let name = txt(node)
   let table: Table | undefined
 
@@ -815,7 +815,7 @@ function lookupTable (node: SyntaxNode, scope?: Scope): Table | undefined {
   return table
 }
 
-function inferName (exprNode: SyntaxNode, scope: Scope): string {
+function inferName(exprNode: SyntaxNode, scope: Scope): string {
   if (exprNode.name == 'Ref') {
     return exprNode.getChildren('Identifier').map(i => txt(i)).join('_')
   }
@@ -823,7 +823,7 @@ function inferName (exprNode: SyntaxNode, scope: Scope): string {
 }
 
 // TODO: do we still need this?
-function unpackAnds (node: SyntaxNode, scope: Scope): Expr[] {
+function unpackAnds(node: SyntaxNode, scope: Scope): Expr[] {
   if (node.name == 'BinaryExpression') {
     let op = txt(node.firstChild?.nextSibling).toLowerCase()
     if (op == 'and') {
@@ -833,21 +833,21 @@ function unpackAnds (node: SyntaxNode, scope: Scope): Expr[] {
   return [analyzeExpr(node, scope)]
 }
 
-export function clearWorkspace () {
+export function clearWorkspace() {
   Object.keys(FILE_MAP).forEach(k => delete FILE_MAP[k])
   diagnostics = []
 }
 
-export function clearDiagnostics () { diagnostics = [] }
-export function getNodeEntity (node: SyntaxNode) { return NODE_ENTITY_MAP.get(node) }
+export function clearDiagnostics() { diagnostics = [] }
+export function getNodeEntity(node: SyntaxNode) { return NODE_ENTITY_MAP.get(node) }
 
-export function recordSyntaxErrors (fi: FileInfo) {
+export function recordSyntaxErrors(fi: FileInfo) {
   fi.tree!.topNode.cursor().iterate(n => {
     if (n.type.isError) diag(n.node, 'Syntax error')
   })
 }
 
-export function diag<T> (node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T {
+export function diag<T>(node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T {
   let file = getFile(node)
   let from = getPosition(node.from, file)
   let to = getPosition(node.to, file)
@@ -855,7 +855,7 @@ export function diag<T> (node: SyntaxNode | SyntaxNodeRef, message: string, defa
   return defaultReturn as T
 }
 
-export function checkTypes (expr: Expr, expected: FieldType[], node: SyntaxNode) {
+export function checkTypes(expr: Expr, expected: FieldType[], node: SyntaxNode) {
   if (expr.type == 'error' || expr.type == 'null') return
   if (expected.includes(expr.type)) return
   diag(node, `Expected ${expected.join(' or ')}, got ${expr.type}`)
@@ -865,7 +865,7 @@ export function checkTypes (expr: Expr, expected: FieldType[], node: SyntaxNode)
 // On the one hand, it often makes type checking easier, since it normalizes things that can be implicitly cast to match,
 // and gives simpler types to the frontend.
 // On the other, it obscures the actual types in cases where they might be relevant, like function signature matching.
-function convertDataType (dataType: string): FieldType | null {
+function convertDataType(dataType: string): FieldType | null {
   switch (dataType.toUpperCase()) {
     case 'INT': case 'INT64': case 'NUMBER': case 'INTEGER': case 'NUMERIC': case 'FLOAT': case 'FLOAT64':
     case 'DECIMAL': case 'DOUBLE': case 'BIGINT': case 'SMALLINT': case 'TINYINT': case 'BYTEINT': case 'BIGDECIMAL':
@@ -884,12 +884,12 @@ function convertDataType (dataType: string): FieldType | null {
 }
 
 // Quote an identifier for the current dialect
-function quote (name: string): string {
+function quote(name: string): string {
   if (config.dialect === 'bigquery') return `\`${name}\``
   return `"${name}"`
 }
 
-function quoteColumn (name: string): string {
+function quoteColumn(name: string): string {
   if (config.dialect === 'bigquery') return `\`${name}\``
   if (config.dialect === 'snowflake') return `"${name.toUpperCase()}"`
   return `"${name}"`

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -35,7 +35,7 @@ export type ConfigInput = Omit<Config, 'dialect' | 'ignoredFiles' | 'envFile'> &
 
 export let config: Config = {dialect: 'duckdb', root: ''} as Config
 
-export function setConfig (cfg: ConfigInput) {
+export function setConfig(cfg: ConfigInput) {
   if (cfg.namespace && !cfg.defaultNamespace) cfg.defaultNamespace = cfg.namespace
   let dialect = cfg.dialect || 'duckdb'
   if (cfg.bigquery) dialect = 'bigquery'
@@ -50,7 +50,7 @@ export function setConfig (cfg: ConfigInput) {
 }
 
 // Read graphene config out of package.json
-export function loadConfig (dir:string, envLoader?: (envFiles: string[] | string) => void) {
+export function loadConfig(dir:string, envLoader?: (envFiles: string[] | string) => void) {
   if (config.root) return
 
   let packageJsonObject = {} as any

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -13,26 +13,26 @@ import {parseMarkdown} from './markdown.ts'
 export {clearWorkspace}
 export {config, loadConfig}
 export type {Query, Table, Diagnostic} from './types.ts'
-export function getTable (name: string) { return Object.values(FILE_MAP).flatMap(f => f.tables).find(t => t.name == name) }
-export function getFile (name: string) { return FILE_MAP[name] }
-export function getFiles () { return Object.values(FILE_MAP) }
-export function getDiagnostics () { return diagnostics }
+export function getTable(name: string) { return Object.values(FILE_MAP).flatMap(f => f.tables).find(t => t.name == name) }
+export function getFile(name: string) { return FILE_MAP[name] }
+export function getFiles() { return Object.values(FILE_MAP) }
+export function getDiagnostics() { return diagnostics }
 
 // Loads and parses all gsql files within a directory
-export async function loadWorkspace (dir: string, includeMd: boolean) {
+export async function loadWorkspace(dir: string, includeMd: boolean) {
   let ignore = ['node_modules/**', '**/.*/**', ...config.ignoredFiles]
   let files = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore, follow: false})
   for await (let file of files) {
     try {
       let contents = await readFile(path.join(dir, file), 'utf-8')
       updateFile(contents, file)
-    } catch (e: any) {
+    } catch(e: any) {
       console.error('Failed to read file', file, e.message)
     }
   }
 }
 
-export function updateFile (contents: string, path: string) {
+export function updateFile(contents: string, path: string) {
   FILE_MAP[path] ||= {path, contents, tree: null, tables: [], queries: []}
   FILE_MAP[path].contents = contents
   FILE_MAP[path].tree = null
@@ -40,7 +40,7 @@ export function updateFile (contents: string, path: string) {
 }
 
 // Analyze all files in the workspace. If content is provided, it's added as a virtual 'input' file and its queries are returned.
-export function analyze (contents?: string, contentType?: 'gsql' | 'md'): Query[] {
+export function analyze(contents?: string, contentType?: 'gsql' | 'md'): Query[] {
   clearDiagnostics()
 
   delete FILE_MAP['input']
@@ -67,13 +67,13 @@ export function analyze (contents?: string, contentType?: 'gsql' | 'md'): Query[
   return []
 }
 
-export function toSql (query: Query, params: Record<string, any> = {}): string {
+export function toSql(query: Query, params: Record<string, any> = {}): string {
   query = structuredClone(query)
   fillInParams(query, params)
   return query.sql
 }
 
-export function getHover (path: string, line: number, col: number): string {
+export function getHover(path: string, line: number, col: number): string {
   let fi = FILE_MAP[path]
   let offset = getOffset(line, col, fi)
 

--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -16,26 +16,26 @@ interface Overload {
 }
 
 // Convert a FunctionDef arg type string (e.g. 'number', 'T', 'string...', 'kw') to allowedTypes
-function parseArgType (typeStr: string): {type: FieldType | 'sql native', rawType?: string}[] {
+function parseArgType(typeStr: string): {type: FieldType | 'sql native', rawType?: string}[] {
   let base = typeStr.replace(/[?.]/g, '')
   if (base === 'kw') return [{type: 'sql native', rawType: 'kw'}]
   if (base === 'T' || base === 'any') return [{type: 'string'}, {type: 'number'}, {type: 'boolean'}, {type: 'date'}, {type: 'timestamp'}, {type: 'json'}]
   return [{type: base as FieldType}]
 }
 
-function getArgInfo (arg: ArgDef): {name: string, type: string} {
+function getArgInfo(arg: ArgDef): {name: string, type: string} {
   let [name, type] = Array.isArray(arg) ? [arg[0], arg[1]] : [arg.name, arg.type]
   return {name, type: Array.isArray(type) ? type[0] : type}
 }
 
-function parseArgTypes (arg: ArgDef): {type: FieldType | 'sql native', rawType?: string}[] {
+function parseArgTypes(arg: ArgDef): {type: FieldType | 'sql native', rawType?: string}[] {
   let type = Array.isArray(arg) ? arg[1] : arg.type
   if (Array.isArray(type)) return type.map(t => ({type: t as FieldType}))
   return parseArgType(type)
 }
 
 // Convert a FunctionDef into one or more Overloads (optional args expand into multiple overloads)
-function convertDef (def: FunctionDef): Overload[] {
+function convertDef(def: FunctionDef): Overload[] {
   let expressionType: 'aggregate' | 'window' | 'scalar' = 'scalar'
   if (def.aggregate) expressionType = 'aggregate'
   else if (def.window) expressionType = 'window'
@@ -60,7 +60,7 @@ function convertDef (def: FunctionDef): Overload[] {
 }
 
 // Build a name -> Overload[] map from a FunctionDef array
-function buildMap (defs: FunctionDef[]): Record<string, Overload[]> {
+function buildMap(defs: FunctionDef[]): Record<string, Overload[]> {
   let map: Record<string, Overload[]> = {}
   for (let def of defs) {
     let overloads = convertDef(def)
@@ -79,7 +79,7 @@ let dialectMaps: Record<string, Record<string, Overload[]>> = {
   snowflake: buildMap(snowflakeFunctions),
 }
 
-function findOverloads (name: string, dialect: string): Overload[] {
+function findOverloads(name: string, dialect: string): Overload[] {
   let map = dialectMaps[dialect] || dialectMaps['duckdb']
   return map[name.toLowerCase()] || []
 }
@@ -90,7 +90,7 @@ function findOverloads (name: string, dialect: string): Overload[] {
 
 type AnalyzeExprFn = (node: SyntaxNode, scope: Scope) => Expr
 
-export function analyzeFunction (node: SyntaxNode, scope: Scope, analyzeExpr: AnalyzeExprFn): Expr {
+export function analyzeFunction(node: SyntaxNode, scope: Scope, analyzeExpr: AnalyzeExprFn): Expr {
   let name = txt(node.getChild('Identifier')).toLowerCase()
   let argNodes = node.getChildren('Expression')
 
@@ -144,7 +144,7 @@ export function analyzeFunction (node: SyntaxNode, scope: Scope, analyzeExpr: An
   return {sql, type: returnType, isAgg, canWindow}
 }
 
-function analyzePercentile (node: SyntaxNode, args: Expr[], digits: string): Expr {
+function analyzePercentile(node: SyntaxNode, args: Expr[], digits: string): Expr {
   let frac = Number(`0.${digits}`)
   if (Number(digits) == 100) return diag(node, 'p100 is not allowed', {sql: 'NULL', type: 'error'})
   if (Number(digits) == 0) return diag(node, 'p0 is not allowed', {sql: 'NULL', type: 'error'})

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -61,7 +61,7 @@ const testTables = `
 `
 
 describe('lang', () => {
-  beforeAll(async () => {
+  beforeAll(async() => {
     await prepareEcommerceTables()
   })
 
@@ -72,7 +72,7 @@ describe('lang', () => {
   })
 
 
-  it('imports all keywords as tokens', async () => {
+  it('imports all keywords as tokens', async() => {
     // Every keyword used via Kw<"..."> in the grammar must be in the specializeIdentifier keyword map in tokens.js.
     // Without this, those keywords would only parse in lowercase (the inline spec_Identifier table is exact-match).
     // We have a test because it's easy to add keywords and forget to add them to tokens, causing the parsing to break if you use the uppercase version of a keyword
@@ -85,14 +85,14 @@ describe('lang', () => {
     expect(missing, 'Keywords in grammar but missing from tokens.js specializeIdentifier').toEqual([])
   })
 
-  it('handles basic select query', async () => {
+  it('handles basic select query', async() => {
     expect('from users select id, name where id = 1')
       .toRenderSql('SELECT users."id" as "id", users."name" as "name" from users as users WHERE users."id"=1')
     await expect('from users select id, name where id = 1')
       .toReturnRows([1, 'Alice'])
   })
 
-  it('handles select 1 without from', async () => {
+  it('handles select 1 without from', async() => {
     expect('select 1')
       .toRenderSql('SELECT 1 as "col_0"')
     await expect('select 1')
@@ -116,7 +116,7 @@ describe('lang', () => {
     expect('from raw.users select id').toRenderSql('select users."id" as "id" from raw.users as users')
   })
 
-  it('ignores workspace files matched by ignoredFiles globs', async () => {
+  it('ignores workspace files matched by ignoredFiles globs', async() => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-workspace-ignore-'))
 
     try {
@@ -230,7 +230,7 @@ describe('lang', () => {
       .toRenderSql('with "active_users" as ( select users."id" as "id", users."name" as "name" from users as users ) select active_users."name" as "active_users_name" from orders as orders inner join active_users as active_users on active_users."id"=orders."user_id"')
   })
 
-  it('expands measures', async () => {
+  it('expands measures', async() => {
     expect('from users select name, total_orders')
       .toRenderSql('select users."name" as "name", (count(distinct orders."id")) as "total_orders" from users as users left join orders as orders on orders."user_id"=users."id" group by 1 order by 2 desc nulls last')
 
@@ -238,7 +238,7 @@ describe('lang', () => {
       .toReturnRows(['Alice', 2], ['Bob', 1])
   })
 
-  it('handles expressions with aggregates', async () => {
+  it('handles expressions with aggregates', async() => {
     expect('from orders select user_id, avg_order_value')
       .toRenderSql('select orders."user_id" as "user_id", (sum(orders."amount")/count(1)) as "avg_order_value" from orders as orders group by 1 order by 2 desc nulls last')
 
@@ -246,14 +246,14 @@ describe('lang', () => {
       .toReturnRows([2, 40], [1, 30])
   })
 
-  it('preserves parentheses in expressions for correct operator precedence', async () => {
+  it('preserves parentheses in expressions for correct operator precedence', async() => {
     expect('from users select (age + age) / (age + age) as result')
       .toRenderSql('select (users."age"+users."age")/(users."age"+users."age") as "result" from users as users')
     await expect('from users select (1 + 2) / (1 + 2) as result limit 1')
       .toReturnRows([1])
   })
 
-  it('supports || string concatenation', async () => {
+  it('supports || string concatenation', async() => {
     expect("from users select name || ' suffix' as result")
       .toRenderSql('select users."name"||\' suffix\' as "result" from users as users')
     await expect("from users select name || '!' as result limit 1")
@@ -307,7 +307,7 @@ describe('lang', () => {
       .toRenderSql('select orders."id" as "id", sum(orders."amount") OVER (ORDER BY orders."id" ASC RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) as "tail_sum" from orders as orders')
   })
 
-  it('executes lag window functions correctly', async () => {
+  it('executes lag window functions correctly', async() => {
     await expect(`
       from orders
       select
@@ -332,7 +332,7 @@ describe('lang', () => {
       .toRenderSql('select (((sum(orders."amount"))+(sum(orders."amount")/count(1)))/((sum(orders."amount"))+(sum(orders."amount")/count(1)))) as "rate" from orders as orders')
   })
 
-  it('supports percentile aggregates via pXX shorthand', async () => {
+  it('supports percentile aggregates via pXX shorthand', async() => {
     await expect('from orders select p10(amount) as min_amt, p50(amount) as median_amt, p999(amount) as max_amt')
       .toReturnRows([24, 40, 40])
   })
@@ -357,7 +357,7 @@ describe('lang', () => {
   // Skipped: computed columns accessed through joins are not fully expanded yet.
   // The view's computed column (orders.total_revenue) needs to be expanded when rendering
   // the CTE, but currently we treat it as a regular column reference.
-  it.skip('supports "table as" (aka view) queries', async () => {
+  it.skip('supports "table as" (aka view) queries', async() => {
     updateFile(`
       table users (
         id int
@@ -414,7 +414,7 @@ describe('lang', () => {
       .toRenderSql('select users."id" as "id", orders."id" as "orders_id" from dataset.users as users left join dataset.orders as orders on users."id"=orders."user_id"')
   })
 
-  it('extends derived tables with additional measures', async () => {
+  it('extends derived tables with additional measures', async() => {
     updateFile(`${testTables}
       table user_facts as (from users select id, total_orders)
       extend user_facts (repeat_buyer: total_orders > 1)
@@ -424,7 +424,7 @@ describe('lang', () => {
       .toReturnRows([1, 2, true], [2, 1, false])
   })
 
-  it('emits CTE for views referenced through joins', async () => {
+  it('emits CTE for views referenced through joins', async() => {
     updateFile(`${testTables}
       table order_stats as (from orders select user_id, sum(amount) as total_spent)
       extend users (join one order_stats on order_stats.user_id = id)
@@ -467,17 +467,17 @@ describe('lang', () => {
       .toRenderSql('select users."name" as "name", users."email" as "email" from users as users group by 2,1 order by 2 asc, 1 asc nulls last')
   })
 
-  it('supports having clause with aggregate', async () => {
+  it('supports having clause with aggregate', async() => {
     await expect('from users select name, sum(payments.amount) as amt group by name having amt > 50')
       .toReturnRows(['Alice', 100])
   })
 
-  it('supports post-agg filters without the need for "having"', async () => {
+  it('supports post-agg filters without the need for "having"', async() => {
     await expect('from users select name, sum(payments.amount) as amt where amt > 50 group by name')
       .toReturnRows(['Alice', 100])
   })
 
-  it('supports order by with direction', async () => {
+  it('supports order by with direction', async() => {
     await expect('from users select name, total_orders order by total_orders desc')
       .toReturnRows(['Alice', 2], ['Bob', 1])
   })
@@ -492,7 +492,7 @@ describe('lang', () => {
       .toHaveDiagnostic(/Unknown field in ORDER BY: nonexistent/i)
   })
 
-  it('supports limit clause', async () => {
+  it('supports limit clause', async() => {
     await expect('from users select name order by name asc limit 1')
       .toReturnRows(['Alice'])
   })
@@ -1219,7 +1219,7 @@ describe('lang', () => {
       .toRenderSql('select users."id" as "id" from users as users where users."age">(select avg(users."age") as "col_0" from users as users)')
   })
 
-  it('supports CTEs', async () => {
+  it('supports CTEs', async() => {
     let q = `with
       high_value as (from orders where amount >= 40 select id, user_id, amount),
       hv_users as (from high_value select user_id)

--- a/lang/markdown.ts
+++ b/lang/markdown.ts
@@ -43,7 +43,7 @@ interface AttrMatch {
   start: number
 }
 
-export function parseMarkdown (fi: FileInfo) {
+export function parseMarkdown(fi: FileInfo) {
   let source = fi.contents
   let fences = collectFences(source)
   let components = collectComponents(source, fences)
@@ -153,7 +153,7 @@ export function parseMarkdown (fi: FileInfo) {
   return parser.parse(doc)
 }
 
-function collectFences (source: string): FenceMatch[] {
+function collectFences(source: string): FenceMatch[] {
   let matches: FenceMatch[] = []
   GSQL_FENCE.lastIndex = 0
   let match: RegExpExecArray | null
@@ -171,7 +171,7 @@ function collectFences (source: string): FenceMatch[] {
   return matches
 }
 
-function collectComponents (source: string, fences: FenceMatch[]): ComponentMatch[] {
+function collectComponents(source: string, fences: FenceMatch[]): ComponentMatch[] {
   let matches: ComponentMatch[] = []
   COMPONENT_TAG.lastIndex = 0
   let match: RegExpExecArray | null
@@ -189,13 +189,13 @@ function collectComponents (source: string, fences: FenceMatch[]): ComponentMatc
   return matches
 }
 
-function extractFenceName (header: string): string | undefined {
+function extractFenceName(header: string): string | undefined {
   let parts = header.trim().split(/\s+/)
   if (parts.length > 1) return parts[1]
   return undefined
 }
 
-function extractAttributes (fragment: string, baseStart: number): Record<string, AttrMatch> {
+function extractAttributes(fragment: string, baseStart: number): Record<string, AttrMatch> {
   let attrs: Record<string, AttrMatch> = {}
   ATTRIBUTE.lastIndex = 0
   let match: RegExpExecArray | null
@@ -208,10 +208,10 @@ function extractAttributes (fragment: string, baseStart: number): Record<string,
   return attrs
 }
 
-function isInsideFence (offset: number, fences: FenceMatch[]) {
+function isInsideFence(offset: number, fences: FenceMatch[]) {
   return fences.some(f => offset >= f.start && offset < f.end)
 }
 
-function isFence (event: FenceMatch | ComponentMatch): event is FenceMatch {
+function isFence(event: FenceMatch | ComponentMatch): event is FenceMatch {
   return (event as FenceMatch).content !== undefined
 }

--- a/lang/metadata.ts
+++ b/lang/metadata.ts
@@ -8,7 +8,7 @@ import {getFile} from './util.ts'
 // - Description lines use plain `-- text` and are concatenated (space-separated).
 // - Key-value metadata lines use `--# key=value` and populate metadata[key] = value.
 // - If the node is not the first token on its line, ignore leading comments (prevents one comment from applying to multiple fields on the same line).
-export function extractLeadingMetadata (node: SyntaxNode): Record<string, string> {
+export function extractLeadingMetadata(node: SyntaxNode): Record<string, string> {
   // 1) Locate the raw file text and find the end of the line immediately above the node
   let src = getFile(node).contents
   if (!src) return {}

--- a/lang/params.ts
+++ b/lang/params.ts
@@ -3,11 +3,11 @@ import {parseTemporalLiteral} from './temporalLiterals.ts'
 
 // Fill in parameter values in a query's SQL strings
 // Params look like $paramName in the SQL
-export function fillInParams (query: Query, params: Record<string, any>) {
+export function fillInParams(query: Query, params: Record<string, any>) {
   query.sql = replaceParams(query.sql, params)
 }
 
-function replaceParams (sql: string, params: Record<string, any>): string {
+function replaceParams(sql: string, params: Record<string, any>): string {
   // Alternation: match single-quoted strings (including escaped '') first, then $params.
   // When we match a quoted string the capture group is undefined, so we return it unchanged.
   return sql.replace(/'(?:[^']|'')*'|\$(\w+)/g, (match, name) => {

--- a/lang/temporalLiterals.ts
+++ b/lang/temporalLiterals.ts
@@ -8,7 +8,7 @@ export type TemporalLiteral = {
   type: Extract<FieldType, 'date' | 'timestamp'>
 }
 
-export function parseTemporalLiteral (value: string, expected: string): TemporalLiteral | null {
+export function parseTemporalLiteral(value: string, expected: string): TemporalLiteral | null {
   let raw = (value ?? '').trim()
   if (!raw) return null
 
@@ -91,7 +91,7 @@ export interface IntervalLiteral {
   unit: TimestampUnit
 }
 
-export function parseIntervalLiteral (value: string): IntervalLiteral | null {
+export function parseIntervalLiteral(value: string): IntervalLiteral | null {
   let raw = (value ?? '').trim().toLowerCase().replace(/\s+/g, ' ')
   if (!raw) return null
   let match = raw.match(/^(-?\d+(?:\.\d+)?)\s+([a-z]+)$/)
@@ -103,11 +103,11 @@ export function parseIntervalLiteral (value: string): IntervalLiteral | null {
   return {quantity, unit}
 }
 
-export function parseIntervalUnit (value: string): TimestampUnit | null {
+export function parseIntervalUnit(value: string): TimestampUnit | null {
   return INTERVAL_UNITS[value.toLowerCase()] || null
 }
 
-function buildResult (
+function buildResult(
   year: number,
   month: number,
   day: number,
@@ -127,17 +127,17 @@ function buildResult (
   }
 }
 
-function inRange (value: number, min: number, max: number) {
+function inRange(value: number, min: number, max: number) {
   return Number.isInteger(value) && value >= min && value <= max
 }
 
-function isValidDate (year: number, month: number, day: number) {
+function isValidDate(year: number, month: number, day: number) {
   if (!inRange(month, 1, 12)) return false
   if (!inRange(day, 1, 31)) return false
   let date = new Date(Date.UTC(year, month - 1, day))
   return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
 }
 
-function pad (value: number) {
+function pad(value: number) {
   return value.toString().padStart(2, '0')
 }

--- a/lang/testHelpers.ts
+++ b/lang/testHelpers.ts
@@ -53,7 +53,7 @@ const ECOMM_SETUP = `
     (501, 2, '2024-01-12', 50);
 `
 
-function codeFrame (source: string, from: number, to: number): string {
+function codeFrame(source: string, from: number, to: number): string {
   let lineStart = source.lastIndexOf('\n', Math.max(0, from - 1)) + 1
   let lineEnd = source.indexOf('\n', to)
   let end = lineEnd === -1 ? source.length : lineEnd
@@ -64,7 +64,7 @@ function codeFrame (source: string, from: number, to: number): string {
   return `${lineText}\n${marker}`
 }
 
-function formatDiagnostics (source: string, diagnostics: Diagnostic[]): string {
+function formatDiagnostics(source: string, diagnostics: Diagnostic[]): string {
   if (!diagnostics.length) return ''
   return diagnostics.map((d, i) => {
     let frame = codeFrame(source, d.from.offset, d.to.offset)
@@ -74,7 +74,7 @@ function formatDiagnostics (source: string, diagnostics: Diagnostic[]): string {
 
 let conn: DuckDBConnection
 
-export async function prepareEcommerceTables () {
+export async function prepareEcommerceTables() {
   let db = await DuckDBInstance.create(':memory:')
   conn = await db.connect()
   await conn.run(ECOMM_SETUP)
@@ -82,13 +82,13 @@ export async function prepareEcommerceTables () {
 
 // small delay to allow debugger to attach, since vitest doesn't support --inspect-wait
 if (process.env.GRAPHENE_DEBUG) {
-  beforeAll(async () => {
+  beforeAll(async() => {
     await new Promise((resolve) => setTimeout(resolve, 1000))
   })
 }
 
 vitestExpect.extend({
-  toRenderSql (received: string, expectedSql: string, opts: {preserveCase?: boolean} = {}) {
+  toRenderSql(received: string, expectedSql: string, opts: {preserveCase?: boolean} = {}) {
     let content = trimIndentation(received)
     let queries = analyze(content, content.includes('```') ? 'md' : 'gsql')
     let errors = getDiagnostics().filter(d => d.severity === 'error')
@@ -100,7 +100,7 @@ vitestExpect.extend({
       }
     }
 
-    function normalizeSql (s: string) {
+    function normalizeSql(s: string) {
       if (!opts.preserveCase) s = s.toLowerCase()
       return s.replace(/[\s\n]+/g, ' ').replace(/\s+$/, '')
     }
@@ -117,7 +117,7 @@ vitestExpect.extend({
     }
   },
 
-  async toReturnRows (received: string, ...expectedRows: unknown[][]) {
+  async toReturnRows(received: string, ...expectedRows: unknown[][]) {
     let content = trimIndentation(received)
     let queries = analyze(content, content.includes('```') ? 'md' : 'gsql')
     let errors = getDiagnostics().filter(d => d.severity === 'error')
@@ -145,7 +145,7 @@ vitestExpect.extend({
         actual: actualRows,
         expected: expectedRows,
       }
-    } catch (err: any) {
+    } catch(err: any) {
       return {
         pass: false,
         message: () => `Execution failed: ${err?.message || String(err)}\nSQL: ${sql}`,
@@ -153,7 +153,7 @@ vitestExpect.extend({
     }
   },
 
-  toHaveDiagnostic (received: string, pattern: RegExp | string) {
+  toHaveDiagnostic(received: string, pattern: RegExp | string) {
     let content = trimIndentation(received)
     analyze(content, content.includes('```') ? 'md' : 'gsql')
 
@@ -171,7 +171,7 @@ vitestExpect.extend({
     }
   },
 
-  toHaveNoErrors (received: string) {
+  toHaveNoErrors(received: string) {
     let content = trimIndentation(received)
     analyze(content, content.includes('```') ? 'md' : 'gsql')
 

--- a/lang/tokens.js
+++ b/lang/tokens.js
@@ -120,7 +120,7 @@ const keywords = {
   unbounded: unbounded,
 }
 
-export function specializeIdentifier (value) {
+export function specializeIdentifier(value) {
   let lower = value.toLowerCase()
   return keywords[lower] || -1
 }

--- a/lang/util.ts
+++ b/lang/util.ts
@@ -1,7 +1,7 @@
 import type {FileInfo} from './types.ts'
 import type {SyntaxNode, SyntaxNodeRef} from '@lezer/common'
 
-function markdownOffset (offset: number, file: FileInfo) {
+function markdownOffset(offset: number, file: FileInfo) {
   let map = file.virtualToMarkdownOffset
   if (!map || map.length === 0) return offset
   if (offset <= 0) return map[0] ?? 0
@@ -9,7 +9,7 @@ function markdownOffset (offset: number, file: FileInfo) {
   return map[offset]
 }
 
-function virtualOffset (offset: number, file: FileInfo) {
+function virtualOffset(offset: number, file: FileInfo) {
   let map = file.virtualToMarkdownOffset
   if (!map || map.length === 0) return offset
   if (offset <= map[0]) return 0
@@ -25,7 +25,7 @@ function virtualOffset (offset: number, file: FileInfo) {
   return low
 }
 
-export function getPosition (offset: number, file: FileInfo) {
+export function getPosition(offset: number, file: FileInfo) {
   let mdOffset = markdownOffset(offset, file)
   let lines = file.contents.split(/\r?\n/)
   let acc = 0
@@ -41,7 +41,7 @@ export function getPosition (offset: number, file: FileInfo) {
   return {offset: mdOffset, line: 1, col: 0}
 }
 
-export function getOffset (line: number, col: number, file: FileInfo) {
+export function getOffset(line: number, col: number, file: FileInfo) {
   let lines = file.contents.split(/\r?\n/)
   let acc = 0
   for (let i = 0; i < line; i++) {
@@ -51,25 +51,25 @@ export function getOffset (line: number, col: number, file: FileInfo) {
   return acc + col
 }
 
-export function getFile (node: SyntaxNode | SyntaxNodeRef): FileInfo {
+export function getFile(node: SyntaxNode | SyntaxNodeRef): FileInfo {
   if (node.node) node = node.node
   let top: SyntaxNode = node as SyntaxNode
   while (top.parent) top = top.parent
   return top!.tree!.fileInfo
 }
 
-export function txt (node: SyntaxNode | null | undefined) {
+export function txt(node: SyntaxNode | null | undefined) {
   if (!node) return ''
   let file = getFile(node)
   let source = file.virtualContents ?? file.contents
   return source.substring(node.from, node.to) || ''
 }
 
-export function compact<T> (obj: T): T {
+export function compact<T>(obj: T): T {
   return Object.fromEntries(Object.entries(obj as any).filter(([_, v]) => v !== undefined)) as T
 }
 
-export function trimIndentation (str: string) {
+export function trimIndentation(str: string) {
   let lines = str.trim().split('\n')
   let indent = lines.slice(1)
     .filter(l => l.trim() !== '')
@@ -83,7 +83,7 @@ export function trimIndentation (str: string) {
   }).join('\n')
 }
 
-export async function pollFor<T> (fn: () => T, timeoutMs: number, interval?: number): Promise<T | null> {
+export async function pollFor<T>(fn: () => T, timeoutMs: number, interval?: number): Promise<T | null> {
   let end = Date.now() + timeoutMs
   while (Date.now() < end) {
     let res = fn()

--- a/scripts/printParseTree.ts
+++ b/scripts/printParseTree.ts
@@ -23,7 +23,7 @@ const contents = await readFile(inputPath, 'utf-8')
 const tree = parser.parse(contents)
 const cursor = tree.cursor()
 
-function printNode (cursor: TreeCursor, source: string, indent = ''): void {
+function printNode(cursor: TreeCursor, source: string, indent = ''): void {
   let name = cursor.type.name
   let text = source.slice(cursor.from, cursor.to).replace(/\s+/g, ' ').trim()
   let preview = text.length > 80 ? `${text.slice(0, 77)}…` : text

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -71,18 +71,18 @@ await $`git push origin v${version}`
 await $`git push`
 console.log("Version pushed. Don't forget to create a PR for this change")
 
-async function confirm (prompt: string) {
+async function confirm(prompt: string) {
   let answer = (await question(prompt)).trim().toLowerCase()
   return answer === 'y' || answer === 'yes'
 }
 
-function bumpVersion (version: string, bumpLevel: string) {
+function bumpVersion(version: string, bumpLevel: string) {
   let [major, minor, patch] = version.split('.').map(x => Number(x))
   if (bumpLevel === 'major') return `${major + 1}.0.0`
   if (bumpLevel === 'minor') return `${major}.${minor + 1}.0`
   return `${major}.${minor}.${patch + 1}`
 }
 
-function escapeRegex (text: string) {
+function escapeRegex(text: string) {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/scripts/turboTest.js
+++ b/scripts/turboTest.js
@@ -12,7 +12,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const WORKSPACE_ROOT = path.resolve(__dirname, '..')
 const searchString = process.argv[2]
 
-async function loadResults () {
+async function loadResults() {
   // Check both cwd and core workspace for test results
   let locations = [
     {resultsPath: path.join(process.cwd(), 'node_modules/.testResults.json'), root: process.cwd()},
@@ -22,7 +22,7 @@ async function loadResults () {
     try {
       let raw = await readFile(resultsPath, 'utf8')
       return {results: JSON.parse(raw), root}
-    } catch (error) {
+    } catch(error) {
       if (error?.code === 'ENOENT') continue
       throw error
     }
@@ -30,7 +30,7 @@ async function loadResults () {
   return {results: null, root: WORKSPACE_ROOT}
 }
 
-function selectFailedTest (results) {
+function selectFailedTest(results) {
   for (let suite of results?.testResults || []) {
     if (suite.status !== 'failed') continue
     for (let test of suite.assertionResults || []) {
@@ -40,7 +40,7 @@ function selectFailedTest (results) {
   }
 }
 
-function searchForTests (search) {
+function searchForTests(search) {
   try {
     let output = execSync(
       `grep -rn --include="*.test.ts" -E "(it|test)\\(.*${search}" .`,
@@ -54,7 +54,7 @@ function searchForTests (search) {
       }
     }
     return matches
-  } catch (error) {
+  } catch(error) {
     if (error.status === 1) return [] // grep found nothing
     throw error
   }

--- a/ui/component-utilities/autoFormatting.js
+++ b/ui/component-utilities/autoFormatting.js
@@ -248,7 +248,7 @@ export const fallbackFormat = (typedValue) => {
  * @param {number} referenceValue
  * @returns {string} the number format code for the given reference value
  */
-export function computeNumberAutoFormatCode (
+export function computeNumberAutoFormatCode(
   referenceValue,
   maxDisplayDecimals = 7,
   significantDigits = AUTO_FORMAT_MEDIAN_PRECISION,
@@ -277,7 +277,7 @@ export function computeNumberAutoFormatCode (
  * @param {number | undefined} value
  * @returns {string} the appropriate unit (B, M, k or '') for the given value
  */
-function getAutoColumnUnit (value) {
+function getAutoColumnUnit(value) {
   let absoluteValue = Math.abs(value)
   if (absoluteValue >= 5000000000000) {
     return 'T'
@@ -292,7 +292,7 @@ function getAutoColumnUnit (value) {
   }
 }
 
-function base10Exponent (value) {
+function base10Exponent(value) {
   if (value === 0) {
     return 0
   } else {

--- a/ui/component-utilities/checkInputs.js
+++ b/ui/component-utilities/checkInputs.js
@@ -1,4 +1,4 @@
-export default function checkInputs (data, reqCols, optCols) {
+export default function checkInputs(data, reqCols, optCols) {
   // reqCols is an array of columns to check in the dataset
   let columns = []
 

--- a/ui/component-utilities/dateParsing.js
+++ b/ui/component-utilities/dateParsing.js
@@ -1,7 +1,7 @@
 import {mutate} from '@tidyjs/tidy'
 import {tidyWithTypes} from './tidyWithTypes.js'
 
-export function standardizeDateString (date) {
+export function standardizeDateString(date) {
   if (date && typeof date === 'string') {
     // Parses an individual string into a JS date object
 
@@ -31,7 +31,7 @@ export function standardizeDateString (date) {
   return date
 }
 
-export function convertColumnToDate (data, column) {
+export function convertColumnToDate(data, column) {
   // Replaces a date column's string values with JS date objects, using the standardizeDateString function
 
   let converted = tidyWithTypes(
@@ -48,7 +48,7 @@ export function convertColumnToDate (data, column) {
   return converted
 }
 
-export function standardizeDateColumn (data, column) {
+export function standardizeDateColumn(data, column) {
   // Replaces a date column's string values with standardized date strings, using the standardizeDateString function
   // Used in Chart.svelte, where using Date objects leads to errors
 

--- a/ui/component-utilities/echarts.js
+++ b/ui/component-utilities/echarts.js
@@ -208,7 +208,7 @@ const echartsAction = (node, options) => {
     updateLabelWidths()
   }
 
-  void (async () => {
+  void (async() => {
     if (document?.fonts?.ready) await document.fonts.ready
     if (destroyed || chart) return
     initChart()
@@ -224,11 +224,11 @@ const echartsAction = (node, options) => {
   window[Symbol.for('chart renders')] ??= 0
   window[Symbol.for('chart renders')]++
   return {
-    update (options) {
+    update(options) {
       window[Symbol.for('chart renders')]++
       updateChart(options)
     },
-    destroy () {
+    destroy() {
       destroyed = true
       if (!chart) return
       if (resizeObserver) {

--- a/ui/component-utilities/formatTitle.js
+++ b/ui/component-utilities/formatTitle.js
@@ -1,14 +1,14 @@
 import {applyTitleTagReplacement} from './formatting'
 
-export default function formatTitle (column, columnFormat) {
+export default function formatTitle(column, columnFormat) {
   let result = applyTitleTagReplacement(column, columnFormat)
   // Allow some acronyms to remain fully capitalized in titles:
   let acronyms = ['id', 'gdp']
   // Allow some joining words to remain fully lowercased in title:
   let lowercase = ['of', 'the', 'and', 'in', 'on']
   // Set name to proper casing:
-  function toTitleCase (str) {
-    return str.replace(/\S*/g, function (txt) {
+  function toTitleCase(str) {
+    return str.replace(/\S*/g, function(txt) {
       if (!acronyms.includes(txt) && !lowercase.includes(txt)) {
         return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
       } else if (acronyms.includes(txt)) {

--- a/ui/component-utilities/formatting.js
+++ b/ui/component-utilities/formatting.js
@@ -55,7 +55,7 @@ export const lookupColumnFormat = (columnName, columnEvidenceType, columnUnitSum
  * @param {'number' | 'date' | 'boolean' | 'string'} [valueType] optional - a string representing the data type within the column that will be formatted ('number', 'date', 'boolean', or 'string)
  * @returns a format object based on the formatString matching a built-in or custom format name, or a new custom format object containing an Excel-style format code
  */
-export function getFormatObjectFromString (formatString, valueType = undefined) {
+export function getFormatObjectFromString(formatString, valueType = undefined) {
   let potentialFormatTag = formatString
   let customFormats = getCustomFormats()
   let matchingFormat = [...BUILT_IN_FORMATS, ...customFormats].find(
@@ -80,7 +80,7 @@ export function getFormatObjectFromString (formatString, valueType = undefined) 
 export const formatValue = (value, columnFormat = undefined, columnUnitSummary = undefined) => {
   try {
     return applyFormatting(value, columnFormat, columnUnitSummary, VALUE_FORMATTING_CONTEXT)
-  } catch (error) {
+  } catch(error) {
     //fallback to default
     console.warn(
       `Unexpected error calling applyFormatting(${value}, ${columnFormat}, ${VALUE_FORMATTING_CONTEXT}, ${columnUnitSummary}). Error=${error}`,
@@ -158,7 +158,7 @@ export const formatExample = (format) => {
   return ''
 }
 
-function applyFormatting (
+function applyFormatting(
   value,
   columnFormat = undefined,
   columnUnitSummary = undefined,
@@ -196,7 +196,7 @@ function applyFormatting (
       if (isAutoFormat(columnFormat, formattingCode)) {
         try {
           result = autoFormat(typedValue, columnFormat, columnUnitSummary)
-        } catch (error) {
+        } catch(error) {
           console.warn(`Unexpected error applying auto formatting. Error=${error}`)
         }
       } else if (columnFormat.valueType === 'number' && typeof typedValue === 'number' && isYearOnlyFormat(formattingCode)) {
@@ -204,7 +204,7 @@ function applyFormatting (
       } else {
         result = ssf.format(formattingCode, typedValue)
       }
-    } catch (error) {
+    } catch(error) {
       console.warn(`Unexpected error applying formatting ${error}`)
     }
   }
@@ -214,11 +214,11 @@ function applyFormatting (
   return result
 }
 
-function isYearOnlyFormat (formattingCode) {
+function isYearOnlyFormat(formattingCode) {
   return typeof formattingCode === 'string' && /^y{2,4}$/i.test(formattingCode.trim())
 }
 
-function formatNumericYear (value, formattingCode) {
+function formatNumericYear(value, formattingCode) {
   let year = String(Math.trunc(value))
   let width = formattingCode.trim().length
   if (width === 2) {
@@ -227,7 +227,7 @@ function formatNumericYear (value, formattingCode) {
   return year.padStart(width, '0')
 }
 
-function getEffectiveFormattingCode (columnFormat, formattingContext = VALUE_FORMATTING_CONTEXT) {
+function getEffectiveFormattingCode(columnFormat, formattingContext = VALUE_FORMATTING_CONTEXT) {
   if (typeof columnFormat === 'string') {
     // This should only be used by end users, not by components.
     return columnFormat
@@ -243,7 +243,7 @@ function getEffectiveFormattingCode (columnFormat, formattingContext = VALUE_FOR
  * Extracts a possible format tag from a column name based on the column name pattern
  * @returns "column_${formatTag}" will return ${formatTag} or undefined if the columnName doesn't match the pattern
  */
-function maybeExtractFormatTag (columnName) {
+function maybeExtractFormatTag(columnName) {
   let normalizedColName = columnName.toLowerCase()
   let lastUnderScoreIndex = normalizedColName.lastIndexOf('_')
 
@@ -261,7 +261,7 @@ function maybeExtractFormatTag (columnName) {
  * @param {'number' | 'date' | 'boolean' | 'string'} [valueType] the known column type
  * @returns a formatted value
  */
-export function fmt (value, format, valueType = undefined) {
+export function fmt(value, format, valueType = undefined) {
   let formatObj = getFormatObjectFromString(format, valueType)
   return formatValue(value, formatObj)
 }

--- a/ui/component-utilities/getColumnExtents.js
+++ b/ui/component-utilities/getColumnExtents.js
@@ -7,7 +7,7 @@ import {tidy, summarize, min, max, median, mean, n, nDistinct, sum} from '@tidyj
  * @param {boolean} [isNumeric]
  * @returns {{ min?: number, max?: number, median?: number, mean?: number, count?: number, countDistinct?: number, sum?: number, maxDecimals: number, unitType: string }}
  */
-export function getColumnUnitSummary (data, columnName, isNumeric = true) {
+export function getColumnUnitSummary(data, columnName, isNumeric = true) {
   let seriesExtents = tidy(
     data,
     isNumeric
@@ -45,7 +45,7 @@ export function getColumnUnitSummary (data, columnName, isNumeric = true) {
  * @param {string} column
  * @returns {[number?, number?]}
  */
-export function getColumnExtentsLegacy (data, column) {
+export function getColumnExtentsLegacy(data, column) {
   let domainData = tidy(data, summarize({min: min(column), max: max(column)}))[0]
   return [domainData.min, domainData.max]
 }
@@ -55,7 +55,7 @@ export function getColumnExtentsLegacy (data, column) {
  * @param {number[]} series
  * @returns {{ maxDecimals: number, unitType: string }}
  */
-function summarizeUnits (series) {
+function summarizeUnits(series) {
   if (series === undefined || series === null || series.length === 0) {
     return {
       maxDecimals: 0,

--- a/ui/component-utilities/getColumnSummary.js
+++ b/ui/component-utilities/getColumnSummary.js
@@ -25,7 +25,7 @@ const EvidenceType = {
  * @param {T} returnType
  * @returns {T extends 'object' ? Record<string, ColumnSummary> : (ColumnSummary & { id: string })[]}
  */
-export default function getColumnSummary (data, returnType = 'object') {
+export default function getColumnSummary(data, returnType = 'object') {
   /** @type {Record<string, ColumnSummary>} */
   let columnSummary = {}
 

--- a/ui/component-utilities/getCompletedData.js
+++ b/ui/component-utilities/getCompletedData.js
@@ -13,7 +13,7 @@ import {findInterval, vectorSeq} from './helpers/getCompletedData.helpers.js'
  * @param {boolean} [fillX=false] - A flag indicating whether the x-axis values should be filled (based on the found interval distance).
  * @return {Record<string, unknown>[]} An array containing the filled data objects.
  */
-export default function getCompletedData (_data, x, y, series, nullsZero = false, fillX = false) {
+export default function getCompletedData(_data, x, y, series, nullsZero = false, fillX = false) {
   let xIsDate = false
   let data = _data
     .map((d) =>

--- a/ui/component-utilities/getDistinctCount.js
+++ b/ui/component-utilities/getDistinctCount.js
@@ -1,6 +1,6 @@
 import {tidy, summarize, nDistinct} from '@tidyjs/tidy'
 
-export default function getDistinctCount (data, column) {
+export default function getDistinctCount(data, column) {
   let distinctCount = tidy(data, summarize({count: nDistinct(column)}))[0].count
 
   return distinctCount

--- a/ui/component-utilities/getDistinctValues.js
+++ b/ui/component-utilities/getDistinctValues.js
@@ -9,7 +9,7 @@
  * @param {string} column - The name of the column from which to extract distinct values.
  * @returns {any[]} An array containing distinct values from the specified column of the dataset.
  */
-export default function getDistinctValues (data, column) {
+export default function getDistinctValues(data, column) {
   let set = new Set(data.map((val) => val[column]))
   return Array.from(set)
 }

--- a/ui/component-utilities/getSeriesConfig.js
+++ b/ui/component-utilities/getSeriesConfig.js
@@ -1,7 +1,7 @@
 import getDistinctValues from './getDistinctValues.js'
 import {fmt} from './formatting.js'
 
-export default function getSeriesConfig (
+export default function getSeriesConfig(
   data,
   x,
   y,
@@ -17,7 +17,7 @@ export default function getSeriesConfig (
   y2 = undefined,
   seriesLabelFmt = undefined,
 ) {
-  function generateTempConfig (seriesData, seriesName, yAxisIndex, baseConfig) {
+  function generateTempConfig(seriesData, seriesName, yAxisIndex, baseConfig) {
     let tempConfig = {
       name: seriesName,
       data: seriesData,
@@ -51,18 +51,18 @@ export default function getSeriesConfig (
 
   // colname, yAxisIndex
 
-  function combineVariables (variable1, variable2) {
+  function combineVariables(variable1, variable2) {
     // Returns an array of arrays, where each individual array is [column_name, yAxisIndex], where yAxisIndex is 0 for y and 1 for y2.
     // E.g., [ ['sales', 0 ], ['gross_profit', 1]] - sales on primary axis, gross profit on secondary
     let array = []
 
     // Helper function to check if a value is undefined
-    function isUndefined (value) {
+    function isUndefined(value) {
       return typeof value === 'undefined'
     }
 
     // Helper function to add non-undefined values to the array with source indicator
-    function addValuesToArray (value, source) {
+    function addValuesToArray(value, source) {
       if (!isUndefined(value)) {
         if (Array.isArray(value)) {
           value.forEach((item) => array.push([item, source]))

--- a/ui/component-utilities/getSortedData.js
+++ b/ui/component-utilities/getSortedData.js
@@ -1,4 +1,4 @@
-export default function getSortedData (data, col, isAsc) {
+export default function getSortedData(data, col, isAsc) {
   let res = [...data].sort((a, b) => {
     return (a[col] < b[col] ? -1 : 1) * (isAsc ? 1 : -1)
   })

--- a/ui/component-utilities/getStackPercentages.js
+++ b/ui/component-utilities/getStackPercentages.js
@@ -1,7 +1,7 @@
 import {groupBy, sum, mutateWithSummary, mutate, rate, rename} from '@tidyjs/tidy'
 import {tidyWithTypes} from './tidyWithTypes.js'
 
-export default function getStackPercentages (data, groupCol, valueCol) {
+export default function getStackPercentages(data, groupCol, valueCol) {
   let pctData
   if (typeof valueCol !== 'object') {
     pctData = tidyWithTypes(

--- a/ui/component-utilities/getStackedData.js
+++ b/ui/component-utilities/getStackedData.js
@@ -1,7 +1,7 @@
 import {groupBy, summarizeAt, sum} from '@tidyjs/tidy'
 import {tidyWithTypes} from './tidyWithTypes.js'
 
-export default function getStackedData (data, groupCol, valueCol) {
+export default function getStackedData(data, groupCol, valueCol) {
   let stackedData = tidyWithTypes(data, groupBy(groupCol, [summarizeAt(valueCol, sum)]))
 
   // If multiple y columns, iterate through data and add stack total column for sorting:

--- a/ui/component-utilities/getYAxisIndex.js
+++ b/ui/component-utilities/getYAxisIndex.js
@@ -1,6 +1,6 @@
 // Helper function for multi-series tooltips:
 // Returns the yAxisIndex for a series since we can't currently access that in ECharts' params
-export default function getYAxisIndex (componentIndex, yCount, y2Count) {
+export default function getYAxisIndex(componentIndex, yCount, y2Count) {
   let totalPatternCount = yCount + y2Count
 
   // Find the position of the index in the repeating sequence

--- a/ui/component-utilities/helpers/getCompletedData.helpers.js
+++ b/ui/component-utilities/helpers/getCompletedData.helpers.js
@@ -4,7 +4,7 @@
  * @param {Array<number>} arr - The array from which differences need to be found.
  * @return {Array<number>} An array containing the differences between consecutive elements.
  */
-export function getDiffs (arr) {
+export function getDiffs(arr) {
   let diffs = []
   for (let i = 1; i < arr.length; i++) diffs.push(arr[i] - arr[i - 1])
   return diffs
@@ -17,7 +17,7 @@ export function getDiffs (arr) {
  * @param {number} b - The second number to find gcd.
  * @return {number} The greatest common divisor of the input numbers a and b.
  */
-export function gcd (a, b) {
+export function gcd(a, b) {
   // Treat non-numeric types as 0
   if (typeof a !== 'number' || isNaN(a)) a = 0
   if (typeof b !== 'number' || isNaN(b)) b = 0
@@ -42,7 +42,7 @@ export function gcd (a, b) {
  * @param {Function} [valueof] - An optional function that defines how to obtain the measuring value.
  * @return {Array} An array containing the minimum and maximum of numbers, respectively.
  */
-export function extent (values, valueof) {
+export function extent(values, valueof) {
   if (!Array.isArray(values)) throw new TypeError('Cannot calculate extent of non-array value.')
   let min
   let max
@@ -75,7 +75,7 @@ export function extent (values, valueof) {
  * @param {number} period - The incremental value for each step in the sequence.
  * @return {Array<number>} An array containing the sequenced numbers.
  */
-export function vectorSeq (values, period) {
+export function vectorSeq(values, period) {
   let [min, max] = extent(values)
 
   let sequence = []
@@ -94,18 +94,18 @@ export function vectorSeq (values, period) {
  * @param {Array<number>} arr - An array containing numbers from which interval is calculated.
  * @return {number|undefined} The interval between numbers in the sorted array, or undefined if the array has only one element.
  */
-export function findInterval (arr) {
+export function findInterval(arr) {
   if (arr.length <= 1) {
     return
   }
 
   // Sort array ascending
-  arr.sort(function (a, b) {
+  arr.sort(function(a, b) {
     return a - b
   })
 
   // 1. Multiply array by 100
-  arr = arr.map(function (x) {
+  arr = arr.map(function(x) {
     return x * 100000000
   })
 

--- a/ui/component-utilities/inputUtils.ts
+++ b/ui/component-utilities/inputUtils.ts
@@ -1,5 +1,5 @@
 
-export function toBoolean (value: any): boolean {
+export function toBoolean(value: any): boolean {
   if (typeof value === 'boolean') return value
   if (typeof value === 'number') return value !== 0
   if (typeof value === 'string') {
@@ -10,13 +10,13 @@ export function toBoolean (value: any): boolean {
   return Boolean(value)
 }
 
-export function ensureArray<T> (value: T | T[] | undefined | null): T[] {
+export function ensureArray<T>(value: T | T[] | undefined | null): T[] {
   if (Array.isArray(value)) return value
   if (value === undefined || value === null) return []
   return [value]
 }
 
-export function serializeValue (value: unknown): string {
+export function serializeValue(value: unknown): string {
   if (value === null || value === undefined) return 'NULL'
   if (typeof value === 'number' || typeof value === 'bigint') return String(value)
   if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE'
@@ -28,7 +28,7 @@ export function serializeValue (value: unknown): string {
 // - Strings are split on commas; whitespace trimmed; empty entries removed.
 // - Arrays are normalized by trimming string items and String()-ing non-strings.
 // - null/undefined -> []
-export function parseCommaList (value: unknown): string[] {
+export function parseCommaList(value: unknown): string[] {
   if (value === undefined || value === null) return []
   if (Array.isArray(value)) return value.map(v => typeof v === 'string' ? v.trim() : String(v)).filter(v => v.length > 0)
   if (typeof value === 'string') return value.split(',').map(v => v.trim()).filter(v => v.length > 0)

--- a/ui/component-utilities/replaceNulls.js
+++ b/ui/component-utilities/replaceNulls.js
@@ -1,7 +1,7 @@
 import {replaceNully} from '@tidyjs/tidy'
 import {tidyWithTypes} from './tidyWithTypes.js'
 
-export default function replaceNulls (data, columns) {
+export default function replaceNulls(data, columns) {
   let colObj = {}
   if (typeof columns === 'object') {
     for (let i = 0; i < columns.length; i++) {

--- a/ui/component-utilities/tidyWithTypes.js
+++ b/ui/component-utilities/tidyWithTypes.js
@@ -1,6 +1,6 @@
 import {tidy} from '@tidyjs/tidy'
 
-export function tidyWithTypes (data, ...ops) {
+export function tidyWithTypes(data, ...ops) {
   let result = tidy(data, ...ops)
   if (Array.isArray(data?._evidenceColumnTypes)) {
     result._evidenceColumnTypes = data._evidenceColumnTypes

--- a/ui/components/Bar.svelte
+++ b/ui/components/Bar.svelte
@@ -130,7 +130,7 @@
         }
 
         let sortOrder = stackedData.map((d: any) => d[x])
-        computedData = [...computedData].sort(function (a: any, b: any) {
+        computedData = [...computedData].sort(function(a: any, b: any) {
           return sortOrder.indexOf(a[x]) - sortOrder.indexOf(b[x])
         })
       }
@@ -188,7 +188,7 @@
       stack: resolvedStackName,
       label: {
         show: labelsBool && seriesLabelsBool,
-        formatter: function (params: any) {
+        formatter: function(params: any) {
           return params.value[swapXY ? 0 : 1] === 0
             ? ''
             : formatValue(
@@ -274,7 +274,7 @@
           label: {
             show: true,
             position: swapXY ? 'right' : 'top',
-            formatter: function (params: any) {
+            formatter: function(params: any) {
               let sum = 0
               seriesConfig.forEach((s: any) => {
                 sum += s.data[params.dataIndex][swapXY ? 0 : 1]

--- a/ui/components/BigValue.svelte
+++ b/ui/components/BigValue.svelte
@@ -11,7 +11,7 @@
 
   let {data, value = undefined, fmt = undefined, title = undefined, subtitle = undefined}: Props = $props()
 
-  function formatValue (input: any) {
+  function formatValue(input: any) {
     if (input === null || input === undefined) return '—'
     if (!fmt) return String(input)
 

--- a/ui/components/Chart.svelte
+++ b/ui/components/Chart.svelte
@@ -224,7 +224,7 @@
 
       // If no y column(s) supplied, assume all number columns other than x are the y columns:
       if (!ySet) {
-        uColNames = columnNames.filter(function (col) {
+        uColNames = columnNames.filter(function(col) {
           return ![xLocal, series, size].includes(col)
         })
 
@@ -572,7 +572,7 @@
             show: yAxisLabels_bool,
             hideOverlap: true,
             showMaxLabel: true,
-            formatter: function (value) {
+            formatter: function(value) {
               return formatAxisValue(value, yFormat, yUnitSummary)
             },
             margin: 4,
@@ -602,7 +602,7 @@
           tooltip: {
             show: true,
             position: 'inside',
-            formatter (p) {
+            formatter(p) {
               if (p.isTruncated()) {
                 return p.name
               }
@@ -624,7 +624,7 @@
             formatter:
               xTypeLocal === 'time' || xTypeLocal === 'category'
                 ? false
-                : function (value) {
+                : function(value) {
                   return formatAxisValue(value, xFormat, xUnitSummary)
                 },
             margin: 6,
@@ -692,7 +692,7 @@
             show: yAxisLabels_bool,
             hideOverlap: true,
             margin: 4,
-            formatter: function (value) {
+            formatter: function(value) {
               return formatAxisValue(value, yFormat, yUnitSummary)
             },
             color: primaryAxisColor,
@@ -732,7 +732,7 @@
             show: y2AxisLabels_bool,
             hideOverlap: true,
             margin: 4,
-            formatter: function (value) {
+            formatter: function(value) {
               return formatAxisValue(value, y2Format, y2UnitSummary)
             },
             color: secondaryAxisColor,
@@ -848,7 +848,7 @@
           trigger: 'axis',
           show: true,
           // formatter function is overridden in ScatterPlot, BubbleChart, and Histogram
-          formatter: function (params) {
+          formatter: function(params) {
             let output
             let xVal
             let yVal
@@ -947,7 +947,7 @@
       config.update(() => {
         return chartConfig
       })
-    } catch (e) {
+    } catch(e) {
       // svelte-ignore non_reactive_update
       error = e.message
       let setTextRed = '\x1b[31m%s\x1b[0m'

--- a/ui/components/Column.svelte
+++ b/ui/components/Column.svelte
@@ -111,7 +111,7 @@
         if (strictBuild) throw new Error(error)
         console.warn(error)
       }
-    } catch (error) {
+    } catch(error) {
       if (strictBuild) throw error
     }
 

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -67,7 +67,7 @@
     refreshQuery()
   })
 
-  function refreshQuery () {
+  function refreshQuery() {
     if (!mounted) return
     let key = data && dates ? `${data}::${dates}` : ''
     if (key === queryKey) return
@@ -102,7 +102,7 @@
     }
   }
 
-  function normalizeInput (value: string | Date | null | undefined): string | null {
+  function normalizeInput(value: string | Date | null | undefined): string | null {
     if (value === null || value === undefined) return null
     if (value instanceof Date) return formatDate(value)
     let parsed = new Date(value)
@@ -110,46 +110,46 @@
     return formatDate(parsed)
   }
 
-  function formatDate (value: Date): string {
+  function formatDate(value: Date): string {
     let year = value.getFullYear()
     let month = String(value.getMonth() + 1).padStart(2, '0')
     let day = String(value.getDate()).padStart(2, '0')
     return `${year}-${month}-${day}`
   }
 
-  function addDays (value: Date, days: number): Date {
+  function addDays(value: Date, days: number): Date {
     let copy = new Date(value) // eslint-disable-line svelte/prefer-svelte-reactivity
     copy.setDate(copy.getDate() + days)
     return copy
   }
 
-  function addDaysString (value: string, days: number): string {
+  function addDaysString(value: string, days: number): string {
     let parsed = new Date(value)
     if (Number.isNaN(parsed.getTime())) return value
     return formatDate(addDays(parsed, days))
   }
 
-  function startOfMonth (value: Date): Date {
+  function startOfMonth(value: Date): Date {
     return new Date(value.getFullYear(), value.getMonth(), 1)
   }
 
-  function startOfYear (value: Date): Date {
+  function startOfYear(value: Date): Date {
     return new Date(value.getFullYear(), 0, 1)
   }
 
-  function addMonths (value: Date, months: number): Date {
+  function addMonths(value: Date, months: number): Date {
     let copy = new Date(value) // eslint-disable-line svelte/prefer-svelte-reactivity
     copy.setMonth(copy.getMonth() + months)
     return copy
   }
 
-  function addYears (value: Date, years: number): Date {
+  function addYears(value: Date, years: number): Date {
     let copy = new Date(value) // eslint-disable-line svelte/prefer-svelte-reactivity
     copy.setFullYear(copy.getFullYear() + years)
     return copy
   }
 
-  function setRange (startValue: string | null, endValue: string | null, preset: string, markTouched: boolean) {
+  function setRange(startValue: string | null, endValue: string | null, preset: string, markTouched: boolean) {
     currentStart = startValue
     currentEnd = endValue
     currentPreset = preset
@@ -157,22 +157,22 @@
     updateParams()
   }
 
-  function updateParams () {
+  function updateParams() {
     window.$GRAPHENE.updateParam(`${name}_start`, currentStart)
     window.$GRAPHENE.updateParam(`${name}_end`, currentEnd)
   }
 
-  function onStartChange (event: Event) {
+  function onStartChange(event: Event) {
     let value = (event.currentTarget as HTMLInputElement).value || null
     setRange(value, currentEnd, '', true)
   }
 
-  function onEndChange (event: Event) {
+  function onEndChange(event: Event) {
     let value = (event.currentTarget as HTMLInputElement).value || null
     setRange(currentStart, value, '', true)
   }
 
-  function applyPreset (preset: string, markTouched = true) {
+  function applyPreset(preset: string, markTouched = true) {
     let baseEnd = (() => {
       if (currentEnd) return new Date(currentEnd)
       if (domainEnd) return new Date(domainEnd)
@@ -186,7 +186,7 @@
     setRange(startVal, endVal, preset, markTouched)
   }
 
-  function computePresetRange (preset: string, baseEndInclusive: Date): {start: Date | null; end: Date | null} | null {
+  function computePresetRange(preset: string, baseEndInclusive: Date): {start: Date | null; end: Date | null} | null {
     let label = preset.trim()
     let today = new Date()
     let endExclusive = addDays(baseEndInclusive, 1)
@@ -254,7 +254,7 @@
     return null
   }
 
-  function onPresetChange (event: Event) {
+  function onPresetChange(event: Event) {
     let value = (event.currentTarget as HTMLSelectElement).value
     if (!value) {
       currentPreset = ''

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -104,7 +104,7 @@
     if (isOpen) activeIndex = ensureActiveIndex(activeIndex, filteredOptions)
   })
 
-  function setupQuery () {
+  function setupQuery() {
     if (!mounted) return
     let key = data ? `${data}::${value}::${resolvedLabelField || ''}` : ''
     if (key === queryKey) return
@@ -142,7 +142,7 @@
     closeMenu(false)
   }
 
-  function filterOptions (opts: Option[], term: string): Option[] {
+  function filterOptions(opts: Option[], term: string): Option[] {
     let trimmed = term.trim().toLowerCase()
     if (!trimmed) return opts
     return opts.filter(opt => {
@@ -151,24 +151,24 @@
     })
   }
 
-  function ensureActiveIndex (current: number, opts: Option[]): number {
+  function ensureActiveIndex(current: number, opts: Option[]): number {
     if (!opts.length) return -1
     if (current >= 0 && current < opts.length) return current
     let selectedIdx = opts.findIndex(opt => isOptionSelected(opt))
     return selectedIdx >= 0 ? selectedIdx : 0
   }
 
-  function isOptionSelected (opt: Option): boolean {
+  function isOptionSelected(opt: Option): boolean {
     let key = optionKey(opt.value)
     return selection.some(val => optionKey(val) === key)
   }
 
-  async function focusSearchInput () {
+  async function focusSearchInput() {
     await tick()
     if (searchInput) searchInput.focus()
   }
 
-  function updateTriggerWidth () {
+  function updateTriggerWidth() {
     if (!triggerEl) {
       if (triggerWidth !== 0) triggerWidth = 0
       return
@@ -177,14 +177,14 @@
     if (width !== triggerWidth) triggerWidth = width
   }
 
-  function openMenu (focusSearch = true) {
+  function openMenu(focusSearch = true) {
     if (isDisabled) return
     updateTriggerWidth()
     isOpen = true
     if (focusSearch) focusSearchInput()
   }
 
-  function closeMenu (focusTrigger: boolean) {
+  function closeMenu(focusTrigger: boolean) {
     if (!isOpen) return
     isOpen = false
     activeIndex = -1
@@ -192,7 +192,7 @@
     if (focusTrigger) triggerEl?.focus()
   }
 
-  function toggleMenu () {
+  function toggleMenu() {
     if (isDisabled) return
     if (isOpen) {
       closeMenu(false)
@@ -201,7 +201,7 @@
     }
   }
 
-  function moveActive (delta: number) {
+  function moveActive(delta: number) {
     if (!filteredOptions.length) {
       activeIndex = -1
       return
@@ -215,12 +215,12 @@
     activeIndex = next
   }
 
-  function selectActiveOption () {
+  function selectActiveOption() {
     if (!filteredOptions.length || activeIndex < 0 || activeIndex >= filteredOptions.length) return
     handleOptionSelect(filteredOptions[activeIndex], true)
   }
 
-  function handleTriggerKeydown (event: KeyboardEvent) {
+  function handleTriggerKeydown(event: KeyboardEvent) {
     if (event.defaultPrevented) return
     if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
@@ -236,7 +236,7 @@
     }
   }
 
-  function handleMenuKeydown (event: KeyboardEvent) {
+  function handleMenuKeydown(event: KeyboardEvent) {
     if (event.key === 'ArrowDown') {
       event.preventDefault()
       moveActive(1)
@@ -260,14 +260,14 @@
     }
   }
 
-  function handleOptionKeydown (event: KeyboardEvent, opt: Option) {
+  function handleOptionKeydown(event: KeyboardEvent, opt: Option) {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       handleOptionSelect(opt, true)
     }
   }
 
-  function handleOptionSelect (opt: Option, fromKeyboard: boolean) {
+  function handleOptionSelect(opt: Option, fromKeyboard: boolean) {
     let key = optionKey(opt.value)
     if (multi) {
       let exists = selection.some(val => optionKey(val) === key)
@@ -283,7 +283,7 @@
     }
   }
 
-  function scrollActiveIntoView () {
+  function scrollActiveIntoView() {
     if (!isOpen || activeIndex < 0) return
     let optionEl = menuEl?.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`)
     optionEl?.scrollIntoView({block: 'nearest'})
@@ -326,7 +326,7 @@
     if (triggerEl) updateTriggerWidth()
   })
 
-  function syncSelection (fromUser: boolean) {
+  function syncSelection(fromUser: boolean) {
     let opts = availableOptions
     if (!opts.length) {
       if (selection.length) updateInputPayload(selection)
@@ -348,7 +348,7 @@
     setSelection(nextSelection, fromUser)
   }
 
-  function setSelection (values: any[], fromUser: boolean) {
+  function setSelection(values: any[], fromUser: boolean) {
     let keys = values.map(optionKey)
     let existingKeys = selection.map(optionKey)
     let changed = keys.length !== existingKeys.length || keys.some((k, idx) => k !== existingKeys[idx])
@@ -361,34 +361,34 @@
     updateInputPayload(selection)
   }
 
-  function updateInputPayload (values: any[]) {
+  function updateInputPayload(values: any[]) {
     let paramValue = values.length ? values[0] : null
     window.$GRAPHENE.updateParam(name, paramValue)
   }
 
-  function selectAll () {
+  function selectAll() {
     if (!multi) return
     setSelection(availableOptions.map(opt => opt.value), true)
   }
 
-  function clearSelection () {
+  function clearSelection() {
     setSelection([], true)
   }
 
   let elementId = $derived(`dropdown-${name}`)
   let menuId = $derived(`${elementId}-menu`)
 
-  function getContainerClass () {
+  function getContainerClass() {
     if (!hidePrint) return 'input-block'
     return 'input-block hide-print'
   }
 
-  function getDropdownClass () {
+  function getDropdownClass() {
     if (!isDisabled) return 'dropdown'
     return 'dropdown is-disabled'
   }
 
-  function getOptionClass (opt: Option, idx: number) {
+  function getOptionClass(opt: Option, idx: number) {
     let classes = 'dropdown-option'
     if (isOptionSelected(opt)) classes += ' is-selected'
     if (activeIndex === idx) classes += ' is-active'

--- a/ui/components/InlineDelta.svelte
+++ b/ui/components/InlineDelta.svelte
@@ -96,7 +96,7 @@
     if (numericValue === null) return '–'
     try {
       return formatValue(numericValue, resolvedFormat, columnUnitSummary)
-    } catch (error) {
+    } catch(error) {
       console.error('Failed to format delta value', error)
       return String(numericValue)
     }

--- a/ui/components/Line.svelte
+++ b/ui/components/Line.svelte
@@ -94,7 +94,7 @@
       // Multi Series
       try {
         computedData = getCompletedData(computedData, x, resolvedY, resolvedSeries)
-      } catch (error) {
+      } catch(error) {
         globalThis.console?.warn('Failed to complete data', {error})
         computedData = []
       }
@@ -104,7 +104,7 @@
     if (handleMissing === 'zero') {
       try {
         computedData = getCompletedData(computedData, x, resolvedY, resolvedSeries, true)
-      } catch (error) {
+      } catch(error) {
         globalThis.console?.warn('Failed to complete data', {error})
         computedData = []
       }

--- a/ui/components/TableRow.svelte
+++ b/ui/components/TableRow.svelte
@@ -58,7 +58,7 @@
 
     try {
       return chroma.scale(column.colorScale).domain(domain)
-    } catch (error) {
+    } catch(error) {
       console.warn('Unable to build color scale for column', column.id, error)
       return undefined
     }

--- a/ui/components/TextInput.svelte
+++ b/ui/components/TextInput.svelte
@@ -29,19 +29,19 @@
     pushValue(value)
   })
 
-  function sanitize (input: string): string {
+  function sanitize(input: string): string {
     if (allowUnsafe) return input
     return input.replace(/'/g, "''")
   }
 
-  function pushValue (input: string) {
+  function pushValue(input: string) {
     let trimmed = input ?? ''
     let _safe = sanitize(trimmed)
     let paramValue = trimmed === '' ? null : trimmed
     window.$GRAPHENE.updateParam(name, paramValue)
   }
 
-  function onInput (event: Event) {
+  function onInput(event: Event) {
     value = (event.currentTarget as HTMLInputElement).value
     pushValue(value)
   }

--- a/ui/components/_Table.svelte
+++ b/ui/components/_Table.svelte
@@ -174,7 +174,7 @@
           resultColumnSummary = [...resultColumnSummary.slice(0, linkIndex), ...resultColumnSummary.slice(linkIndex + 1)]
         }
       }
-    } catch (thrown) {
+    } catch(thrown) {
       let message = thrown instanceof Error ? thrown.message : 'Unable to prepare dataset'
       logError(thrown, {queryId: 'DataTable'})
       resultError = message

--- a/ui/internal/ErrorDisplay.svelte
+++ b/ui/internal/ErrorDisplay.svelte
@@ -22,26 +22,26 @@
 
   let {error: raw}: Props = $props()
 
-  function normalize (raw: unknown): ErrorLike {
+  function normalize(raw: unknown): ErrorLike {
     if (typeof raw === 'string') return {message: raw}
     if (raw instanceof globalThis.Error) return {message: raw.message}
     if (raw && typeof raw === 'object') return raw as ErrorLike
     return {message: String(raw)}
   }
 
-  function normalizePath (path: string) {
+  function normalizePath(path: string) {
     return path.replace(/\\/g, '/').replace(/^file:\/\//, '')
   }
 
-  function looksAbsolutePath (path: string) {
+  function looksAbsolutePath(path: string) {
     return path.startsWith('/') || /^[A-Za-z]:\//.test(path)
   }
 
   // "/foo/bar/baz.md" → "baz.md"
-  function basename (path: string) { return normalizePath(path).split('/').pop() || path }
+  function basename(path: string) { return normalizePath(path).split('/').pop() || path }
 
   // Classify query errors by type for a more descriptive message prefix.
-  function classifyError (e: ErrorLike) {
+  function classifyError(e: ErrorLike) {
     if (e.type === 'analysis' || e.from || e.loc || e.codeFrame || e.frame) return `GSQL error - ${e.message || 'Unknown query error'}`
     if (e.type === 'database') return e.message ? `Database query failed: ${e.message}` : 'Database query failed'
     if (e.type === 'server') return e.message ? `Server error while running query: ${e.message}` : 'Server error while running query'

--- a/ui/internal/NavSidebar.svelte
+++ b/ui/internal/NavSidebar.svelte
@@ -18,7 +18,7 @@
   let normalizedCurrent = $derived(deriveCurrentFile(currentFile, normalizedFiles, baseRoute))
   let currentRoute = $derived(normalizedCurrent ? pathToRoute(normalizedCurrent) : '/')
 
-  function deriveCurrentFile (_currentFile, _normalizedFiles, _baseRoute) {
+  function deriveCurrentFile(_currentFile, _normalizedFiles, _baseRoute) {
     let fromProp = normalizeFilePath(currentFile)
     let route = getLocationRoute()
     if (route && normalizedFiles) {
@@ -28,11 +28,11 @@
     return fromProp
   }
 
-  function normalizeFilePath (filePath) {
+  function normalizeFilePath(filePath) {
     return (filePath || '').replace(/^\.\//, '').replace(/\\/g, '/')
   }
 
-  function getLocationRoute () {
+  function getLocationRoute() {
     if (typeof window === 'undefined') return null
     let route = window.location.pathname || '/'
     route = route.replace(/\/+$/, '') || '/'
@@ -56,7 +56,7 @@
     }
   })
 
-  function toggleFolder (path) {
+  function toggleFolder(path) {
     if (!path) return
     let next = new SvelteSet(openFolders)
     if (next.has(path)) next.delete(path)
@@ -64,22 +64,22 @@
     openFolders = next
   }
 
-  function handleFolderRowKey (event, path) {
+  function handleFolderRowKey(event, path) {
     if (event.key !== 'Enter' && event.key !== ' ') return
     event.preventDefault()
     toggleFolder(path)
   }
 
-  function isOpen (path, openSet = openFolders) {
+  function isOpen(path, openSet = openFolders) {
     if (!path) return true
     return openSet.has(path)
   }
 
-  function isVisible (node, openSet = openFolders) {
+  function isVisible(node, openSet = openFolders) {
     return node.ancestors.every((path) => isOpen(path, openSet))
   }
 
-  function buildTree (paths) {
+  function buildTree(paths) {
     let root = []
     let folderMap = new SvelteMap()
 
@@ -131,7 +131,7 @@
     return sortNodes(root)
   }
 
-  function sortNodes (nodes) {
+  function sortNodes(nodes) {
     return nodes
       .map((node) => {
         if (node.type === 'folder' && node.children?.length) {
@@ -147,7 +147,7 @@
       })
   }
 
-  function flattenTree (nodes, depth = 0, ancestors = []) {
+  function flattenTree(nodes, depth = 0, ancestors = []) {
     let list = []
     for (let node of nodes) {
       if (node.type === 'folder') {
@@ -163,12 +163,12 @@
     return list
   }
 
-  function createDefaultOpenFolders (_treeNodes, currentPath) {
+  function createDefaultOpenFolders(_treeNodes, currentPath) {
     let next = new SvelteSet()
     return mergeAncestorFolders(next, currentPath)
   }
 
-  function mergeAncestorFolders (openSet, filePath) {
+  function mergeAncestorFolders(openSet, filePath) {
     if (!filePath) return new SvelteSet(openSet)
     let parts = filePath.split('/')
     parts.pop()
@@ -181,7 +181,7 @@
     return next
   }
 
-  function formatLabel (value, type) {
+  function formatLabel(value, type) {
     let cleaned = type === 'file' ? value.replace(/\.md$/, '') : value
     if (cleaned.toLowerCase() === 'index') return 'Home'
     return cleaned
@@ -191,14 +191,14 @@
       .join(' ')
   }
 
-  function pathToRoute (path) {
+  function pathToRoute(path) {
     let clean = path.replace(/\.md$/, '')
     let prefix = baseRoute ? '/' + baseRoute : ''
     if (!clean || clean === 'index') return prefix || '/'
     return prefix + '/' + clean
   }
 
-  function handleLinkClick (event, href) {
+  function handleLinkClick(event, href) {
     if (!onNavigate) return
     if (href.startsWith('http') || href.startsWith('//')) return
     event.preventDefault()

--- a/ui/internal/clientCache.ts
+++ b/ui/internal/clientCache.ts
@@ -5,12 +5,12 @@
 const TTL_MS = 1000 * 60 * 60 * 2
 
 let cache: Cache | null = null
-async function getCache () {
+async function getCache() {
   cache ||= await caches.open('graphene-data')
   return cache
 }
 
-export async function getHashes () {
+export async function getHashes() {
   let store = await getCache()
   let keys = await store.keys()
   return keys.map(k => {
@@ -24,13 +24,13 @@ export async function getHashes () {
   }).filter(h => !!h)
 }
 
-export async function cacheRead (hash: string): Promise<any | null> {
+export async function cacheRead(hash: string): Promise<any | null> {
   let store = await getCache()
   let resp = await store.match(`https://graphene-cache/${hash}`, {ignoreSearch: true})
   return await resp?.clone().json()
 }
 
-export async function cacheWrite (hash: string, response:Response) {
+export async function cacheWrite(hash: string, response:Response) {
   if (!hash) return
   let store = await getCache()
 

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -32,19 +32,19 @@ let params = {} as Record<string, any>
 let queries = [] as QueryNode[]
 let queryResults = {} as Record<string, {rows: any[], fields?: Field[]}>
 
-function registerQuery (name: string, contents: string) {
+function registerQuery(name: string, contents: string) {
   queries = queries.filter(q => q.name !== name)
   queries.push({name, contents, loading: false, fields: new Map(), errors: []})
 }
 
 const getRoutePath = () => typeof window === 'undefined' ? '/' : (window.location.pathname || '/')
 
-function updateParam (name: string, value: any) {
+function updateParam(name: string, value: any) {
   params[name] = value
   runAll() // for now, do the easy thing and reload it all
 }
 
-function query (source: string, fields: Record<string, string | string[]>, callback: ResultHandler) {
+function query(source: string, fields: Record<string, string | string[]>, callback: ResultHandler) {
   // using Map here because it preserves the order in which we add fields to the select, which we use when we get the result.
   let map = new Map(Object.entries(fields))
   let exprs: string[] = []
@@ -61,11 +61,11 @@ function query (source: string, fields: Record<string, string | string[]>, callb
   runAll()
 }
 
-function unsubscribe (callback: ResultHandler) {
+function unsubscribe(callback: ResultHandler) {
   queries = queries.filter(q => q.callback !== callback)
 }
 
-async function runNode (n: QueryNode) {
+async function runNode(n: QueryNode) {
   if (!n.callback) throw new Error('running node nobody is listening to')
   n.callback({}) // notify that the query is loading
   n.loading = true
@@ -117,26 +117,26 @@ async function runNode (n: QueryNode) {
       n.errors.forEach(e => (e as any).queryId = idStr)
       n.callback({errors: n.errors})
     }
-  } catch (e) {
+  } catch(e) {
     n.errors = [e as Error]
   } finally {
     n.loading = false
   }
 }
 
-function runAll () {
+function runAll() {
   if (runPending) return runPending
   runPending = Promise.resolve().then(_runAll).finally(() => runPending = null)
 }
 
-async function _runAll () {
+async function _runAll() {
   await Promise.all(queries.map(async n => {
     if (!n.callback) return
     await runNode(n)
   }))
 }
 
-function translateData (data: any, node: QueryNode) {
+function translateData(data: any, node: QueryNode) {
   let rows = data.rows || []
   rows.dataLoaded = true // evidence components need this to be set
   rows._evidenceColumnTypes = []
@@ -175,7 +175,7 @@ errorProvider('queryEngine', () => {
   return Object.values(unique) as Error[]
 })
 
-function evidenceType (type: string | undefined) {
+function evidenceType(type: string | undefined) {
   if (type === 'string') return 'string'
   if (type === 'number') return 'number'
   if (type === 'boolean') return 'boolean'

--- a/ui/internal/runSocket.ts
+++ b/ui/internal/runSocket.ts
@@ -6,13 +6,13 @@ import {getErrors} from './telemetry.ts'
 let socket: WebSocket | null = null
 connect()
 
-function captureChart (chartTitle: string) {
+function captureChart(chartTitle: string) {
   let escaped = window.CSS.escape(chartTitle)
   let canvas = document.querySelector(`[data-chart-title="${escaped}"] canvas`) as HTMLCanvasElement | null
   return canvas?.toDataURL('image/png')
 }
 
-async function takeScreenshot () {
+async function takeScreenshot() {
   if (!(window as any).html2canvas) {
     let html2canvas = await import('@graphenedata/html2canvas')
     ;(window as any).html2canvas = html2canvas.default
@@ -21,13 +21,13 @@ async function takeScreenshot () {
   return canvas?.toDataURL('image/png')
 }
 
-function connect () {
+function connect() {
   let wsUrl = `ws://${window.location.host}/_api/ws`
   socket = new WebSocket(wsUrl)
   socket.onclose = () => setTimeout(connect, 2000)
   socket.onopen = () => socket!.send(JSON.stringify({type: 'register', url: window.location.href}))
 
-  socket.onmessage = async (event) => {
+  socket.onmessage = async(event) => {
     let {type, requestId, chart} = JSON.parse(event.data)
     if (type !== 'check') return
 

--- a/ui/internal/telemetry.ts
+++ b/ui/internal/telemetry.ts
@@ -14,17 +14,17 @@ window.addEventListener('unhandledrejection', (event) => {
   staticErrors.push(event.reason)
 })
 
-export function logError (e: Error | string, ctx?: any) {
+export function logError(e: Error | string, ctx?: any) {
   if (typeof e === 'string') e = new Error(e)
   if (ctx) Object.assign(e, ctx)
   staticErrors.push(e)
 }
 
-export function errorProvider (key:string, fn: ErrorProvider) {
+export function errorProvider(key:string, fn: ErrorProvider) {
   errorProviders[key] = fn
 }
 
-export function getErrors (): Error[] {
+export function getErrors(): Error[] {
   let provided = Object.values(errorProviders).flatMap(p => p())
   return staticErrors.concat(provided)
 }

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -7,12 +7,12 @@ import stripAnsi from 'strip-ansi'
 import {trimIndentation} from '../../lang/util.ts'
 
 let logs = ''
-function log (...args: any[]) {
+function log(...args: any[]) {
   // console.log(...args) // useful for debugging, but pollutes test outputs
   logs += args.map(a => String(a)).join(' ') + '\n'
 }
 
-function outputLines () {
+function outputLines() {
   let normalized = logs.replace(/graphene-screenshot-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.png/g, 'graphene-screenshot-<timestamp>.png')
   normalized = normalized.replace(/Screenshot saved to[^\n]*graphene-screenshot-<timestamp>\.png/g, 'Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png')
   return stripAnsi(normalized.trim())
@@ -20,7 +20,7 @@ function outputLines () {
 
 test.beforeEach(() => { logs = '' })
 
-test('check defaults to analyzing the whole workspace', async () => {
+test('check defaults to analyzing the whole workspace', async() => {
   updateFile(`
     table tmp_bad as (
       from flights select not_a_function()
@@ -35,7 +35,7 @@ test('check defaults to analyzing the whole workspace', async () => {
   `.trim())
 })
 
-test('check with mdFile reports analysis errors', async ({server, page}) => {
+test('check with mdFile reports analysis errors', async({server, page}) => {
   expectConsoleError('Failed to load resource')
   server.mockFile('/other.md', `
     \`\`\`sql error_query
@@ -60,7 +60,7 @@ test('check with mdFile reports analysis errors', async ({server, page}) => {
   `.trim())
 })
 
-test('cli run with md file reports runtime query errors', async ({server, page}) => {
+test('cli run with md file reports runtime query errors', async({server, page}) => {
   expectConsoleError('Failed to load resource')
   server.mockFile('/index.md', `
     # Runtime Cast Error Page
@@ -79,7 +79,7 @@ test('cli run with md file reports runtime query errors', async ({server, page})
   `))
 })
 
-test('cli run with md file reports runtime chart configuration errors', async ({server, page}) => {
+test('cli run with md file reports runtime chart configuration errors', async({server, page}) => {
   expectConsoleError('Error in Bar Chart')
   expectConsoleError(/ECharts.*has been disposed/)
   server.mockFile('/index.md', `
@@ -99,7 +99,7 @@ test('cli run with md file reports runtime chart configuration errors', async ({
 `))
 })
 
-test('cli run with md file reports table configuration errors', async ({server, page}) => {
+test('cli run with md file reports table configuration errors', async({server, page}) => {
   server.mockFile('/index.md', `
     # Runtime Table Config Error
     \`\`\`sql table_data
@@ -117,7 +117,7 @@ test('cli run with md file reports table configuration errors', async ({server, 
 `))
 })
 
-test('cli run with md file reports html compilation errors', async ({server, page}) => {
+test('cli run with md file reports html compilation errors', async({server, page}) => {
   expectConsoleError('Failed to load resource')
   expectConsoleError('Internal Server Error')
   expectConsoleError('Failed to fetch dynamically imported module')
@@ -136,7 +136,7 @@ test('cli run with md file reports html compilation errors', async ({server, pag
   expect(output).toContain('^')
 })
 
-test('cli run with --chart captures a single chart screenshot', async ({server, page}) => {
+test('cli run with --chart captures a single chart screenshot', async({server, page}) => {
   server.mockFile('/index.md', `
     # Chart Screenshot
     \`\`\`sql chart_data

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -32,7 +32,7 @@ export interface ServerFixture {
 export const test = base.extend<{browser: Browser, page: Page, server: ServerFixture, mount: MountFn, chart: ChartFixture}>({
   browser: [
     // eslint-disable-next-line no-empty-pattern
-    async ({}, use) => {
+    async({}, use) => {
       let b = await chromium.launch({
         headless: !process.env.GRAPHENE_DEBUG,
         args: [
@@ -50,7 +50,7 @@ export const test = base.extend<{browser: Browser, page: Page, server: ServerFix
     {scope: 'worker'},
   ],
 
-  page: async ({browser}, use) => {
+  page: async({browser}, use) => {
     let context = await browser.newContext({
       viewport: {width: 1280, height: 720},
       deviceScaleFactor: 1,
@@ -77,14 +77,14 @@ export const test = base.extend<{browser: Browser, page: Page, server: ServerFix
   // This boots up our cli server on a unique port for e2e tests.
   server: [
     // eslint-disable-next-line no-empty-pattern
-    async ({}, use: (fixture: ServerFixture) => Promise<void>) => {
+    async({}, use: (fixture: ServerFixture) => Promise<void>) => {
       let port = await getAvailablePort()
       let viteRoot = path.join(fileURLToPath(import.meta.url), '../../../examples/flights')
       process.env.GRAPHENE_PORT = String(port)
       setConfig({port, root: viteRoot})
       let server = await serve2()
 
-      function cleanup () {
+      function cleanup() {
         clearWorkspace()
         Object.keys(mockFileMap).forEach((key) => delete mockFileMap[key])
 
@@ -119,8 +119,8 @@ export const test = base.extend<{browser: Browser, page: Page, server: ServerFix
     {scope: 'worker'} as any,
   ],
 
-  mount: async ({page, server}: {page: Page, server: ServerFixture}, use) => {
-    let mountFn = async (componentPath: string, props: any) => {
+  mount: async({page, server}: {page: Page, server: ServerFixture}, use) => {
+    let mountFn = async(componentPath: string, props: any) => {
       await page.goto(`${server.url()}/__ct`)
 
       // evidence depends on the object being set on an array, but wont serialize when playwright sends it to the frontend, so unpack it here
@@ -161,8 +161,8 @@ export const test = base.extend<{browser: Browser, page: Page, server: ServerFix
     await expect(page.locator('#component-test > :not(dialog)').first()).toBeVisible()
   },
 
-  chart: async ({page}, use) => {
-    let readConfig: ChartConfigFn = async (selector) => {
+  chart: async({page}, use) => {
+    let readConfig: ChartConfigFn = async(selector) => {
       if (typeof selector !== 'function') throw new Error('chartConfig selector must be a function')
       let selectorSource = selector.toString()
       await page.waitForFunction(() => {
@@ -176,7 +176,7 @@ export const test = base.extend<{browser: Browser, page: Page, server: ServerFix
         try {
           let fn = new Function('config', `return (${source})(config)`)
           return fn(option)
-        } catch (error) {
+        } catch(error) {
           console.error('chartConfig selector error', error)
           return null
         }
@@ -193,7 +193,7 @@ test.beforeEach(() => {
   clearWorkspace()
 })
 
-async function getAvailablePort (): Promise<number> {
+async function getAvailablePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
     let srv = net.createServer()
     srv.unref()
@@ -205,7 +205,7 @@ async function getAvailablePort (): Promise<number> {
   })
 }
 
-function trimIndentation (str:string) {
+function trimIndentation(str:string) {
   let lines = str.split('\n')
   let firstContentLine = lines[1] // Skip the first line (assumed to be empty) and find indentation of second line
   if (!firstContentLine) return str
@@ -227,7 +227,7 @@ declare global {
   }
 }
 
-export async function waitForGrapheneLoad (page: Page, timeout = 20_000) {
+export async function waitForGrapheneLoad(page: Page, timeout = 20_000) {
   await page.waitForFunction(() => Boolean(window.$GRAPHENE), null, {timeout})
   await page.evaluate((ms) => window.$GRAPHENE.waitForLoad?.(ms), timeout)
 }

--- a/ui/tests/globalSetup.ts
+++ b/ui/tests/globalSetup.ts
@@ -4,7 +4,7 @@ import {fileURLToPath} from 'url'
 import path from 'path'
 import {setConfig} from '../../lang/config.ts'
 
-export default async function setup (project: TestProject) {
+export default async function setup(project: TestProject) {
   let viteRoot = path.join(fileURLToPath(import.meta.url), '../../../examples/flights')
   setConfig({root: viteRoot})
 

--- a/ui/tests/hmr.test.ts
+++ b/ui/tests/hmr.test.ts
@@ -1,7 +1,7 @@
 import {test, expect} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
 
-test('valid → invalid → valid via HMR', async ({server, page}) => {
+test('valid → invalid → valid via HMR', async({server, page}) => {
   expectConsoleError('Failed to load resource')
   expectConsoleError('Internal Server Error')
   expectConsoleError('Failed to fetch dynamically imported module')
@@ -20,7 +20,7 @@ test('valid → invalid → valid via HMR', async ({server, page}) => {
   await expect(page.getByRole('heading', {name: 'Fixed Page'})).toBeVisible({timeout: 5000})
 })
 
-test('load broken page, fix via HMR', async ({server, page}) => {
+test('load broken page, fix via HMR', async({server, page}) => {
   expectConsoleError('Failed to load resource')
   expectConsoleError('Internal Server Error')
   expectConsoleError('Failed to fetch dynamically imported module')
@@ -35,7 +35,7 @@ test('load broken page, fix via HMR', async ({server, page}) => {
   await expect(page.getByRole('heading', {name: 'Now Working'})).toBeVisible({timeout: 5000})
 })
 
-test('editing unrelated md does not reload current page', async ({server, page}) => {
+test('editing unrelated md does not reload current page', async({server, page}) => {
   server.mockFile('/index.md', '# Main Page')
   server.mockFile('/other.md', '# Other Page')
 
@@ -55,7 +55,7 @@ test('editing unrelated md does not reload current page', async ({server, page})
   await expect(page.getByRole('heading', {name: 'Main Page'})).toBeVisible()
 })
 
-test('editing unrelated md does not reload broken page', async ({server, page}) => {
+test('editing unrelated md does not reload broken page', async({server, page}) => {
   expectConsoleError('Failed to load resource')
   expectConsoleError('Internal Server Error')
   expectConsoleError('Failed to fetch dynamically imported module')

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -1,10 +1,10 @@
 import {expect, test, waitForGrapheneLoad} from './fixtures.ts'
 
-test.beforeEach(async ({page}) => {
+test.beforeEach(async({page}) => {
   await page.setViewportSize({width: 900, height: 620})
 })
 
-async function loadDropdownPage (server: {mockFile: (path: string, content: string) => void, url: () => string}, page: any, componentMarkup: string) {
+async function loadDropdownPage(server: {mockFile: (path: string, content: string) => void, url: () => string}, page: any, componentMarkup: string) {
   server.mockFile('/index.md', `
     # Input Playground
 
@@ -18,7 +18,7 @@ async function loadDropdownPage (server: {mockFile: (path: string, content: stri
   await waitForGrapheneLoad(page)
 }
 
-async function lockOpenDropdownWidth (page: any, width = 220) {
+async function lockOpenDropdownWidth(page: any, width = 220) {
   await page.evaluate((lockedWidth) => {
     let menu = document.querySelector('.dropdown-menu[role="listbox"]') as HTMLElement | null
     if (!menu) return
@@ -28,7 +28,7 @@ async function lockOpenDropdownWidth (page: any, width = 220) {
   }, width)
 }
 
-async function startParamTracking (page: any) {
+async function startParamTracking(page: any) {
   await page.evaluate(() => {
     let w = window as any
     w.__paramUpdates = []
@@ -40,7 +40,7 @@ async function startParamTracking (page: any) {
   })
 }
 
-function lastParamUpdate (page: any, name?: string): Promise<{name: string, value: unknown} | null> {
+function lastParamUpdate(page: any, name?: string): Promise<{name: string, value: unknown} | null> {
   return page.evaluate((paramName) => {
     let updates = (window as any).__paramUpdates as Array<{name: string, value: unknown}> | undefined
     if (paramName) updates = updates?.filter((update) => update.name === paramName)
@@ -49,11 +49,11 @@ function lastParamUpdate (page: any, name?: string): Promise<{name: string, valu
   }, name)
 }
 
-function allParamUpdates (page: any): Promise<Array<{name: string, value: unknown}>> {
+function allParamUpdates(page: any): Promise<Array<{name: string, value: unknown}>> {
   return page.evaluate(() => (window as any).__paramUpdates ?? [])
 }
 
-test('dropdown single-select supports open, select, and close behaviors', async ({server, page}) => {
+test('dropdown single-select supports open, select, and close behaviors', async({server, page}) => {
   await loadDropdownPage(server, page, '<Dropdown name="carrier" data="dropdown_options" value="code" label="label" title="Carrier" />')
   let trigger = page.getByRole('combobox', {name: 'Carrier'})
   await expect(trigger).toBeVisible()
@@ -78,7 +78,7 @@ test('dropdown single-select supports open, select, and close behaviors', async 
   await expect(menu).toBeHidden()
 })
 
-test('dropdown multi-select supports select-all and clear', async ({server, page}) => {
+test('dropdown multi-select supports select-all and clear', async({server, page}) => {
   await loadDropdownPage(server, page, '<Dropdown name="carrier_multi" data="dropdown_options" value="code" label="label" title="Carriers" multiple=true placeholder="Pick carriers" />')
   let trigger = page.getByRole('combobox', {name: 'Carriers'})
 
@@ -103,7 +103,7 @@ test('dropdown multi-select supports select-all and clear', async ({server, page
   expect(await lastParamUpdate(page, 'carrier_multi')).toEqual({name: 'carrier_multi', value: null})
 })
 
-test('dropdown search filters options and shows empty state', async ({server, page}) => {
+test('dropdown search filters options and shows empty state', async({server, page}) => {
   await loadDropdownPage(server, page, '<Dropdown name="carrier_search" data="dropdown_options" value="code" label="label" title="Carrier Search" />')
   let trigger = page.getByRole('combobox', {name: 'Carrier Search'})
 
@@ -111,7 +111,7 @@ test('dropdown search filters options and shows empty state', async ({server, pa
   let menu = page.getByRole('listbox')
   let search = menu.getByPlaceholder('Carrier Search')
   await search.fill('AA')
-  await expect.poll(async () => await menu.locator('[role="option"]').count()).toBeGreaterThan(0)
+  await expect.poll(async() => await menu.locator('[role="option"]').count()).toBeGreaterThan(0)
   let filteredOptions = await menu.locator('[role="option"]').allTextContents()
   expect(filteredOptions.every(text => text.includes('AA'))).toBe(true)
   await lockOpenDropdownWidth(page)
@@ -124,7 +124,7 @@ test('dropdown search filters options and shows empty state', async ({server, pa
   await expect(menu).screenshot('dropdown-search-empty')
 })
 
-test('dropdown keyboard navigation selects active option', async ({server, page}) => {
+test('dropdown keyboard navigation selects active option', async({server, page}) => {
   await loadDropdownPage(server, page, '<Dropdown name="carrier_keys" data="dropdown_options" value="code" label="label" title="Keyboard Carrier" />')
   let trigger = page.getByRole('combobox', {name: 'Keyboard Carrier'})
 
@@ -145,7 +145,7 @@ test('dropdown keyboard navigation selects active option', async ({server, page}
   expect(update?.name).toBe('carrier_keys')
 })
 
-test('dropdown defaultValue and disabled state render correctly', async ({server, page}) => {
+test('dropdown defaultValue and disabled state render correctly', async({server, page}) => {
   await loadDropdownPage(server, page, `
     <Dropdown name="carrier_default" data="dropdown_options" value="code" label="label" title="Default Carrier" defaultValue="AA" />
     <Dropdown name="carrier_disabled" data="dropdown_options" value="code" label="label" title="Disabled Carrier" disabled=true defaultValue="AS" />
@@ -165,7 +165,7 @@ test('dropdown defaultValue and disabled state render correctly', async ({server
   await expect(disabledTrigger).screenshot('dropdown-disabled')
 })
 
-test('dropdown boolean-string attributes handle defaults and footer actions', async ({server, page}) => {
+test('dropdown boolean-string attributes handle defaults and footer actions', async({server, page}) => {
   await loadDropdownPage(server, page, `
     <Dropdown
       name="carrier_no_default"
@@ -211,7 +211,7 @@ test('dropdown boolean-string attributes handle defaults and footer actions', as
   await expect(page.getByRole('listbox')).screenshot('dropdown-select-all-default-disable-button')
 })
 
-test('dropdown supports manual options and labelField mapping', async ({server, page}) => {
+test('dropdown supports manual options and labelField mapping', async({server, page}) => {
   server.mockFile('/index.md', `
     # Input Playground
 
@@ -239,7 +239,7 @@ test('dropdown supports manual options and labelField mapping', async ({server, 
   await manualTrigger.click()
   await page.getByRole('option', {name: 'United'}).click()
   await expect(manualTrigger).toContainText('United')
-  await expect.poll(async () => await lastParamUpdate(page, 'manual_carrier')).toEqual({name: 'manual_carrier', value: 'UA'})
+  await expect.poll(async() => await lastParamUpdate(page, 'manual_carrier')).toEqual({name: 'manual_carrier', value: 'UA'})
 
   let mappedTrigger = page.getByRole('combobox', {name: 'Label Field Carrier'})
   await mappedTrigger.click()
@@ -248,7 +248,7 @@ test('dropdown supports manual options and labelField mapping', async ({server, 
   await expect(page.getByRole('listbox')).screenshot('dropdown-manual-and-label-field')
 })
 
-test('text input and date range render label, description, placeholder, and print visibility attrs', async ({mount, page}) => {
+test('text input and date range render label, description, placeholder, and print visibility attrs', async({mount, page}) => {
   await mount('components/TextInput.svelte', {
     name: 'search_label',
     label: 'Search Label',
@@ -281,7 +281,7 @@ test('text input and date range render label, description, placeholder, and prin
   await expect(page.locator('#component-test')).screenshot('date-range-label-description-default-preset')
 })
 
-test('text input updates params and date range applies preset', async ({mount, page}) => {
+test('text input updates params and date range applies preset', async({mount, page}) => {
   await mount('components/TextInput.svelte', {name: 'search_text', title: 'Search Text', defaultValue: 'alpha', placeholder: 'Type here'})
   let textInput = page.getByLabel('Search Text')
   await expect(textInput).toHaveValue('alpha')

--- a/ui/tests/logWatcher.ts
+++ b/ui/tests/logWatcher.ts
@@ -9,16 +9,16 @@ let expected: Matcher[] = []
 let unexpected: string[] = []
 
 // Registers an expected console error for the current test.
-export function expectConsoleError (matcher: Matcher) {
+export function expectConsoleError(matcher: Matcher) {
   expected.push(matcher)
 }
 
-export function resetExpectedLogs () {
+export function resetExpectedLogs() {
   expected = []
   unexpected = []
 }
 
-function isExpected (log: string): boolean {
+function isExpected(log: string): boolean {
   for (let ex of expected) {
     if (typeof ex == 'string' && log.includes(ex)) return true
     if (ex instanceof RegExp && log.match(ex)) return true
@@ -27,14 +27,14 @@ function isExpected (log: string): boolean {
 }
 
 // Handles Vitest console output and fails fast on unexpected lines.
-export function onServerLog (log: string) {
+export function onServerLog(log: string) {
   if (isExpected(log)) return false
   console.log(log)
   unexpected.push(log)
 }
 
 // Starts tracking warning/error browser console output for a page.
-export function trackBrowserConsole (page: Page) {
+export function trackBrowserConsole(page: Page) {
   page.on('console', msg => {
     if (msg.type() !== 'warning' && msg.type() !== 'error') return
     let text = msg.text()
@@ -51,6 +51,6 @@ export function trackBrowserConsole (page: Page) {
   })
 }
 
-export function assertOnlyExpectedLogs () {
+export function assertOnlyExpectedLogs() {
   expect(unexpected).toEqual([])
 }

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -1,7 +1,7 @@
 import {test, expect, waitForGrapheneLoad} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
 
-test('loads markdown files', async ({server, page}) => {
+test('loads markdown files', async({server, page}) => {
   server.mockFile('/index.md', `
     # Flight Delay Analysis
 
@@ -21,7 +21,7 @@ test('loads markdown files', async ({server, page}) => {
   await expect(page).screenshot('loads-markdown-files')
 })
 
-test('expands nav for nested files', async ({server, page}) => {
+test('expands nav for nested files', async({server, page}) => {
   server.mockFile('/other/index.md', '# Other Folder')
   server.mockFile('/other/more.md', 'Hi there!')
   await page.goto(server.url() + '/other/more')
@@ -32,7 +32,7 @@ test('expands nav for nested files', async ({server, page}) => {
   await expect(nav.getByRole('link', {name: 'More'})).toHaveAttribute('aria-current', 'page')
 })
 
-test('allows collapsing and expanding folders', async ({server, page}) => {
+test('allows collapsing and expanding folders', async({server, page}) => {
   server.mockFile('/other/index.md', '# Other Folder')
   server.mockFile('/other/more.md', 'More page content')
   await page.goto(server.url() + '/other/more')
@@ -48,7 +48,7 @@ test('allows collapsing and expanding folders', async ({server, page}) => {
 })
 
 
-test('renders gsql query errors clearly with file context', async ({server, page}) => {
+test('renders gsql query errors clearly with file context', async({server, page}) => {
   expectConsoleError('Failed to load resource')
   server.mockFile('/index.md', `
     # Broken Dashboard
@@ -73,7 +73,7 @@ test('renders gsql query errors clearly with file context', async ({server, page
   await expect(page).screenshot('reports-analysis-query-errors')
 })
 
-test('renders database query failures clearly', async ({server, page}) => {
+test('renders database query failures clearly', async({server, page}) => {
   expectConsoleError('Failed to load resource')
   server.mockFile('/index.md', `
     # Database Failure
@@ -91,7 +91,7 @@ test('renders database query failures clearly', async ({server, page}) => {
   await expect(page).screenshot('reports-database-query-errors')
 })
 
-test('renders generic server failures clearly', async ({server, page}) => {
+test('renders generic server failures clearly', async({server, page}) => {
   expectConsoleError('Failed to load resource')
   server.mockFile('/index.md', `
     # Server Failure
@@ -103,7 +103,7 @@ test('renders generic server failures clearly', async ({server, page}) => {
     <BarChart data="broken_query" x="origin" y="dep_delay" />
   `)
 
-  await page.route('**/_api/query', async (route) => {
+  await page.route('**/_api/query', async(route) => {
     await route.fulfill({
       status: 500,
       contentType: 'application/json',
@@ -118,7 +118,7 @@ test('renders generic server failures clearly', async ({server, page}) => {
   await expect(page).screenshot('reports-server-query-errors')
 })
 
-test('renders html syntax errors with error display', async ({server, page}) => {
+test('renders html syntax errors with error display', async({server, page}) => {
   expectConsoleError('Failed to load resource')
   expectConsoleError('Internal Server Error')
   expectConsoleError('Failed to fetch dynamically imported module')
@@ -135,7 +135,7 @@ test('renders html syntax errors with error display', async ({server, page}) => 
   await expect(page).screenshot('html-syntax-error')
 })
 
-test('renders literal less-than characters', async ({server, page}) => {
+test('renders literal less-than characters', async({server, page}) => {
   server.mockFile('/index.md', `
     # Comparison
     Profit is 1 < 2 and losses are 0 < 1.
@@ -146,7 +146,7 @@ test('renders literal less-than characters', async ({server, page}) => {
   await expect(page.locator('main')).toHaveText(/1 < 2/)
 })
 
-test('sanitizes unsafe html', async ({server, page}) => {
+test('sanitizes unsafe html', async({server, page}) => {
   server.mockFile('/index.md', `
     # Sanitized
     <script>window.__MD_SCRIPT__ = true</script>

--- a/ui/tests/matchers.ts
+++ b/ui/tests/matchers.ts
@@ -7,12 +7,12 @@ import type {Locator, Page} from 'playwright'
 // Snapshot directory - must be set via setSnapshotDir() in a setupFiles script
 let snapshotDir: string | undefined
 
-export function setSnapshotDir (dir: string) {
+export function setSnapshotDir(dir: string) {
   snapshotDir = dir
 }
 
 const extendedExpect = baseExpect.extend({
-  async screenshot (subject: Page | Locator, snapshotName: string) {
+  async screenshot(subject: Page | Locator, snapshotName: string) {
     if (!snapshotDir) throw new Error('Snapshot directory not configured. Call setSnapshotDir() in a setup file.')
     if (process.env.GRAPHENE_DEBUG) return {message: () => '', pass: true} // don't check screenshots when debugging (browser might not be the same size)
     let page = subject.constructor.name === 'Page' ? subject : (subject as Locator).page()
@@ -21,7 +21,7 @@ const extendedExpect = baseExpect.extend({
     let testFile = path.basename(testPath)
 
     // Wait for fonts to load to ensure consistent rendering across environments
-    await (page as Page).evaluate(async () => {
+    await (page as Page).evaluate(async() => {
       await document.fonts.ready
       await (window as any).$GRAPHENE?.waitForLoad?.()
       await new Promise(r => requestAnimationFrame(r))
@@ -61,7 +61,7 @@ const extendedExpect = baseExpect.extend({
   },
 })
 
-async function writeBuffer (filePath: string, data: Buffer) {
+async function writeBuffer(filePath: string, data: Buffer) {
   await fs.mkdir(path.dirname(filePath), {recursive: true})
   await fs.writeFile(filePath, data)
 }

--- a/ui/tests/pack-install.test.ts
+++ b/ui/tests/pack-install.test.ts
@@ -16,7 +16,7 @@ interface RunResult {
 
 const shouldRunPackInstallTest = !!process.env.CI || process.env.GRAPHENE_PACK_TEST === '1'
 
-function run (command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv = process.env): Promise<RunResult> {
+function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv = process.env): Promise<RunResult> {
   return new Promise((resolve) => {
     let child = spawn(command, args, {cwd, env})
     let stdout = ''
@@ -27,12 +27,12 @@ function run (command: string, args: string[], cwd: string, env: NodeJS.ProcessE
   })
 }
 
-function expectSuccess (step: string, result: RunResult) {
+function expectSuccess(step: string, result: RunResult) {
   if (result.code === 0) return
   throw new Error(`[pack-install.test] ${step} failed (code ${result.code})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`)
 }
 
-async function getAvailablePort (): Promise<number> {
+async function getAvailablePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
     let srv = net.createServer()
     srv.unref()
@@ -44,21 +44,21 @@ async function getAvailablePort (): Promise<number> {
   })
 }
 
-function parseTarballPath (result: RunResult, cwd: string) {
+function parseTarballPath(result: RunResult, cwd: string) {
   let matches = Array.from((result.stdout + result.stderr).matchAll(/([^\s]+\.tgz)/g), m => m[1])
   let tarball = matches.at(-1)
   if (!tarball) throw new Error('Could not find packed .tgz path in pnpm pack output')
   return path.isAbsolute(tarball) ? tarball : path.resolve(cwd, tarball)
 }
 
-function parseScreenshotPath (output: string, cwd: string) {
+function parseScreenshotPath(output: string, cwd: string) {
   let match = output.match(/Screenshot saved to\s+(.+\.png)/)
   if (!match) throw new Error(`Could not find screenshot path in output:\n${output}`)
   let screenshotPath = match[1].trim()
   return path.isAbsolute(screenshotPath) ? screenshotPath : path.resolve(cwd, screenshotPath)
 }
 
-test.skipIf(!shouldRunPackInstallTest)('packs cli and installs it into a user project', {timeout: 300_000}, async ({page}) => {
+test.skipIf(!shouldRunPackInstallTest)('packs cli and installs it into a user project', {timeout: 300_000}, async({page}) => {
   let testsDir = path.dirname(fileURLToPath(import.meta.url))
   let coreDir = path.resolve(testsDir, '../..')
   let cliDir = path.join(coreDir, 'cli')

--- a/ui/tests/table.test.ts
+++ b/ui/tests/table.test.ts
@@ -3,7 +3,7 @@ import {groupedDataForSection, tableDataForPagination, tableDataWithDates, times
 
 const tableSelector = '[data-testid="DataTable-no-id"] table'
 
-test('renders table data', async ({mount, page}) => {
+test('renders table data', async({mount, page}) => {
   await mount('components/Table.svelte', {data: timeseriesGrouped(), title: 'Sales'})
   await waitForGrapheneLoad(page)
   let table = page.locator(tableSelector)
@@ -11,7 +11,7 @@ test('renders table data', async ({mount, page}) => {
   await expect(page.locator('.table-container')).screenshot('table-renders-data')
 })
 
-test('sorts by column header', async ({mount, page}) => {
+test('sorts by column header', async({mount, page}) => {
   await mount('components/Table.svelte', {data: tableDataWithDates()})
   let table = page.locator(tableSelector)
   await table.locator('tr:has(td)').first().waitFor()
@@ -32,7 +32,7 @@ test('sorts by column header', async ({mount, page}) => {
   await expect(page.locator('.table-container')).screenshot('sort-descending')
 })
 
-test('sortable=false keeps header clicks from changing order', async ({mount, page}) => {
+test('sortable=false keeps header clicks from changing order', async({mount, page}) => {
   await mount('components/Table.svelte', {data: tableDataWithDates(), sortable: false})
   let table = page.locator(tableSelector)
   await table.locator('tr:has(td)').first().waitFor()
@@ -46,7 +46,7 @@ test('sortable=false keeps header clicks from changing order', async ({mount, pa
   await expect(page.locator('.table-container')).screenshot('sort-disabled')
 })
 
-test('paginates rows', async ({mount, page}) => {
+test('paginates rows', async({mount, page}) => {
   await mount('components/Table.svelte', {data: tableDataForPagination(12), rows: 5})
   let table = page.locator('[data-testid="DataTable-no-id"] table')
   await expect(table).toBeVisible()
@@ -71,7 +71,7 @@ test('paginates rows', async ({mount, page}) => {
   await expect(page.locator('.table-container')).screenshot('pagination-first-last')
 })
 
-test('colorscale with colorBreakpoints applies correct background colors', async ({server, page}) => {
+test('colorscale with colorBreakpoints applies correct background colors', async({server, page}) => {
   // Three columns with different value ranges against the same 0-1 breakpoints.
   // High column should be green, low column should be red — verify via screenshot.
   server.mockFile('/index.md', `
@@ -92,7 +92,7 @@ test('colorscale with colorBreakpoints applies correct background colors', async
   await expect(page.locator('.table-container')).screenshot('colorscale-breakpoints')
 })
 
-test('colorBreakpoints work when all column values are identical', async ({server, page}) => {
+test('colorBreakpoints work when all column values are identical', async({server, page}) => {
   // Edge case: all rows have the same value (columnMin === columnMax).
   // Breakpoints define the domain, so val=1.0 should map to green end of 0/0.5/1 scale.
   server.mockFile('/index.md', `
@@ -111,7 +111,7 @@ test('colorBreakpoints work when all column values are identical', async ({serve
   await expect(page.locator('.table-container')).screenshot('colorscale-breakpoints-uniform')
 })
 
-test('groupType=section renders correct rowSpan for first row of each group', async ({mount, page}) => {
+test('groupType=section renders correct rowSpan for first row of each group', async({mount, page}) => {
   await mount('components/Table.svelte', {data: groupedDataForSection(), groupBy: 'time_horizon', groupType: 'section'})
   await waitForGrapheneLoad(page)
   let table = page.locator(tableSelector)
@@ -128,7 +128,7 @@ test('groupType=section renders correct rowSpan for first row of each group', as
   await expect(page.locator('.table-container')).screenshot('group-section-rowspan')
 })
 
-test('row numbers stay stable across sort and pagination states', async ({mount, page}) => {
+test('row numbers stay stable across sort and pagination states', async({mount, page}) => {
   await mount('components/Table.svelte', {
     data: tableDataForPagination(12),
     rows: 5,
@@ -153,7 +153,7 @@ test('row numbers stay stable across sort and pagination states', async ({mount,
   await expect(page.locator('.table-container')).screenshot('row-numbers-sort-asc-page-2')
 })
 
-test('accordion grouping with subtotals renders and collapses predictably', async ({mount, page}) => {
+test('accordion grouping with subtotals renders and collapses predictably', async({mount, page}) => {
   await mount('components/Table.svelte', {
     data: groupedDataForSection(),
     groupBy: 'time_horizon',
@@ -193,7 +193,7 @@ test('accordion grouping with subtotals renders and collapses predictably', asyn
   await expect(page.locator('.table-container')).screenshot('group-accordion-subtotals-collapsed')
 })
 
-test('table attributes render grouped headers, wrapped titles, and row styling options', async ({server, page}) => {
+test('table attributes render grouped headers, wrapped titles, and row styling options', async({server, page}) => {
   server.mockFile('/index.md', `
     \`\`\`sql table_style_data
     from flights
@@ -234,7 +234,7 @@ test('table attributes render grouped headers, wrapped titles, and row styling o
   await expect(page.locator('.table-container')).screenshot('attribute-groups-and-styling')
 })
 
-test('section groups respect groupNamePosition and subtotal styles', async ({mount, page}) => {
+test('section groups respect groupNamePosition and subtotal styles', async({mount, page}) => {
   await mount('components/Table.svelte', {
     data: groupedDataForSection(),
     groupBy: 'time_horizon',
@@ -252,7 +252,7 @@ test('section groups respect groupNamePosition and subtotal styles', async ({mou
   await expect(page.locator('.table-container')).screenshot('section-group-position-top')
 })
 
-test('total row renders for ungrouped tables', async ({mount, page}) => {
+test('total row renders for ungrouped tables', async({mount, page}) => {
   await mount('components/Table.svelte', {
     data: tableDataForPagination(4),
     rowNumbers: true,
@@ -267,7 +267,7 @@ test('total row renders for ungrouped tables', async ({mount, page}) => {
   await expect(page.locator('.table-container')).screenshot('total-row-basic')
 })
 
-test('row-level link behavior opens external destinations and hides link column', async ({mount, page}) => {
+test('row-level link behavior opens external destinations and hides link column', async({mount, page}) => {
   let rows = [
     {name: 'Alpha', value: 12, url: 'https://example.com/alpha'},
     {name: 'Beta', value: 8, url: null},
@@ -299,7 +299,7 @@ test('row-level link behavior opens external destinations and hides link column'
   await popup.close()
 })
 
-test('colorscale and link content columns render together', async ({server, page}) => {
+test('colorscale and link content columns render together', async({server, page}) => {
   server.mockFile('/index.md', `
     \`\`\`sql style_table
     from flights select carrier, count(*) / 30000.0 as retention, 'https://example.com' as details_url group by carrier order by carrier limit 5
@@ -325,7 +325,7 @@ test('colorscale and link content columns render together', async ({server, page
   await popup.close()
 })
 
-test('image and link content columns honor sizing, labels, and tab target attributes', async ({server, page}) => {
+test('image and link content columns honor sizing, labels, and tab target attributes', async({server, page}) => {
   server.mockFile('/index.md', `
     \`\`\`sql media_table
     from flights

--- a/ui/tests/testData.ts
+++ b/ui/tests/testData.ts
@@ -1,6 +1,6 @@
 type TableRows = {rows: any}
 
-export function singleDim (): TableRows {
+export function singleDim(): TableRows {
   let result: Record<string, number> = {}
   ordersByCategory.forEach((row: any) => {
     result[row.category] = (result[row.category] || 0) + row.sales_usd0k
@@ -13,7 +13,7 @@ export function singleDim (): TableRows {
   return {rows}
 }
 
-export function timeseries (): TableRows {
+export function timeseries(): TableRows {
   let result: Record<string, number> = {}
   ordersByCategory.forEach((row: any) => {
     result[row.month] = (result[row.month] || 0) + row.sales_usd0k
@@ -26,7 +26,7 @@ export function timeseries (): TableRows {
   return {rows}
 }
 
-export function timeseriesGrouped (): TableRows {
+export function timeseriesGrouped(): TableRows {
   let rows = ordersByCategory.map((row: any) => ({...row, month: new Date(row.month)})) as any
   rows._evidenceColumnTypes = [
     {name: 'month', evidenceType: 'date'},
@@ -36,7 +36,7 @@ export function timeseriesGrouped (): TableRows {
   return {rows}
 }
 
-export function timeseriesWithDateSeries (): TableRows {
+export function timeseriesWithDateSeries(): TableRows {
   let rows = [
     {quarter: '2021-01-01', category: 'Widgets', sales: 100},
     {quarter: '2021-01-01', category: 'Gadgets', sales: 200},
@@ -53,7 +53,7 @@ export function timeseriesWithDateSeries (): TableRows {
   return {rows}
 }
 
-export function yearlyCounts (): TableRows {
+export function yearlyCounts(): TableRows {
   let rows = [
     {year: 2000, flights: 90},
     {year: 2001, flights: 80},
@@ -69,7 +69,7 @@ export function yearlyCounts (): TableRows {
   return {rows}
 }
 
-export function tableDataWithDates (): TableRows {
+export function tableDataWithDates(): TableRows {
   let rows = [
     {month: '2021-03-01', sales: 50},
     {month: '2021-01-01', sales: 75},
@@ -82,7 +82,7 @@ export function tableDataWithDates (): TableRows {
   return {rows}
 }
 
-export function tableDataForPagination (count = 15): TableRows {
+export function tableDataForPagination(count = 15): TableRows {
   let rows = Array.from({length: count}, (_, index) => ({
     item: `Row ${index + 1}`,
     value: index + 1,
@@ -94,7 +94,7 @@ export function tableDataForPagination (count = 15): TableRows {
   return {rows}
 }
 
-export function groupedDataForSection (): TableRows {
+export function groupedDataForSection(): TableRows {
   let rows = [
     {time_horizon: '30 days', sku: 'SKU-A', units: 100},
     {time_horizon: '30 days', sku: 'SKU-B', units: 80},

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -2,31 +2,31 @@ import {expect, test} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
 import {singleDim, timeseries, timeseriesGrouped, timeseriesWithDateSeries, yearlyCounts} from './testData.ts'
 
-test.beforeEach(async ({page}) => {
+test.beforeEach(async({page}) => {
   await page.setViewportSize({width: 680, height: 400})
 })
 
-test('bar chart', async ({mount, chart}) => {
+test('bar chart', async({mount, chart}) => {
   await mount('components/BarChart.svelte', {data: timeseries(), x: 'month', y: 'sales_usd0k'})
   await expect(chart.el).screenshot('bar-chart')
 })
 
-test('horizontal bar chart', async ({mount, chart}) => {
+test('horizontal bar chart', async({mount, chart}) => {
   await mount('components/BarChart.svelte', {data: singleDim(), x: 'category', y: 'value', swapXY: true})
   await expect(chart.el).screenshot('horizontal-bar-chart')
 })
 
-test('area chart', async ({mount, chart}) => {
+test('area chart', async({mount, chart}) => {
   await mount('components/AreaChart.svelte', {data: timeseries(), x: 'month', y: 'sales_usd0k'})
   await expect(chart.el).screenshot('area-chart')
 })
 
-test('stacked area chart', async ({mount, chart}) => {
+test('stacked area chart', async({mount, chart}) => {
   await mount('components/AreaChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', series: 'category', type: 'stacked'})
   await expect(chart.el).screenshot('stacked-area-chart')
 })
 
-test('stacked100 keeps time axis when x values are dates', async ({mount, chart}) => {
+test('stacked100 keeps time axis when x values are dates', async({mount, chart}) => {
   await mount('components/AreaChart.svelte', {
     data: timeseriesGrouped(),
     x: 'month',
@@ -39,7 +39,7 @@ test('stacked100 keeps time axis when x values are dates', async ({mount, chart}
   await expect(chart.el).screenshot('stacked100-date-axis-order')
 })
 
-test('line chart timeseries', async ({mount, page, chart}) => {
+test('line chart timeseries', async({mount, page, chart}) => {
   await mount('components/LineChart.svelte', {data: timeseries(), x: 'month', y: 'sales_usd0k'})
   await expect(page.locator('canvas')).toBeVisible()
   let axisType = await chart.config(c => c.xAxis[0].type)
@@ -47,19 +47,19 @@ test('line chart timeseries', async ({mount, page, chart}) => {
   await expect(chart.el).screenshot('line-chart-timeseries')
 })
 
-test('pie chart', async ({mount, chart}) => {
+test('pie chart', async({mount, chart}) => {
   await mount('components/PieChart.svelte', {data: singleDim(), category: 'category', value: 'value'})
   await expect(chart.el).screenshot('pie-chart')
 })
 
-test('big value', async ({mount, page, chart}) => {
+test('big value', async({mount, page, chart}) => {
   await mount('components/BigValue.svelte', {data: singleDim(), value: 'value', fmt: 'num0', title: 'Sales'})
   await expect(page.getByText('Sales')).toBeVisible()
   await expect(page.getByText('611,113')).toBeVisible()
   await expect(chart.el).screenshot('big-value')
 })
 
-test('chart uses css named colors from comma-separated palette', async ({mount, chart}) => {
+test('chart uses css named colors from comma-separated palette', async({mount, chart}) => {
   await mount('components/LineChart.svelte', {
     data: timeseriesGrouped(),
     x: 'month',
@@ -72,7 +72,7 @@ test('chart uses css named colors from comma-separated palette', async ({mount, 
   expect(colors).toEqual(['red', 'SteelBlue', '#00ff00'])
 })
 
-test('chart accepts json string palette', async ({mount, chart}) => {
+test('chart accepts json string palette', async({mount, chart}) => {
   await mount('components/LineChart.svelte', {
     data: timeseriesGrouped(),
     x: 'month',
@@ -85,7 +85,7 @@ test('chart accepts json string palette', async ({mount, chart}) => {
   expect(colors).toEqual(['#123456', 'LightPink', 'hsl(120, 100%, 50%)'])
 })
 
-test('series colors accepts json string input', async ({mount, chart}) => {
+test('series colors accepts json string input', async({mount, chart}) => {
   await mount('components/LineChart.svelte', {
     data: timeseriesGrouped(),
     x: 'month',
@@ -105,7 +105,7 @@ test('series colors accepts json string input', async ({mount, chart}) => {
   expect(colors).toContain('#123456')
 })
 
-test('bar chart y-axis uses integer ticks for integer data', async ({mount, chart}) => {
+test('bar chart y-axis uses integer ticks for integer data', async({mount, chart}) => {
   // there was a regression where we'd try to render fractional ticks (0, 0.25, 0.5, 0.75, 1), but they got rounded
   let rows = [{category: 'A', count: 1}, {category: 'B', count: 1}, {category: 'C', count: 1}] as any
   rows._evidenceColumnTypes = [{name: 'category', evidenceType: 'string'}, {name: 'count', evidenceType: 'number'}]
@@ -115,7 +115,7 @@ test('bar chart y-axis uses integer ticks for integer data', async ({mount, char
   await expect(chart.el).screenshot('bar-chart-integer-ticks')
 })
 
-test('line chart dual axis shows both y-axis labels', async ({mount, chart}) => {
+test('line chart dual axis shows both y-axis labels', async({mount, chart}) => {
   let data = timeseries() as any
   let rows = data.rows.map((r: any) => ({...r, profit_usd0k: r.sales_usd0k * 0.1}))
   rows._evidenceColumnTypes = [
@@ -142,7 +142,7 @@ test('line chart dual axis shows both y-axis labels', async ({mount, chart}) => 
   await expect(chart.el).screenshot('line-chart-dual-axis')
 })
 
-test('line chart seriesLabelFmt formats date series names', async ({mount, chart}) => {
+test('line chart seriesLabelFmt formats date series names', async({mount, chart}) => {
   await mount('components/LineChart.svelte', {
     data: timeseriesWithDateSeries(),
     x: 'category',
@@ -155,7 +155,7 @@ test('line chart seriesLabelFmt formats date series names', async ({mount, chart
   await expect(chart.el).screenshot('line-chart-series-label-fmt')
 })
 
-test('numeric year xFmt=yyyy keeps year labels', async ({mount, chart}) => {
+test('numeric year xFmt=yyyy keeps year labels', async({mount, chart}) => {
   await mount('components/BarChart.svelte', {
     data: yearlyCounts(),
     x: 'year',
@@ -170,7 +170,7 @@ test('numeric year xFmt=yyyy keeps year labels', async ({mount, chart}) => {
   await expect(chart.el).screenshot('bar-chart-numeric-year-xfmt')
 })
 
-test('bar chart accepts comma-separated multi y', async ({mount, chart}) => {
+test('bar chart accepts comma-separated multi y', async({mount, chart}) => {
   let data = timeseries() as any
   // augment dataset with a second numeric column while preserving metadata
   let rows = data.rows.map((r: any) => ({...r, profit_usd0k: r.sales_usd0k * 0.5}))
@@ -187,7 +187,7 @@ test('bar chart accepts comma-separated multi y', async ({mount, chart}) => {
   await expect(chart.el).screenshot('bar-chart-multi-y')
 })
 
-test('bar chart grouped labels', async ({mount, chart}) => {
+test('bar chart grouped labels', async({mount, chart}) => {
   await mount('components/BarChart.svelte', {
     data: timeseriesGrouped(),
     x: 'month',
@@ -210,7 +210,7 @@ test('bar chart grouped labels', async ({mount, chart}) => {
   await expect(chart.el).screenshot('bar-chart-grouped-labels')
 })
 
-test('bar chart invalid horizontal timeseries renders error state', async ({mount, page}) => {
+test('bar chart invalid horizontal timeseries renders error state', async({mount, page}) => {
   expectConsoleError('Error in Bar Chart')
 
   await mount('components/BarChart.svelte', {
@@ -225,7 +225,7 @@ test('bar chart invalid horizontal timeseries renders error state', async ({moun
   await expect(page.locator('#component-test')).screenshot('bar-chart-horizontal-timeseries-error')
 })
 
-test('line chart markers and step', async ({mount, chart}) => {
+test('line chart markers and step', async({mount, chart}) => {
   await mount('components/LineChart.svelte', {
     data: timeseries(),
     x: 'month',
@@ -247,7 +247,7 @@ test('line chart markers and step', async ({mount, chart}) => {
   await expect(chart.el).screenshot('line-chart-markers-step')
 })
 
-test('line chart wraps x labels when requested', async ({mount, chart}) => {
+test('line chart wraps x labels when requested', async({mount, chart}) => {
   let data = longCategorySeriesData()
   await mount('components/LineChart.svelte', {
     data,
@@ -268,7 +268,7 @@ test('line chart wraps x labels when requested', async ({mount, chart}) => {
   await expect(chart.el).screenshot('line-chart-wrapped-x-labels')
 })
 
-test('line chart applies axis controls and padding attributes', async ({mount, chart}) => {
+test('line chart applies axis controls and padding attributes', async({mount, chart}) => {
   await mount('components/LineChart.svelte', {
     data: timeseries(),
     x: 'month',
@@ -305,7 +305,7 @@ test('line chart applies axis controls and padding attributes', async ({mount, c
   await expect(chart.el).screenshot('line-chart-axis-controls')
 })
 
-test('area chart stacked100', async ({mount, chart}) => {
+test('area chart stacked100', async({mount, chart}) => {
   await mount('components/AreaChart.svelte', {
     data: timeseriesGrouped(),
     x: 'month',
@@ -323,7 +323,7 @@ test('area chart stacked100', async ({mount, chart}) => {
   await expect(chart.el).screenshot('area-chart-stacked100')
 })
 
-test('area chart supports stepped markers and hidden line', async ({mount, chart}) => {
+test('area chart supports stepped markers and hidden line', async({mount, chart}) => {
   await mount('components/AreaChart.svelte', {
     data: areaMissingData(),
     x: 'month',
@@ -347,7 +347,7 @@ test('area chart supports stepped markers and hidden line', async ({mount, chart
   await expect(chart.el).screenshot('area-chart-stepped-markers-no-line')
 })
 
-test('bar chart applies secondary axis colors and assignment', async ({mount, chart}) => {
+test('bar chart applies secondary axis colors and assignment', async({mount, chart}) => {
   let data = timeseries() as any
   let rows = data.rows.map((r: any) => ({...r, profit_usd0k: r.sales_usd0k * 0.15}))
   rows._evidenceColumnTypes = [...data.rows._evidenceColumnTypes, {name: 'profit_usd0k', evidenceType: 'number'}]
@@ -378,7 +378,7 @@ test('bar chart applies secondary axis colors and assignment', async ({mount, ch
   await expect(chart.el).screenshot('bar-chart-secondary-axis-line')
 })
 
-test('line chart applies series options to each rendered series', async ({mount, chart}) => {
+test('line chart applies series options to each rendered series', async({mount, chart}) => {
   await mount('components/LineChart.svelte', {
     data: timeseriesGrouped(),
     x: 'month',
@@ -393,7 +393,7 @@ test('line chart applies series options to each rendered series', async ({mount,
   await expect(chart.el).screenshot('line-chart-series-options-smooth')
 })
 
-test('pie chart with series options', async ({mount, chart}) => {
+test('pie chart with series options', async({mount, chart}) => {
   await mount('components/PieChart.svelte', {
     data: singleDim(),
     category: 'category',
@@ -415,7 +415,7 @@ test('pie chart with series options', async ({mount, chart}) => {
   await expect(chart.el).screenshot('pie-chart-labeled')
 })
 
-test('big value percent formatting', async ({mount, page}) => {
+test('big value percent formatting', async({mount, page}) => {
   await mount('components/BigValue.svelte', {
     data: percentData(),
     value: 'ratio',
@@ -430,7 +430,7 @@ test('big value percent formatting', async ({mount, page}) => {
   await expect(page.locator('#component-test')).screenshot('big-value-percent')
 })
 
-test('big value null renders em dash', async ({mount, page}) => {
+test('big value null renders em dash', async({mount, page}) => {
   await mount('components/BigValue.svelte', {
     data: nullValueData(),
     value: 'value',
@@ -442,7 +442,7 @@ test('big value null renders em dash', async ({mount, page}) => {
   await expect(page.locator('#component-test')).screenshot('big-value-null')
 })
 
-test('echarts primitive honors dimensions and metadata attributes', async ({mount, page}) => {
+test('echarts primitive honors dimensions and metadata attributes', async({mount, page}) => {
   await mount('components/ECharts.svelte', {
     config: {
       xAxis: {type: 'category', data: ['A', 'B', 'C']},
@@ -465,7 +465,7 @@ test('echarts primitive honors dimensions and metadata attributes', async ({moun
   await expect(page.locator('#component-test')).screenshot('echarts-standalone')
 })
 
-test('echarts primitive supports svg renderer', async ({mount, page}) => {
+test('echarts primitive supports svg renderer', async({mount, page}) => {
   await mount('components/ECharts.svelte', {
     config: {
       xAxis: {type: 'category', data: ['A', 'B', 'C']},
@@ -484,7 +484,7 @@ test('echarts primitive supports svg renderer', async ({mount, page}) => {
   await expect(page.locator('#component-test')).screenshot('echarts-svg-renderer')
 })
 
-function longCategorySeriesData () {
+function longCategorySeriesData() {
   let rows = [
     {label: 'A very long category label for January', value: 11},
     {label: 'A very long category label for February', value: 19},
@@ -498,19 +498,19 @@ function longCategorySeriesData () {
   return {rows}
 }
 
-function percentData () {
+function percentData() {
   let rows = [{ratio: 0.314}] as any
   rows._evidenceColumnTypes = [{name: 'ratio', evidenceType: 'number'}]
   return {rows}
 }
 
-function nullValueData () {
+function nullValueData() {
   let rows = [{value: null}] as any
   rows._evidenceColumnTypes = [{name: 'value', evidenceType: 'number'}]
   return {rows}
 }
 
-function areaMissingData () {
+function areaMissingData() {
   let rows = [
     {month: 'Jan', sales: 12},
     {month: 'Feb', sales: null},

--- a/ui/web.js
+++ b/ui/web.js
@@ -51,7 +51,7 @@ window.$GRAPHENE.renderComplete = (id) => {
   pendingRenders.delete(String(id))
 }
 
-window.$GRAPHENE.waitForLoad = async (timeout = 20_000) => {
+window.$GRAPHENE.waitForLoad = async(timeout = 20_000) => {
   let g = window.$GRAPHENE
   let end = Date.now() + timeout
   while (Date.now() < end) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     reporters: ['default', 'json'],
     outputFile: 'node_modules/.testResults.json',
     slowTestThreshold: 5_000,
-    onConsoleLog (log) {
+    onConsoleLog(log) {
       // silence some expected logs that aren't helpful in tests
       if (log.startsWith('Server running at http://')) return false
       if (log.startsWith('manually calling optimizeDeps is deprecated.')) return false

--- a/vscode/esbuild.mjs
+++ b/vscode/esbuild.mjs
@@ -8,7 +8,7 @@ const __dirname = path.dirname(__filename)
 
 const aliasPlugin = {
   name: 'alias-lang-analyze',
-  setup (b) {
+  setup(b) {
     b.onResolve({filter: /^@graphene\/lang$/}, _args => {
       return {path: path.resolve(__dirname, '../lang/core.ts')}
     })

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -5,7 +5,7 @@ import {LanguageClient, type LanguageClientOptions, type ServerOptions, State, T
 let client: LanguageClient
 let showedErrorToast = false
 
-export function activate (context: vscode.ExtensionContext) {
+export function activate(context: vscode.ExtensionContext) {
   let module = context.asAbsolutePath(path.join('dist', 'server.js'))
 
   let serverOptions: ServerOptions = {
@@ -35,7 +35,7 @@ export function activate (context: vscode.ExtensionContext) {
   })
 }
 
-export function deactivate () {
+export function deactivate() {
   if (client?.state === State.Running) {
     client?.stop()
   }

--- a/vscode/src/languageServer.ts
+++ b/vscode/src/languageServer.ts
@@ -56,17 +56,17 @@ connection.onDidChangeWatchedFiles(async change => {
 })
 
 let handle: NodeJS.Timeout | undefined
-function debouncedAnalyze () {
+function debouncedAnalyze() {
   if (handle) clearTimeout(handle)
   handle = setTimeout(analyzeNow, 200)
 }
 
-async function analyzeNow () {
+async function analyzeNow() {
   await initialLoad
   try {
     analyze()
     perFileVscodeDiagnostics().forEach(d => connection.sendDiagnostics(d))
-  } catch (err) {
+  } catch(err) {
     let message = (err instanceof Error ? (err.stack || err.message) : String(err))
     connection.console.error(`Analyze failed: ${message}`)
     connection.sendNotification('graphene/analyzeError', {message})
@@ -88,7 +88,7 @@ async function analyzeNow () {
 // })
 
 // Group diagnostics by file, and translate them to VSCode's format.
-function perFileVscodeDiagnostics () {
+function perFileVscodeDiagnostics() {
   let diags = getDiagnostics()
   return getFiles().map(f => {
     let diagnostics: Diagnostic[] = diags.filter(d => d.file == f.path).map(d => {
@@ -107,7 +107,7 @@ function perFileVscodeDiagnostics () {
   })
 }
 
-function toPath (uri: string) {
+function toPath(uri: string) {
   let abs = decodeURIComponent(uri.replace('file://', ''))
   // In graphene, paths should be relative to the root
   return path.relative(config.root, abs)


### PR DESCRIPTION
This seems like the only rule oxfmt and eslint disagree on. Pretty minor, but oxfmt doesn't make it configurable, so it wins!

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/145?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->