### PR TITLE
Automate publishing via action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,119 @@
+name: Publish
+
+# This publishes new package versions to npm and the vscode marketplaces when we detect that a [release]
+# commit has been merged to main. I chose to run this on push instead of on pull_request close to make it a bit
+# safer, but it means our logic to detect publishes is a little more complex.
+# In a nutshell, we need the commit to have [release] in the message, and then we check if there is a tag already for
+# the version in cli/package.json.
+# The publish runs on the exact sha in the PR, _not_ whatever is on main, ensuring we don't inadvertantly publish changes.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  detect:
+    if: startsWith(github.event.head_commit.message, '[release]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_release: ${{ steps.detect.outputs.should_release }}
+      pr_number: ${{ steps.detect.outputs.pr_number }}
+    steps:
+      - name: Detect release commit and merged PR
+        id: detect
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let mergeSha = context.payload.after
+            let commit = await github.graphql(`
+              query($owner: String!, $repo: String!, $oid: GitObjectID!) {
+                repository(owner: $owner, name: $repo) {
+                  object(oid: $oid) {
+                    ... on Commit {
+                      associatedPullRequests(first: 20) {
+                        nodes {
+                          number
+                          merged
+                          baseRefName
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, {owner: context.repo.owner, repo: context.repo.repo, oid: mergeSha})
+
+            let prs = commit.repository.object?.associatedPullRequests?.nodes || []
+            let pr = prs.find(x => x.merged && x.baseRefName === 'main')
+            if (!pr) throw new Error('Missing PR')
+
+            core.setOutput('pr_number', String(pr.number))
+            let pkg = await github.rest.repos.getContent({owner: context.repo.owner, repo: context.repo.repo, path: 'cli/package.json', ref: `refs/pull/${pr.number}/head`})
+
+            if (Array.isArray(pkg.data) || pkg.data.type !== 'file' || !pkg.data.content) {
+              throw new Error('Could not read cli/package.json from PR head commit')
+            }
+
+            let raw = Buffer.from(pkg.data.content, 'base64').toString('utf8')
+            let version = JSON.parse(raw).version
+            if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+              throw new Error(`Invalid version in cli/package.json: ${version}`)
+            }
+
+            let tagName = `v${version}`
+            let tagExists = true
+            try {
+              await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${tagName}`,
+              })
+            } catch (err) {
+              if (err.status === 404) tagExists = false
+              else throw err
+            }
+
+            let shouldRelease = !tagExists
+            // core.info(`changed files: ${changed.join(', ')}`)
+            core.info(`merged PR: #${pr.number}`)
+            core.info(`cli version: ${version}`)
+            core.info(`tag ${tagName} exists: ${tagExists}`)
+            core.info(`should release: ${shouldRelease}`)
+            core.setOutput('should_release', shouldRelease ? 'true' : 'false')
+
+  publish:
+    needs: [detect]
+    if: needs.detect.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    environment: publish
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout merged PR head
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ needs.detect.outputs.pr_number }}/head
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish release
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/publish.ts

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+/package.json @rogueg
+/.github/* @rogueg

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "graphene",
   "private": true,
+  "version": "0.0.14",
   "type": "module",
   "engines": {
     "node": ">=24.0.0"

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,3 @@ To test out packaged graphene, `cd cli && pnpm pack`. In a new folder, you can `
 Linking allows you to use your local version of Graphene (including uncommitted/unpublished changes) in another project.
 Within Graphene, `cd cli && npm link`. Then in the project consuming Graphene, `npm link @graphenedata/cli`
 If you use worktrees, you'll have to rerun both steps if you want to change which worktree a link points at.
-
-# Publishing
-`node --env-file=../../publish.env ./scripts/publish.ts patch`

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,88 +1,75 @@
 #!/usr/bin/env zx
 
-import {$, argv, fs, question} from 'zx'
+import {$, fs} from 'zx'
 
-// You'll need a env file that has the following tokens: VSCE_PAT, OVSX_PAT
-// node --env-file ../publish.env scripts/publi sh.ts patch
+// CI release entrypoint.
+// The workflow checks out the PR merge commit SHA before invoking this script,
+// so every side effect here (tag, package publish, GitHub release) is tied to that exact commit.
 
 $.verbose = true
-$.shell = 'zsh'
+$.shell = 'bash'
 
-let bumpLevel = argv._[0]
-if (!['major', 'minor', 'patch'].includes(bumpLevel)) {
-  throw new Error('Must provide major|minor|patch')
-}
-
+// Require all credentials up front so we fail before creating tags or publishing anything.
 if (!process.env.VSCE_PAT) throw new Error('VSCE_PAT required')
 if (!process.env.OVSX_PAT) throw new Error('OVSX_PAT required')
 
-// Check that we're logged in befores starting things
-await $`(cd vscode && npx vsce verify-pat)`
-await $`(cd vscode && npx ovsx verify-pat)`
-await $`(cd cli && pnpm whoami)`
-
-// let branch = (await $`git rev-parse --abbrev-ref HEAD`).stdout.trim()
-// if (branch !== 'main') throw new Error('Publishing must run on main')
-
-let status = (await $`git status --porcelain`).stdout.trim()
-status = status.replace('M CHANGELOG.md', '').trim() // changelog updates are expected, and will be committed
-if (status.length > 0) throw new Error('Working tree must be clean before publishing')
-
-await $`git fetch origin main --quiet`
-let tracking = (await $`git status -sb`).stdout.split('\n')[0]
-if (tracking.includes('behind')) {
-  if (!(await confirm('Repo is behind origin/main. Continue anyway? (y/N) '))) process.exit(1)
+// package.json is authoritative for release version; cli/vscode must match exactly.
+let rootVersion = await readVersion('package.json')
+let cliVersion = await readVersion('cli/package.json')
+let vscodeVersion = await readVersion('vscode/package.json')
+if (rootVersion !== cliVersion || rootVersion !== vscodeVersion) {
+  throw new Error(`Version mismatch: package=${rootVersion}, cli=${cliVersion}, vscode=${vscodeVersion}`)
 }
 
-let currentVersion = JSON.parse(await fs.readFile('cli/package.json', 'utf8')).version
-let nextVersion = bumpVersion(currentVersion, bumpLevel)
-let changelog = await fs.readFile('CHANGELOG.md', 'utf8')
-let hasNextSection = new RegExp(`^##\\s+${escapeRegex(nextVersion)}\\b`, 'm').test(changelog)
-if (!hasNextSection) {
-  throw new Error(`Missing CHANGELOG section for ${nextVersion}. Hey you should go run this change log command before publishing.`)
-}
+let tag = `v${rootVersion}`
 
-// tests
-await $`pnpm lint`
-await $`pnpm test`
-await $`pnpm check-examples`
+// Guard rails for retries and partial runs.
+// We intentionally fail on existing tag/release so we never publish two different artifacts for one version.
+await $`git fetch origin --tags --quiet`
+let localTagExists = (await $`git rev-parse --verify refs/tags/${tag}`.nothrow()).exitCode === 0
+if (localTagExists) throw new Error(`Tag ${tag} already exists locally`)
 
-// bump versions
-await $`(cd cli && npm version ${bumpLevel} --no-git-tag-version)`
-await $`(cd vscode && npm version ${bumpLevel} --no-git-tag-version)`
+let remoteTag = (await $`git ls-remote --tags origin refs/tags/${tag}`.nothrow()).stdout.trim()
+if (remoteTag) throw new Error(`Tag ${tag} already exists on origin`)
 
-// // dry-run packaging
-await $`(cd cli && npm publish --access public --dry-run)`
-if (!(await confirm('Does the npm publish dry run look right? (y/N) '))) process.exit(1)
-await $`(cd vscode && npx vsce package --no-dependencies)`
-if (!(await confirm('Does the vsce package look right? (y/N) '))) process.exit(1)
+let existingRelease = (await $`gh release view ${tag}`.nothrow()).exitCode === 0
+if (existingRelease) throw new Error(`GitHub release ${tag} already exists`)
 
-// actually publish
-await $({stdio: 'inherit'})`(cd cli && npm publish --access public)`
+// Tag first so package registries and GitHub release all point to the same immutable version marker.
+await $`git tag ${tag}`
+await $`git push origin ${tag}`
+
+// Publish package artifacts.
+await $`(cd cli && npm publish --access public)`
 await $`(cd vscode && npx vsce publish --no-dependencies)`
 await $`(cd vscode && npx ovsx publish --no-dependencies)`
 
-// create git commit/tag
-const version = JSON.parse(await fs.readFile('cli/package.json', 'utf8')).version
-await $`git add -A .`
-await $`git commit -m ${`Release v${version}`}`
-await $`git tag v${version}`
-await $`git push origin v${version}`
-await $`git push`
-console.log("Version pushed. Don't forget to create a PR for this change")
+// Publish GitHub release notes from the matching changelog section.
+let changelog = await fs.readFile('CHANGELOG.md', 'utf8')
+let releaseNotes = getChangelogSection(changelog, rootVersion)
+await fs.writeFile('.release-notes.md', releaseNotes)
+await $`gh release create ${tag} --title ${tag} --notes-file .release-notes.md`
 
-async function confirm(prompt: string) {
-  let answer = (await question(prompt)).trim().toLowerCase()
-  return answer === 'y' || answer === 'yes'
+console.log(`Published ${tag}`)
+
+async function readVersion(path: string) {
+  // Read and validate strict semver from a package manifest.
+  let json = JSON.parse(await fs.readFile(path, 'utf8'))
+  let version = json.version
+  if (!/^\d+\.\d+\.\d+$/.test(version)) throw new Error(`Invalid semver in ${path}: ${version}`)
+  return version
 }
 
-function bumpVersion(version: string, bumpLevel: string) {
-  let [major, minor, patch] = version.split('.').map(x => Number(x))
-  if (bumpLevel === 'major') return `${major + 1}.0.0`
-  if (bumpLevel === 'minor') return `${major}.${minor + 1}.0`
-  return `${major}.${minor}.${patch + 1}`
-}
+function getChangelogSection(changelog: string, version: string) {
+  // Extract the exact markdown block under "## <version>" until the next top-level version heading.
+  let targetHeader = `## ${version}`
+  let lines = changelog.split('\n')
+  let start = lines.findIndex(line => line.trim() === targetHeader)
+  if (start === -1) throw new Error(`Missing changelog section for ${version}`)
 
-function escapeRegex(text: string) {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  let end = lines.findIndex((line, idx) => idx > start && /^##\s+/.test(line))
+  let section = lines.slice(start + 1, end === -1 ? undefined : end).join('\n').trim()
+  if (!section) throw new Error(`Changelog section for ${version} is empty`)
+
+  return `## ${version}\n\n${section}`
 }


### PR DESCRIPTION
The idea is that to release, you have an agent make a release PR. When that PR is merged, we automatically create the github release, npm package, and git tags.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/150?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->