### PR TITLE
Add reset for queryEngine

### DIFF
--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -65,6 +65,12 @@ function unsubscribe(callback: ResultHandler) {
   queries = queries.filter(q => q.callback !== callback)
 }
 
+function resetQueryEngine() {
+  params = {}
+  queries = []
+  queryResults = {}
+}
+
 async function runNode(n: QueryNode) {
   if (!n.callback) throw new Error('running node nobody is listening to')
   n.callback({}) // notify that the query is loading
@@ -196,6 +202,7 @@ Object.assign(window.$GRAPHENE, {
   updateParam,
   query,
   unsubscribe,
+  resetQueryEngine,
   isQueryLoading,
   queryResults,
 })

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -105,7 +105,8 @@ async function runNode(n: QueryNode) {
       n.callback(result)
     } else {
       // request failed. Record it
-      let isJson = response.headers.get('Content-Type') === 'application/json'
+      let contentType = response.headers.get('Content-Type') || ''
+      let isJson = contentType.includes('application/json')
       let body = isJson ? await response.json() : await response.text()
       n.errors = Array.isArray(body) ? body : [{message: body}]
 


### PR DESCRIPTION
Used when we dynamically change the page, rather than a full page load

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/graphene-data/graphene/152?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->