### PR TITLE
Stop automatically quoting columns

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -145,7 +145,7 @@ function expandColumns(table: Table | null, alias: string, query: Query, scope: 
       let expr = analyzeExpr(col.exprNode, {query: scope.query, table, alias, otherTables: scope.otherTables})
       query.fields.push({name: outName, sql: expr.sql, type: expr.type, metadata: col.metadata})
     } else {
-      query.fields.push({name: outName, sql: `${alias}.${quoteColumn(col.name)}`, type: col.type, metadata: col.metadata})
+      query.fields.push({name: outName, sql: `${alias}.${col.name}`, type: col.type, metadata: col.metadata})
     }
   }
 }
@@ -325,8 +325,8 @@ function formatTablePath(path: string): string {
 }
 
 function buildSql(query: Query, cteMap: Map<string, CteTable>): string {
-  let ctes: string[] = [...cteMap.values()].map(c => `${quote(c.name)} as ( ${c.query.sql} )`)
-  let selectParts = query.fields.map(f => `${f.sql} as ${quote(f.name)}`)
+  let ctes: string[] = [...cteMap.values()].map(c => `${c.name} as ( ${c.query.sql} )`)
+  let selectParts = query.fields.map(f => `${f.sql} as ${f.name}`)
   let baseJoin = query.joins.find(j => j.source == 'from')
 
   // No FROM clause (e.g. `select 1`)
@@ -334,10 +334,10 @@ function buildSql(query: Query, cteMap: Map<string, CteTable>): string {
 
   function renderTableRef(table: Table): string {
     if (table.type === 'view') {
-      if (!ctes.some(c => c.startsWith(quote(table.name) + ' '))) {
-        ctes.push(`${quote(table.name)} as ( ${table.query.sql} )`)
+      if (!ctes.some(c => c.startsWith(table.name + ' '))) {
+        ctes.push(`${table.name} as ( ${table.query.sql} )`)
       }
-      return quote(table.name)
+      return table.name
     }
     if (table.type === 'subquery') return `( ${table.query.sql} )`
     return formatTablePath(table.tablePath)
@@ -397,7 +397,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       // Check output fields first (for referencing aliases in HAVING)
       if (scope.query && pathNodes.length == 0) {
         let outField = scope.query.fields.find(f => f.name == fieldName)
-        if (outField) return {sql: outField.isAgg ? quote(fieldName) : outField.sql, type: outField.type, isAgg: outField.isAgg}
+        if (outField) return {sql: outField.isAgg ? fieldName : outField.sql, type: outField.type, isAgg: outField.isAgg}
       }
 
       // Follow any dot path (e.g., `users.orders` in `users.orders.amount`), then find the field
@@ -429,7 +429,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       NODE_ENTITY_MAP.set(fieldNode, {entityType: 'field', field: col, table})
 
       // Simple case: this is just a regular column on a table
-      if (!col.exprNode) return {sql: `${alias}.${quoteColumn(col.name)}`, type: col.type}
+      if (!col.exprNode) return {sql: `${alias}.${col.name}`, type: col.type}
 
       // Computed column: analyze its expression in the matched table's scope
       if (analysisStack.has(col)) return diag(col.exprNode, 'Cycles are not allowed between computed columns', {sql: 'NULL', type: 'error'})
@@ -960,16 +960,4 @@ function convertDataType(dataType: string): FieldType | null {
     default:
       return null
   }
-}
-
-// Quote an identifier for the current dialect
-function quote(name: string): string {
-  if (config.dialect === 'bigquery') return `\`${name}\``
-  return `"${name}"`
-}
-
-function quoteColumn(name: string): string {
-  if (config.dialect === 'bigquery') return `\`${name}\``
-  if (config.dialect === 'snowflake') return `"${name.toUpperCase()}"`
-  return `"${name}"`
 }

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -86,31 +86,31 @@ describe('lang', () => {
   })
 
   it('handles basic select query', async () => {
-    expect('from users select id, name where id = 1').toRenderSql('SELECT users."id" as "id", users."name" as "name" from users as users WHERE users."id"=1')
+    expect('from users select id, name where id = 1').toRenderSql('SELECT users.id as id, users.name as name from users as users WHERE users.id=1')
     await expect('from users select id, name where id = 1').toReturnRows([1, 'Alice'])
   })
 
   it('handles select 1 without from', async () => {
-    expect('select 1').toRenderSql('SELECT 1 as "col_0"')
+    expect('select 1').toRenderSql('SELECT 1 as col_0')
     await expect('select 1').toReturnRows([1])
   })
 
-  it('uppercases identifiers for snowflake queries', () => {
+  it('renders unquoted identifiers for snowflake queries', () => {
     setConfig({dialect: 'snowflake', root: ''})
     expect('from users select id, orders.amount as amt order by amt desc').toRenderSql(
-      'SELECT users."ID" as "id", orders."AMOUNT" as "amt" FROM USERS as users LEFT JOIN ORDERS as orders ON orders."USER_ID"=users."ID" ORDER BY 2 desc NULLS LAST',
+      'SELECT users.id as id, orders.amount as amt FROM USERS as users LEFT JOIN ORDERS as orders ON orders.user_id=users.id ORDER BY 2 desc NULLS LAST',
     )
   })
 
   it('applies defaultNamespace to unqualified table paths', () => {
     setConfig({root: '', defaultNamespace: 'analytics'})
-    expect('from users select id').toRenderSql('select users."id" as "id" from analytics.users as users')
+    expect('from users select id').toRenderSql('select users.id as id from analytics.users as users')
   })
 
   it('does not apply defaultNamespace to already-qualified table paths', () => {
     setConfig({root: '', defaultNamespace: 'analytics'})
     updateFile('table raw.users (id int)', 'namespaced.gsql')
-    expect('from raw.users select id').toRenderSql('select users."id" as "id" from raw.users as users')
+    expect('from raw.users select id').toRenderSql('select users.id as id from raw.users as users')
   })
 
   it('ignores workspace files matched by ignoredFiles globs', async () => {
@@ -157,58 +157,55 @@ describe('lang', () => {
       'snowflake_chain.gsql',
     )
 
-    // Column references should be uppercase, aliases lowercase (quoted) for proper result set casing
-    // Note: uppercasing happens in core.ts via uppercaseTable() for table names, but column
-    // names in expressions still use original case.
+    // Snowflake table paths are uppercased by dialect formatting, while select aliases remain as authored.
+    // Note: this skipped test documents nested join-chain behavior that may diverge from current defaults.
     expect('from users_chain select orders_chain.order_item_view_chain.order_id').toRenderSql(
-      `SELECT orders_chain_order_item_view_chain."ORDER_ID" as "orders_chain_order_item_view_chain_order_id"
-        from USERS_CHAIN as USERS_CHAIN LEFT JOIN ORDERS_CHAIN AS orders_chain ON orders_chain."USER_ID"=USERS_CHAIN."ID"
-        LEFT JOIN ORDER_ITEM_VIEW_CHAIN AS orders_chain_order_item_view_chain ON orders_chain_order_item_view_chain."ORDER_ID"=orders_chain."ID"`,
+      `SELECT orders_chain_order_item_view_chain.ORDER_ID as orders_chain_order_item_view_chain_order_id
+        from USERS_CHAIN as USERS_CHAIN LEFT JOIN ORDERS_CHAIN AS orders_chain ON orders_chain.USER_ID=USERS_CHAIN.ID
+        LEFT JOIN ORDER_ITEM_VIEW_CHAIN AS orders_chain_order_item_view_chain ON orders_chain_order_item_view_chain.ORDER_ID=orders_chain.ID`,
       {preserveCase: true},
     )
   })
 
   it('expands plain wildcard', () => {
-    expect('from users select *').toRenderSql(
-      'select users."id" as "id", users."name" as "name", users."email" as "email", users."created_at" as "created_at", users."age" as "age" from users as users',
-    )
+    expect('from users select *').toRenderSql('select users.id as id, users.name as name, users.email as email, users.created_at as created_at, users.age as age from users as users')
   })
 
   it('expands plain wildcard when mixed with other select items', () => {
     expect('from users select *, email as contact').toRenderSql(
-      'select users."id" as "id", users."name" as "name", users."email" as "email", users."created_at" as "created_at", users."age" as "age", users."email" as "contact" from users as users',
+      'select users.id as id, users.name as name, users.email as email, users.created_at as created_at, users.age as age, users.email as contact from users as users',
     )
   })
 
   it('expands wildcards on a specific join', () => {
     expect('from orders select users.*').toRenderSql(
-      'select users."id" as "id", users."name" as "name", users."email" as "email", users."created_at" as "created_at", users."age" as "age" from orders as orders left join users as users on users."id"=orders."user_id"',
+      'select users.id as id, users.name as name, users.email as email, users.created_at as created_at, users.age as age from orders as orders left join users as users on users.id=orders.user_id',
     )
   })
 
   it('excludes aggregates from wildcard expansion', () => {
     // especially if those aggs are indirectly an agg agg expression
-    expect('table t (amount int, sum(amount) / count() as weird_avg) from t select *').toRenderSql('select t."amount" as "amount" from t as t')
+    expect('table t (amount int, sum(amount) / count() as weird_avg) from t select *').toRenderSql('select t.amount as amount from t as t')
   })
 
   it('expands dot-join syntax', () => {
-    expect('from orders select id, users.name').toRenderSql('select orders."id" as "id", users."name" as "users_name" from orders as orders left join users as users on users."id"=orders."user_id"')
+    expect('from orders select id, users.name').toRenderSql('select orders.id as id, users.name as users_name from orders as orders left join users as users on users.id=orders.user_id')
   })
 
   it('handles column naming when mutliple columns have the same name', () => {
     expect('from orders select users.id, order_items.id').toRenderSql(
-      'select users."id" as "users_id", order_items."id" as "order_items_id" from orders as orders left join users as users on users."id"=orders."user_id" left join order_items as order_items on order_items."order_id"=orders."id"',
+      'select users.id as users_id, order_items.id as order_items_id from orders as orders left join users as users on users.id=orders.user_id left join order_items as order_items on order_items.order_id=orders.id',
     )
   })
 
   it('supports ad-hoc query joins', () => {
     expect('from orders join users on users.id = orders.user_id select amount, users.name').toRenderSql(
-      'select orders."amount" as "amount", users."name" as "users_name" from orders as orders inner join users as users on users."id"=orders."user_id"',
+      'select orders.amount as amount, users.name as users_name from orders as orders inner join users as users on users.id=orders.user_id',
     )
   })
 
   it('supports cross join without an ON clause', () => {
-    expect('from orders cross join users select amount, users.name').toRenderSql('select orders."amount" as "amount", users."name" as "users_name" from orders as orders cross join users as users')
+    expect('from orders cross join users select amount, users.name').toRenderSql('select orders.amount as amount, users.name as users_name from orders as orders cross join users as users')
   })
 
   it('rejects cross join with an ON clause', () => {
@@ -216,9 +213,7 @@ describe('lang', () => {
   })
 
   it('resolves bare refs across ad-hoc joins and errors on ambiguity', () => {
-    expect('from orders join users on users.id = orders.user_id select amount').toRenderSql(
-      'select orders."amount" as "amount" from orders as orders inner join users as users on users."id"=orders."user_id"',
-    )
+    expect('from orders join users on users.id = orders.user_id select amount').toRenderSql('select orders.amount as amount from orders as orders inner join users as users on users.id=orders.user_id')
 
     expect('from orders join users on users.id = orders.user_id select id').toHaveDiagnostic(/ambiguous field "id"/i)
   })
@@ -227,17 +222,17 @@ describe('lang', () => {
     updateFile('table user_totals as (from orders select user_id, sum(amount) as total)', 'user_totals.gsql')
 
     expect('from users join user_totals on user_totals.user_id = users.id select name, user_totals.total').toRenderSql(
-      'with "user_totals" as ( select orders."user_id" as "user_id", sum(orders."amount") as "total" from orders as orders group by 1 order by 2 desc nulls last ) select users."name" as "name", user_totals."total" as "user_totals_total" from users as users inner join "user_totals" as user_totals on user_totals."user_id"=users."id"',
+      'with user_totals as ( select orders.user_id as user_id, sum(orders.amount) as total from orders as orders group by 1 order by 2 desc nulls last ) select users.name as name, user_totals.total as user_totals_total from users as users inner join user_totals as user_totals on user_totals.user_id=users.id',
     )
 
     expect('with active_users as (from users select id, name) from orders join active_users on active_users.id = orders.user_id select active_users.name').toRenderSql(
-      'with "active_users" as ( select users."id" as "id", users."name" as "name" from users as users ) select active_users."name" as "active_users_name" from orders as orders inner join active_users as active_users on active_users."id"=orders."user_id"',
+      'with active_users as ( select users.id as id, users.name as name from users as users ) select active_users.name as active_users_name from orders as orders inner join active_users as active_users on active_users.id=orders.user_id',
     )
   })
 
   it('expands measures', async () => {
     expect('from users select name, total_orders').toRenderSql(
-      'select users."name" as "name", (count(distinct orders."id")) as "total_orders" from users as users left join orders as orders on orders."user_id"=users."id" group by 1 order by 2 desc nulls last',
+      'select users.name as name, (count(distinct orders.id)) as total_orders from users as users left join orders as orders on orders.user_id=users.id group by 1 order by 2 desc nulls last',
     )
 
     await expect('from users select name, total_orders').toReturnRows(['Alice', 2], ['Bob', 1])
@@ -245,19 +240,19 @@ describe('lang', () => {
 
   it('handles expressions with aggregates', async () => {
     expect('from orders select user_id, avg_order_value').toRenderSql(
-      'select orders."user_id" as "user_id", (sum(orders."amount")/count(1)) as "avg_order_value" from orders as orders group by 1 order by 2 desc nulls last',
+      'select orders.user_id as user_id, (sum(orders.amount)/count(1)) as avg_order_value from orders as orders group by 1 order by 2 desc nulls last',
     )
 
     await expect('from orders select user_id, avg_order_value').toReturnRows([2, 40], [1, 30])
   })
 
   it('preserves parentheses in expressions for correct operator precedence', async () => {
-    expect('from users select (age + age) / (age + age) as result').toRenderSql('select (users."age"+users."age")/(users."age"+users."age") as "result" from users as users')
+    expect('from users select (age + age) / (age + age) as result').toRenderSql('select (users.age+users.age)/(users.age+users.age) as result from users as users')
     await expect('from users select (1 + 2) / (1 + 2) as result limit 1').toReturnRows([1])
   })
 
   it('supports || string concatenation', async () => {
-    expect("from users select name || ' suffix' as result").toRenderSql('select users."name"||\' suffix\' as "result" from users as users')
+    expect("from users select name || ' suffix' as result").toRenderSql("select users.name||' suffix' as result from users as users")
     await expect("from users select name || '!' as result limit 1").toReturnRows(['Alice!'])
   })
 
@@ -276,16 +271,16 @@ describe('lang', () => {
           rows between 1 preceding and current row
         ) as running_total
     `).toRenderSql(
-      'select orders."user_id" as "user_id", sum(orders."amount") OVER (PARTITION BY orders."user_id" ORDER BY orders."id" ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) as "running_total" from orders as orders',
+      'select orders.user_id as user_id, sum(orders.amount) OVER (PARTITION BY orders.user_id ORDER BY orders.id ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) as running_total from orders as orders',
     )
   })
 
   it('supports window-only functions with over', () => {
-    expect('from users select row_number() over (order by id) as rn').toRenderSql('select row_number() OVER (ORDER BY users."id" ASC) as "rn" from users as users')
+    expect('from users select row_number() over (order by id) as rn').toRenderSql('select row_number() OVER (ORDER BY users.id ASC) as rn from users as users')
   })
 
   it('supports empty over clause', () => {
-    expect('from users select row_number() over () as rn').toRenderSql('select row_number() OVER () as "rn" from users as users')
+    expect('from users select row_number() over () as rn').toRenderSql('select row_number() OVER () as rn from users as users')
   })
 
   it('rejects over on scalar functions', () => {
@@ -294,19 +289,19 @@ describe('lang', () => {
 
   it('does not treat windowed aggregates as query aggregates', () => {
     expect('from orders select id, sum(amount) over (order by id) as running_amount').toRenderSql(
-      'select orders."id" as "id", sum(orders."amount") OVER (ORDER BY orders."id" ASC) as "running_amount" from orders as orders',
+      'select orders.id as id, sum(orders.amount) OVER (ORDER BY orders.id ASC) as running_amount from orders as orders',
     )
   })
 
   it('supports count(*) over partitioning', () => {
     expect('from orders select id, count(*) over (partition by user_id) as flights_per_user').toRenderSql(
-      'select orders."id" as "id", count(1) OVER (PARTITION BY orders."user_id") as "flights_per_user" from orders as orders',
+      'select orders.id as id, count(1) OVER (PARTITION BY orders.user_id) as flights_per_user from orders as orders',
     )
   })
 
   it('supports range frame with unbounded following', () => {
     expect('from orders select id, sum(amount) over (order by id range between current row and unbounded following) as tail_sum').toRenderSql(
-      'select orders."id" as "id", sum(orders."amount") OVER (ORDER BY orders."id" ASC RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) as "tail_sum" from orders as orders',
+      'select orders.id as id, sum(orders.amount) OVER (ORDER BY orders.id ASC RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) as tail_sum from orders as orders',
     )
   })
 
@@ -334,9 +329,7 @@ describe('lang', () => {
     )`,
       'models.gsql',
     )
-    expect('from orders select rate').toRenderSql(
-      'select (((sum(orders."amount"))+(sum(orders."amount")/count(1)))/((sum(orders."amount"))+(sum(orders."amount")/count(1)))) as "rate" from orders as orders',
-    )
+    expect('from orders select rate').toRenderSql('select (((sum(orders.amount))+(sum(orders.amount)/count(1)))/((sum(orders.amount))+(sum(orders.amount)/count(1)))) as rate from orders as orders')
   })
 
   it('supports percentile aggregates via pXX shorthand', async () => {
@@ -345,19 +338,19 @@ describe('lang', () => {
 
   it('supports pXX over empty window', () => {
     expect('from orders select id, p50(amount) over () as p50_all order by id').toRenderSql(
-      'select orders."id" as "id", quantile_cont(orders."amount", 0.5) OVER () as "p50_all" from orders as orders order by 1 asc nulls last',
+      'select orders.id as id, quantile_cont(orders.amount, 0.5) OVER () as p50_all from orders as orders order by 1 asc nulls last',
     )
   })
 
   it('supports pXX over partition windows', () => {
     expect('from orders select id, p50(amount) over (partition by user_id) as p50_by_user order by id').toRenderSql(
-      'select orders."id" as "id", quantile_cont(orders."amount", 0.5) OVER (PARTITION BY orders."user_id") as "p50_by_user" from orders as orders order by 1 asc nulls last',
+      'select orders.id as id, quantile_cont(orders.amount, 0.5) OVER (PARTITION BY orders.user_id) as p50_by_user from orders as orders order by 1 asc nulls last',
     )
   })
 
   it('does not treat windowed pXX as query aggregates', () => {
     expect('from orders select id, p50(amount) over (partition by user_id) as p50_by_user').toRenderSql(
-      'select orders."id" as "id", quantile_cont(orders."amount", 0.5) OVER (PARTITION BY orders."user_id") as "p50_by_user" from orders as orders',
+      'select orders.id as id, quantile_cont(orders.amount, 0.5) OVER (PARTITION BY orders.user_id) as p50_by_user from orders as orders',
     )
   })
 
@@ -388,18 +381,18 @@ describe('lang', () => {
 
   it.skip('handles complex joins with measures', () => {
     expect('from products select name, category, total_sold where popular_item').toRenderSql(
-      'select products."name" as "name", products."category" as "category", (sum(orders."amount")) as "total_sold" from products as products left join orders as orders on orders."product_id"=products."id" group by 1, 2 having sum(orders."amount")>1000 order by 3 desc nulls last',
+      'select products.name as name, products.category as category, (sum(orders.amount)) as total_sold from products as products left join orders as orders on orders.product_id=products.id group by 1, 2 having sum(orders.amount)>1000 order by 3 desc nulls last',
     )
   })
 
   it.skip('handles subqueries', () => {
-    expect('from (select id, name from users) select id, name').toRenderSql(`WITH __stage0 AS ( SELECT users."id" as "id", users."name" as "name" from users as users )
-      SELECT __stage0."id" as "id", __stage0."name" as "name" from __stage0 as __stage0`)
+    expect('from (select id, name from users) select id, name').toRenderSql(`WITH __stage0 AS ( SELECT users.id as id, users.name as name from users as users )
+      SELECT __stage0.id as id, __stage0.name as name from __stage0 as __stage0`)
   })
 
   it.skip('handles subqueries with alias', () => {
-    expect('from (select id, name from users) as u select id, name').toRenderSql(`WITH __stage0 AS ( SELECT users."id" as "id", users."name" as "name" from users as users )
-      SELECT __stage0."id" as "id", __stage0."name" as "name" from __stage0 as __stage0`)
+    expect('from (select id, name from users) as u select id, name').toRenderSql(`WITH __stage0 AS ( SELECT users.id as id, users.name as name from users as users )
+      SELECT __stage0.id as id, __stage0.name as name from __stage0 as __stage0`)
   })
 
   // Skipped: computed columns accessed through joins are not fully expanded yet.
@@ -426,7 +419,7 @@ describe('lang', () => {
 
     expect('from users select name, ltv') // query the view indirectly, through a join
       .toRenderSql(
-        'with __stage0 as ( select users."id" as "id", (coalesce(sum(orders."amount"),0)) as "ltv" from users as users left join orders as orders on orders."user_id"=users."id" group by 1 ) select users."name" as "name", (user_facts."ltv") as "ltv" from users as users left join __stage0 as user_facts on user_facts."id"=users."id"',
+        'with __stage0 as ( select users.id as id, (coalesce(sum(orders.amount),0)) as ltv from users as users left join orders as orders on orders.user_id=users.id group by 1 ) select users.name as name, (user_facts.ltv) as ltv from users as users left join __stage0 as user_facts on user_facts.id=users.id',
       )
 
     await expect('select * from users') // wildcards should include ltv
@@ -446,7 +439,7 @@ describe('lang', () => {
     )
 
     expect('from order_items select id, users.name').toRenderSql(
-      'select order_items."id" as "id", users."name" as "users_name" from order_items as order_items left join users as users on users."id"=order_items."user_id"',
+      'select order_items.id as id, users.name as users_name from order_items as order_items left join users as users on users.id=order_items.user_id',
     )
   })
 
@@ -458,7 +451,7 @@ describe('lang', () => {
     updateFile(testTables, 'models.gsql')
 
     expect('from user_facts select id, email order by id').toRenderSql(
-      'with "user_facts" as ( select users."id" as "id", users."name" as "name", users."email" as "email", users."created_at" as "created_at", users."age" as "age" from users as users ) select user_facts."id" as "id", user_facts."email" as "email" from "user_facts" as user_facts order by 1 asc nulls last',
+      'with user_facts as ( select users.id as id, users.name as name, users.email as email, users.created_at as created_at, users.age as age from users as users ) select user_facts.id as id, user_facts.email as email from user_facts as user_facts order by 1 asc nulls last',
     )
   })
 
@@ -472,7 +465,7 @@ describe('lang', () => {
     )
 
     expect('from dataset.users select id, orders.id').toRenderSql(
-      'select users."id" as "id", orders."id" as "orders_id" from dataset.users as users left join dataset.orders as orders on users."id"=orders."user_id"',
+      'select users.id as id, orders.id as orders_id from dataset.users as users left join dataset.orders as orders on users.id=orders.user_id',
     )
   })
 
@@ -498,39 +491,39 @@ describe('lang', () => {
     )
 
     expect('from users select name, order_stats.total_spent order by name').toRenderSql(
-      'with "order_stats" as ( select orders."user_id" as "user_id", sum(orders."amount") as "total_spent" from orders as orders group by 1 order by 2 desc nulls last ) select users."name" as "name", order_stats."total_spent" as "order_stats_total_spent" from users as users left join "order_stats" as order_stats on order_stats."user_id"=users."id" order by 1 asc nulls last',
+      'with order_stats as ( select orders.user_id as user_id, sum(orders.amount) as total_spent from orders as orders group by 1 order by 2 desc nulls last ) select users.name as name, order_stats.total_spent as order_stats_total_spent from users as users left join order_stats as order_stats on order_stats.user_id=users.id order by 1 asc nulls last',
     )
 
     await expect('from users select name, order_stats.total_spent order by name').toReturnRows(['Alice', 60], ['Bob', 40])
   })
 
   it('supports select distinct', () => {
-    expect('from users select distinct name, email').toRenderSql('select users."name" as "name", users."email" as "email" from users as users group by 1,2 order by 1 asc nulls last')
+    expect('from users select distinct name, email').toRenderSql('select users.name as name, users.email as email from users as users group by 1,2 order by 1 asc nulls last')
   })
 
   it('coun(distinct)', () => {
-    expect('from users select count(distinct name)').toRenderSql('select count(distinct users."name") as "col_0" from users as users')
+    expect('from users select count(distinct name)').toRenderSql('select count(distinct users.name) as col_0 from users as users')
   })
 
   it('adds groupBy to select if needed', () => {
     expect('from users select count(orders.id) as total group by name').toRenderSql(
-      'select users."name" as "name", count(distinct orders."id") as "total" from users as users left join orders as orders on orders."user_id"=users."id" group by 1 order by 2 desc nulls last',
+      'select users.name as name, count(distinct orders.id) as total from users as users left join orders as orders on orders.user_id=users.id group by 1 order by 2 desc nulls last',
     )
   })
 
   it('doesnt duplicate groupBys', () => {
     expect('from users select name, count(orders.id) group by name').toRenderSql(
-      'select users."name" as "name", count(distinct orders."id") as "col_1" from users as users left join orders as orders on orders."user_id"=users."id" group by 1 order by 2 desc nulls last',
+      'select users.name as name, count(distinct orders.id) as col_1 from users as users left join orders as orders on orders.user_id=users.id group by 1 order by 2 desc nulls last',
     )
   })
 
   it('group by can refer to an alias', () => {
-    expect('from users select name as n group by n').toRenderSql('select users."name" as "n" from users as users group by 1 order by 1 asc nulls last')
+    expect('from users select name as n group by n').toRenderSql('select users.name as n from users as users group by 1 order by 1 asc nulls last')
   })
 
   it('group by positional number', async () => {
     expect('from users select name, email, avg(age) group by 2, 1').toRenderSql(
-      'select users."name" as "name", users."email" as "email", avg(users."age") as "col_2" from users as users group by 2,1 order by 3 desc nulls last',
+      'select users.name as name, users.email as email, avg(users.age) as col_2 from users as users group by 2,1 order by 3 desc nulls last',
     )
     await expect('from users select name, email, avg(age) group by 2, 1').toReturnRows(['Bob', 'bob@example.com', 40], ['Alice', 'alice@example.com', 30])
   })
@@ -548,9 +541,7 @@ describe('lang', () => {
   })
 
   it('order by positional number', () => {
-    expect('from users select name, email order by 2 asc, 1 desc').toRenderSql(
-      'select users."name" as "name", users."email" as "email" from users as users order by 2 asc nulls last,1 desc nulls last',
-    )
+    expect('from users select name, email order by 2 asc, 1 desc').toRenderSql('select users.name as name, users.email as email from users as users order by 2 asc nulls last,1 desc nulls last')
   })
 
   it('order by nonexistent field produces diagnostic', () => {
@@ -562,9 +553,9 @@ describe('lang', () => {
   })
 
   it('supports is null/is not null', () => {
-    expect('from users select name where email is null').toRenderSql('select users."name" as "name" from users as users where users."email" is null')
+    expect('from users select name where email is null').toRenderSql('select users.name as name from users as users where users.email is null')
 
-    expect('from users select name where email is not null').toRenderSql('select users."name" as "name" from users as users where users."email" is not null')
+    expect('from users select name where email is not null').toRenderSql('select users.name as name from users as users where users.email is not null')
   })
 
   it('parses offset but reports diagnostic', () => {
@@ -572,30 +563,28 @@ describe('lang', () => {
   })
 
   it('supports in expressions', () => {
-    expect("from users select id where name in ('Alice','Bob')").toRenderSql('select users."id" as "id" from users as users where users."name" in (\'Alice\',\'Bob\')')
-    expect("from users select id where name not in ('Alice','Bob')").toRenderSql('select users."id" as "id" from users as users where users."name" not in (\'Alice\',\'Bob\')')
+    expect("from users select id where name in ('Alice','Bob')").toRenderSql("select users.id as id from users as users where users.name in ('Alice','Bob')")
+    expect("from users select id where name not in ('Alice','Bob')").toRenderSql("select users.id as id from users as users where users.name not in ('Alice','Bob')")
   })
 
   it('supports between expressions', () => {
-    expect('from users select id where age between 18 and 30').toRenderSql('select users."id" as "id" from users as users where users."age" BETWEEN 18 AND 30')
-    expect('from users select id where age not between 18 and 30').toRenderSql('select users."id" as "id" from users as users where users."age" NOT BETWEEN 18 AND 30')
+    expect('from users select id where age between 18 and 30').toRenderSql('select users.id as id from users as users where users.age BETWEEN 18 AND 30')
+    expect('from users select id where age not between 18 and 30').toRenderSql('select users.id as id from users as users where users.age NOT BETWEEN 18 AND 30')
     expect('from users select id where age between 18 and 30 and email is not null').toRenderSql(
-      'select users."id" as "id" from users as users where (users."age" BETWEEN 18 AND 30 AND users."email" IS NOT NULL)',
+      'select users.id as id from users as users where (users.age BETWEEN 18 AND 30 AND users.email IS NOT NULL)',
     )
     expect('from users select id where age between 18 and 30 or email is not null').toRenderSql(
-      'select users."id" as "id" from users as users where (users."age" BETWEEN 18 AND 30 OR users."email" IS NOT NULL)',
+      'select users.id as id from users as users where (users.age BETWEEN 18 AND 30 OR users.email IS NOT NULL)',
     )
   })
 
   it('supports case expressions', () => {
-    expect("from users select case when age > 35 then 'old' else 'young' end as bucket").toRenderSql(
-      'select case when (users."age">35) then \'old\' else \'young\' end as "bucket" from users as users',
-    )
+    expect("from users select case when age > 35 then 'old' else 'young' end as bucket").toRenderSql("select case when (users.age>35) then 'old' else 'young' end as bucket from users as users")
   })
 
   it('propagates isAgg through case expressions for GROUP BY', () => {
     expect("from users select name, case when count() > 2 then 'many' else 'few' end as bucket").toRenderSql(
-      'select users."name" as "name", case WHEN (count(1)>2) THEN \'many\' ELSE \'few\' END as "bucket" from users as users group by 1 order by 2 desc nulls last',
+      "select users.name as name, case WHEN (count(1)>2) THEN 'many' ELSE 'few' END as bucket from users as users group by 1 order by 2 desc nulls last",
     )
   })
 
@@ -687,24 +676,24 @@ describe('lang', () => {
   it('can create new tables from queries', () => {
     expect(`table completed_orders as (from orders where status = 'completed' select id)
       from completed_orders select id`).toRenderSql(
-      'with "completed_orders" as ( select orders."id" as "id" from orders as orders where orders."status"=\'completed\' ) select completed_orders."id" as "id" from "completed_orders" as completed_orders',
+      "with completed_orders as ( select orders.id as id from orders as orders where orders.status='completed' ) select completed_orders.id as id from completed_orders as completed_orders",
     )
   })
 
   it('can correctly count through a join', () => {
-    expect('from orders select count(users.id)').toRenderSql('select count(distinct users."id") as "col_0" from orders as orders left join users as users on users."id"=orders."user_id"')
+    expect('from orders select count(users.id)').toRenderSql('select count(distinct users.id) as col_0 from orders as orders left join users as users on users.id=orders.user_id')
   })
 
   it('handles min/max through a join', () => {
-    expect('from orders select min(users.age)').toRenderSql('select min(users."age") as "col_0" from orders as orders left join users as users on users."id"=orders."user_id"')
+    expect('from orders select min(users.age)').toRenderSql('select min(users.age) as col_0 from orders as orders left join users as users on users.id=orders.user_id')
   })
 
   it('supports function calling', () => {
-    expect("from users select coalesce(name, 'Unknown') as name2").toRenderSql('select coalesce(users."name",\'Unknown\') as "name2" from users as users')
+    expect("from users select coalesce(name, 'Unknown') as name2").toRenderSql("select coalesce(users.name,'Unknown') as name2 from users as users")
   })
 
   it('supports agg function calling', () => {
-    expect('from users select age, string_agg(name)').toRenderSql('select users."age" as "age", string_agg(users."name") as "col_1" from users as users group by 1 order by 2 desc nulls last')
+    expect('from users select age, string_agg(name)').toRenderSql('select users.age as age, string_agg(users.name) as col_1 from users as users group by 1 order by 2 desc nulls last')
   })
 
   it('rejects variadic functions called with 0 args', () => {
@@ -725,28 +714,28 @@ describe('lang', () => {
     // This test ensures generic return types with aggregate: true are properly marked as measures
     // When working correctly, it should generate SQL with group by (since it's an aggregate)
     expect('from users select name, any_value(age) as sample_age').toRenderSql(
-      'select users."name" as "name", any_value(users."age") as "sample_age" from users as users group by 1 order by 2 desc nulls last',
+      'select users.name as name, any_value(users.age) as sample_age from users as users group by 1 order by 2 desc nulls last',
     )
   })
 
   it.skip('supports malloy date functions', () => {
-    expect('from users select name, month(created_at)').toRenderSql('select users."name" as "name", extract(month from users."created_at") as "col_1" from users as users')
+    expect('from users select name, month(created_at)').toRenderSql('select users.name as name, extract(month from users.created_at) as col_1 from users as users')
   })
 
   it('allows queries with semicolons', () => {
-    expect('table t (id int); select id, name from users;').toRenderSql('select users."id" as "id", users."name" as "name" from users as users')
+    expect('table t (id int); select id, name from users;').toRenderSql('select users.id as id, users.name as name from users as users')
   })
 
   it('allows trailing commas in select/group/order/in lists and function args', () => {
-    expect('select id, name, from users').toRenderSql('select users."id" as "id", users."name" as "name" from users as users')
+    expect('select id, name, from users').toRenderSql('select users.id as id, users.name as name from users as users')
 
-    expect('from users select count() group by name,').toRenderSql('select users."name" as "name", count(1) as "col_0" from users as users group by 1 order by 2 desc nulls last')
+    expect('from users select count() group by name,').toRenderSql('select users.name as name, count(1) as col_0 from users as users group by 1 order by 2 desc nulls last')
 
-    expect('from users select name order by name asc,').toRenderSql('select users."name" as "name" from users as users order by 1 asc nulls last')
+    expect('from users select name order by name asc,').toRenderSql('select users.name as name from users as users order by 1 asc nulls last')
 
-    expect("from users select id where name in ('Alice','Bob',)").toRenderSql('select users."id" as "id" from users as users where users."name" in (\'Alice\',\'Bob\')')
+    expect("from users select id where name in ('Alice','Bob',)").toRenderSql("select users.id as id from users as users where users.name in ('Alice','Bob')")
 
-    expect("from users select coalesce(name, 'Unknown',) as name2").toRenderSql('select coalesce(users."name",\'Unknown\') as "name2" from users as users')
+    expect("from users select coalesce(name, 'Unknown',) as name2").toRenderSql("select coalesce(users.name,'Unknown') as name2 from users as users")
   })
 
   it('allows optional commas between table items and semicolon terminators', () => {
@@ -754,50 +743,48 @@ describe('lang', () => {
       id int,
       name text
     );
-    from t select id, name`).toRenderSql('select t."id" as "id", t."name" as "name" from t as t')
+    from t select id, name`).toRenderSql('select t.id as id, t.name as name from t as t')
 
     expect(`table completed_ids as (from users select id,) ;
-      from completed_ids select id`).toRenderSql('with "completed_ids" as ( select users."id" as "id" from users as users ) select completed_ids."id" as "id" from "completed_ids" as completed_ids')
+      from completed_ids select id`).toRenderSql('with completed_ids as ( select users.id as id from users as users ) select completed_ids.id as id from completed_ids as completed_ids')
   })
 
   it('supports count_if (function we added)', () => {
-    expect('from orders select count_if(amount > 100)').toRenderSql('select count_if(orders."amount">100) as "col_0" from orders as orders')
+    expect('from orders select count_if(amount > 100)').toRenderSql('select count_if(orders.amount>100) as col_0 from orders as orders')
   })
 
   it('supports count_if alias for countif on BigQuery', () => {
     setConfig({root: '', bigquery: {}})
-    expect('from orders select count_if(amount > 100)').toRenderSql('select countif(orders.`amount`>100) as `col_0` from `orders` as orders')
+    expect('from orders select count_if(amount > 100)').toRenderSql('select countif(orders.amount>100) as col_0 from `orders` as orders')
   })
 
   it('supports BigQuery math functions', () => {
     setConfig({root: '', bigquery: {}})
     expect('from orders select abs(amount), sqrt(amount), round(amount, 2)').toRenderSql(
-      'select abs(orders.`amount`) as `col_0`, sqrt(orders.`amount`) as `col_1`, round(orders.`amount`,2) as `col_2` from `orders` as orders',
+      'select abs(orders.amount) as col_0, sqrt(orders.amount) as col_1, round(orders.amount,2) as col_2 from `orders` as orders',
     )
   })
 
   it('supports BigQuery string functions', () => {
     setConfig({root: '', bigquery: {}})
-    expect('from users select lower(name), upper(name), length(name)').toRenderSql(
-      'select lower(users.`name`) as `col_0`, upper(users.`name`) as `col_1`, length(users.`name`) as `col_2` from `users` as users',
-    )
+    expect('from users select lower(name), upper(name), length(name)').toRenderSql('select lower(users.name) as col_0, upper(users.name) as col_1, length(users.name) as col_2 from `users` as users')
   })
 
   it('supports functions with keyword args', () => {
     setConfig({root: '', bigquery: {}})
-    expect('from users select timestamp_diff(created_at, created_at, day)').toRenderSql('select timestamp_diff(users.`created_at`,users.`created_at`,day) as `col_0` from `users` as users')
+    expect('from users select timestamp_diff(created_at, created_at, day)').toRenderSql('select timestamp_diff(users.created_at,users.created_at,day) as col_0 from `users` as users')
   })
 
   it('renders BigQuery pXX windows via PERCENTILE_CONT', () => {
     setConfig({root: '', bigquery: {}})
     expect('from orders select id, p50(amount) over (partition by user_id) as p50_by_user order by id').toRenderSql(
-      'select orders.`id` as `id`, PERCENTILE_CONT(orders.`amount`, 0.5) OVER (PARTITION BY orders.`user_id`) as `p50_by_user` from `orders` as orders order by 1 asc nulls last',
+      'select orders.id as id, PERCENTILE_CONT(orders.amount, 0.5) OVER (PARTITION BY orders.user_id) as p50_by_user from `orders` as orders order by 1 asc nulls last',
     )
   })
 
   it('keeps existing BigQuery non-window pXX behavior', () => {
     setConfig({root: '', bigquery: {}})
-    expect('from orders select p50(amount) as p50').toRenderSql('select approx_quantiles(orders.`amount`, 100)[OFFSET(50)] as `p50` from `orders` as orders')
+    expect('from orders select p50(amount) as p50').toRenderSql('select approx_quantiles(orders.amount, 100)[OFFSET(50)] as p50 from `orders` as orders')
   })
 
   it('keeps BigQuery pXX limits for windows', () => {
@@ -809,48 +796,46 @@ describe('lang', () => {
     setConfig({root: '', bigquery: {}})
     updateFile('table calendar (created_at timestamp, day text, week text)', 'calendar.gsql')
 
-    expect('from calendar select week').toRenderSql('select calendar.`week` as `week` from `calendar` as calendar')
+    expect('from calendar select week').toRenderSql('select calendar.week as week from `calendar` as calendar')
 
-    expect('from calendar select timestamp_diff(created_at, created_at, week)').toRenderSql(
-      'select timestamp_diff(calendar.`created_at`,calendar.`created_at`,week) as `col_0` from `calendar` as calendar',
-    )
+    expect('from calendar select timestamp_diff(created_at, created_at, week)').toRenderSql('select timestamp_diff(calendar.created_at,calendar.created_at,week) as col_0 from `calendar` as calendar')
 
-    expect('from calendar select date_trunc(created_at, week)').toRenderSql('select date_trunc(calendar.`created_at`,week) as `col_0` from `calendar` as calendar')
+    expect('from calendar select date_trunc(created_at, week)').toRenderSql('select date_trunc(calendar.created_at,week) as col_0 from `calendar` as calendar')
   })
 
   it('supports date_trunc on date columns (as opposed to timestamp)', () => {
     setConfig({root: '', bigquery: {}})
     updateFile('table events (event_date date)', 'events.gsql')
-    expect('from events select date_trunc(event_date, month)').toRenderSql('select date_trunc(events.`event_date`,month) as `col_0` from `events` as events')
+    expect('from events select date_trunc(event_date, month)').toRenderSql('select date_trunc(events.event_date,month) as col_0 from `events` as events')
 
     setConfig({root: ''}) // duckdb (default)
-    expect("from events select date_trunc('month', event_date)").toRenderSql('select date_trunc(\'month\',events."event_date") as "col_0" from events as events')
+    expect("from events select date_trunc('month', event_date)").toRenderSql("select date_trunc('month',events.event_date) as col_0 from events as events")
 
     setConfig({dialect: 'snowflake', root: ''})
-    expect("from events select date_trunc('month', event_date)").toRenderSql('select DATE_TRUNC(\'month\',EVENTS."EVENT_DATE") as "COL_0" from EVENTS as EVENTS')
+    expect("from events select date_trunc('month', event_date)").toRenderSql("select DATE_TRUNC('month',EVENTS.EVENT_DATE) as COL_0 from EVENTS as EVENTS")
   })
 
   it('supports extract expressions', () => {
-    expect('from users select extract(hour from created_at)').toRenderSql('select extract(hour from users."created_at") as "col_0" from users as users')
+    expect('from users select extract(hour from created_at)').toRenderSql('select extract(hour from users.created_at) as col_0 from users as users')
   })
 
   it('supports null and boolean literals', () => {
-    expect('from users select name, null, true, FALSE').toRenderSql('select users."name" as "name", null as "col_1", true as "col_2", false as "col_3" from users as users')
+    expect('from users select name, null, true, FALSE').toRenderSql('select users.name as name, null as col_1, true as col_2, false as col_3 from users as users')
   })
 
   it('coerces string literals to timestamps in comparisons', () => {
-    expect("from users select id where created_at >= '2024-01-01'").toRenderSql('select users."id" as "id" from users as users where users."created_at">=TIMESTAMP \'2024-01-01 00:00:00\'')
+    expect("from users select id where created_at >= '2024-01-01'").toRenderSql("select users.id as id from users as users where users.created_at>=TIMESTAMP '2024-01-01 00:00:00'")
   })
 
   it('coerces string literals to timestamps in IN lists', () => {
     expect("from users select id where created_at in ('2024-01-01','2024-01-02')").toRenderSql(
-      'select users."id" as "id" from users as users where users."created_at" in (TIMESTAMP \'2024-01-01 00:00:00\',TIMESTAMP \'2024-01-02 00:00:00\')',
+      "select users.id as id from users as users where users.created_at in (TIMESTAMP '2024-01-01 00:00:00',TIMESTAMP '2024-01-02 00:00:00')",
     )
   })
 
   it('coerces string literals to timestamps in BETWEEN bounds', () => {
     expect("from users select id where created_at between '2024-01-01' and '2024-01-31'").toRenderSql(
-      'select users."id" as "id" from users as users where users."created_at" BETWEEN TIMESTAMP \'2024-01-01 00:00:00\' AND TIMESTAMP \'2024-01-31 00:00:00\'',
+      "select users.id as id from users as users where users.created_at BETWEEN TIMESTAMP '2024-01-01 00:00:00' AND TIMESTAMP '2024-01-31 00:00:00'",
     )
   })
 
@@ -870,35 +855,33 @@ describe('lang', () => {
   })
 
   it('supports interval keyword with quoted string', () => {
-    expect("from users select created_at + interval '5 minutes' as shifted").toRenderSql('select users."created_at" + INTERVAL 5 minute as "shifted" from users as users')
+    expect("from users select created_at + interval '5 minutes' as shifted").toRenderSql('select users.created_at + INTERVAL 5 minute as shifted from users as users')
   })
 
   it('supports interval keyword with unquoted number and unit', () => {
-    expect('from users select created_at + interval 5 minutes as shifted').toRenderSql('select users."created_at" + INTERVAL 5 minute as "shifted" from users as users')
+    expect('from users select created_at + interval 5 minutes as shifted').toRenderSql('select users.created_at + INTERVAL 5 minute as shifted from users as users')
   })
 
   it('supports interval keyword with numeric field quantity', () => {
-    expect('from users select created_at - interval age minute as shifted').toRenderSql('select users."created_at" - INTERVAL users."age" minute as "shifted" from users as users')
+    expect('from users select created_at - interval age minute as shifted').toRenderSql('select users.created_at - INTERVAL users.age minute as shifted from users as users')
   })
 
   it('supports date keyword', () => {
-    expect("from users select date '2024-01-01' as d").toRenderSql('select DATE \'2024-01-01\' as "d" from users as users')
+    expect("from users select date '2024-01-01' as d").toRenderSql("select DATE '2024-01-01' as d from users as users")
   })
 
   it('allows temporal keywords as column names', () => {
     // Columns can be named 'date' or 'timestamp' even though these are also keywords for literals
     updateFile('table foo (id VARCHAR, date DATE, timestamp TIMESTAMP)', 'foo.gsql')
-    expect('from foo select id').toRenderSql('select foo."id" as "id" from foo as foo')
+    expect('from foo select id').toRenderSql('select foo.id as id from foo as foo')
   })
 
   it('supports timestamp keyword', () => {
-    expect("from users select id where created_at >= timestamp '2024-01-01 12:00:00'").toRenderSql(
-      'select users."id" as "id" from users as users where users."created_at">=TIMESTAMP \'2024-01-01 12:00:00\'',
-    )
+    expect("from users select id where created_at >= timestamp '2024-01-01 12:00:00'").toRenderSql("select users.id as id from users as users where users.created_at>=TIMESTAMP '2024-01-01 12:00:00'")
   })
 
   it('supports ::DATE cast syntax', () => {
-    expect("from users select '2024-01-01'::DATE as d").toRenderSql('select CAST(\'2024-01-01\' AS DATE) as "d" from users as users')
+    expect("from users select '2024-01-01'::DATE as d").toRenderSql("select CAST('2024-01-01' AS DATE) as d from users as users")
   })
 
   it('diagnoses invalid date literal in date keyword', () => {
@@ -926,7 +909,7 @@ describe('lang', () => {
   })
 
   it('allows join expressions to refer to the alias', () => {
-    expect('table t (oid int, join one users as usr on usr.id = oid); from t select usr.name').toRenderSql('select usr."name" as "usr_name" from t as t left join users as usr on usr."id"=t."oid"')
+    expect('table t (oid int, join one users as usr on usr.id = oid); from t select usr.name').toRenderSql('select usr.name as usr_name from t as t left join users as usr on usr.id=t.oid')
   })
 
   it('allows measures to refer to themselves', () => {
@@ -937,7 +920,7 @@ describe('lang', () => {
     let queries = analyze(`${testTables}
       from users select id where name = $name
     `)
-    expect(toSql(queries[0], {name: 'Alice'})).toMatch(/WHERE users\."name"='Alice'/)
+    expect(toSql(queries[0], {name: 'Alice'})).toMatch(/WHERE users\.name='Alice'/)
   })
 
   it('does not treat $word inside single-quoted strings as params', () => {
@@ -964,7 +947,7 @@ describe('lang', () => {
         current_timestamp(),
         current_timestamp(3),
         local_timestamp()
-    `).toRenderSql('select current_date() as "col_0", current_time() as "col_1", current_timestamp() as "col_2", current_timestamp(3) as "col_3", localtimestamp() as "col_4" from users as users')
+    `).toRenderSql('select current_date() as col_0, current_time() as col_1, current_timestamp() as col_2, current_timestamp(3) as col_3, localtimestamp() as col_4 from users as users')
   })
 
   it('supports bigquery current datetime functions with optional args', () => {
@@ -982,7 +965,7 @@ describe('lang', () => {
           current_datetime(),
           current_datetime('UTC')
       `).toRenderSql(
-        "select current_date() as `col_0`, current_date('America/Los_Angeles') as `col_1`, current_time() as `col_2`, current_time('UTC') as `col_3`, current_timestamp() as `col_4`, current_timestamp('America/Los_Angeles') as `col_5`, current_datetime() as `col_6`, current_datetime() as `col_7`, current_datetime('UTC') as `col_8` from `users` as users",
+        "select current_date() as col_0, current_date('America/Los_Angeles') as col_1, current_time() as col_2, current_time('UTC') as col_3, current_timestamp() as col_4, current_timestamp('America/Los_Angeles') as col_5, current_datetime() as col_6, current_datetime() as col_7, current_datetime('UTC') as col_8 from `users` as users",
       )
     } finally {
       setConfig({root: ''})
@@ -994,7 +977,7 @@ describe('lang', () => {
       table active_users as (from users select id where age > $minAge)
       from active_users select id
     `)
-    expect(toSql(queries[0], {minAge: 20})).toMatch(/WHERE users\."age">20/)
+    expect(toSql(queries[0], {minAge: 20})).toMatch(/WHERE users\.age>20/)
   })
 
   it.skip('supports array parameters in filters', () => {
@@ -1006,7 +989,7 @@ describe('lang', () => {
   })
 
   it('assumes * when no fields are selected', () => {
-    expect('from users').toRenderSql('select users."id" as "id", users."name" as "name", users."email" as "email", users."created_at" as "created_at", users."age" as "age" from users as users')
+    expect('from users').toRenderSql('select users.id as id, users.name as name, users.email as email, users.created_at as created_at, users.age as age from users as users')
   })
 
   it('can analyze markdown files', () => {
@@ -1016,23 +999,21 @@ describe('lang', () => {
       \`\`\`
       <BarChart data="test" x="name" y="avg(age)" />
     `).toRenderSql(
-      'with "test" as ( select users."id" as "id", users."name" as "name", users."email" as "email", users."created_at" as "created_at", users."age" as "age" from users as users where users."age">20 ) select test."name" as "name", avg(test."age") as "col_1" from "test" as test group by 1 order by 2 desc nulls last',
+      'with test as ( select users.id as id, users.name as name, users.email as email, users.created_at as created_at, users.age as age from users as users where users.age>20 ) select test.name as name, avg(test.age) as col_1 from test as test group by 1 order by 2 desc nulls last',
     )
   })
 
-  it('snowflake query_source (CTE) aliases match references', () => {
-    // When querying from a query_source table in Snowflake, the CTE's aliases must match
-    // the outer query's references. Both use uppercase for internal consistency, but
-    // the final output aliases are lowercase.
-    // Note: using case-insensitive comparison since column uppercasing happens in core.ts
-    // via uppercaseTable() which affects table names but not all identifiers.
+  it('snowflake named markdown queries preserve lowercase aliases in component references', () => {
     setConfig({dialect: 'snowflake', root: ''})
     expect(`
-      \`\`\`gsql test
-        from users select count() as num
+      \`\`\`gsql by_state
+        from users select name as state_code, count() as num
       \`\`\`
-      <BigValue data="test" value="num" />
-    `).toRenderSql('WITH "test" as ( SELECT count(1) as "num" from USERS as USERS ) SELECT test."num" as "num" from "test" as test')
+      <BarChart data="by_state" x="state_code" y="num" />
+    `).toRenderSql(
+      'WITH by_state as ( SELECT users.name as state_code, count(1) as num FROM USERS as users GROUP BY 1 ORDER BY 2 desc NULLS LAST ) SELECT by_state.state_code as state_code, by_state.num as num FROM by_state as by_state',
+      {preserveCase: true},
+    )
   })
 
   it('reports the right line/col number for markdown errors', () => {
@@ -1068,14 +1049,14 @@ describe('lang', () => {
       \`\`\`
       <BarChart data="test" x="name" y="avg(age)" title="Count > 0" />
     `).toRenderSql(
-      'with "test" as ( select users."id" as "id", users."name" as "name", users."email" as "email", users."created_at" as "created_at", users."age" as "age" from users as users where users."age">20 ) select test."name" as "name", avg(test."age") as "col_1" from "test" as test group by 1 order by 2 desc nulls last',
+      'with test as ( select users.id as id, users.name as name, users.email as email, users.created_at as created_at, users.age as age from users as users where users.age>20 ) select test.name as name, avg(test.age) as col_1 from test as test group by 1 order by 2 desc nulls last',
     )
   })
 
   it('handles params in a md code fence', () => {
     let queries = analyze('```gsql test\nfrom users where age > $cutoff\n```\n<BarChart data="test" x="name" y="avg(age)" />', 'md')
     let sql = toSql(queries[0], {cutoff: 20})
-    expect(sql).toMatch(/"age">20/)
+    expect(sql).toMatch(/age>20/)
   })
 
   it('trimmed sanitization breaks a simple join cycle', () => {
@@ -1098,8 +1079,8 @@ describe('lang', () => {
     `,
       'cycle.gsql',
     )
-    expect('from alpha select count(*)').toRenderSql('select count(1) as "col_0" from alpha as alpha')
-    expect('from alpha select avg_num').toRenderSql('select (avg(beta."num")) as "avg_num" from alpha as alpha left join beta as beta on beta."alpha_id"=alpha."id"')
+    expect('from alpha select count(*)').toRenderSql('select count(1) as col_0 from alpha as alpha')
+    expect('from alpha select avg_num').toRenderSql('select (avg(beta.num)) as avg_num from alpha as alpha left join beta as beta on beta.alpha_id=alpha.id')
     // expect('from beta select alpha.avg_num').toRenderSql('')
   })
 
@@ -1116,7 +1097,7 @@ describe('lang', () => {
       'models.gsql',
     )
 
-    expect('from users select name where is_adult').toRenderSql('select users."name" as "name" from users as users where (users."age">=18)')
+    expect('from users select name where is_adult').toRenderSql('select users.name as name from users as users where (users.age>=18)')
   })
 
   it('has correct precedence between binary and logic expressions', () => {
@@ -1156,37 +1137,37 @@ describe('lang', () => {
   it('supports standard functions in bigquery', () => {
     // BigQuery uses a different dialect than the StandardSQL that many use in Malloy. Ensure that we're loading standard fns into bigquery
     setConfig({root: '', bigquery: {}})
-    expect('from users select floor(age) as floored_age').toRenderSql('select floor(users.`age`) as `floored_age` from `users` as users')
+    expect('from users select floor(age) as floored_age').toRenderSql('select floor(users.age) as floored_age from `users` as users')
   })
 
-  it('renders window order expressions with BigQuery quoting', () => {
+  it('renders window order expressions with BigQuery identifiers', () => {
     setConfig({root: '', bigquery: {}})
-    expect('from orders select row_number() over (order by amount desc) as rn').toRenderSql('select row_number() OVER (ORDER BY orders.`amount` DESC) as `rn` from `orders` as orders')
+    expect('from orders select row_number() over (order by amount desc) as rn').toRenderSql('select row_number() OVER (ORDER BY orders.amount DESC) as rn from `orders` as orders')
   })
 
-  it('renders window frames in Snowflake with uppercase identifiers', () => {
+  it('renders window frames in Snowflake with unquoted identifiers', () => {
     setConfig({dialect: 'snowflake', root: ''})
     expect('from orders select sum(amount) over (order by id rows between unbounded preceding and current row) as running_amount').toRenderSql(
-      'SELECT sum(orders."AMOUNT") OVER (ORDER BY orders."ID" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as "running_amount" FROM ORDERS as orders',
+      'SELECT sum(orders.AMOUNT) OVER (ORDER BY orders.ID ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as running_amount FROM ORDERS as orders',
     )
   })
 
   it('renders Snowflake pXX partition windows', () => {
     setConfig({dialect: 'snowflake', root: ''})
     expect('from orders select id, p50(amount) over (partition by user_id) as p50_by_user order by id').toRenderSql(
-      'SELECT orders."ID" as "id", PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY orders."AMOUNT") OVER (PARTITION BY orders."USER_ID") as "p50_by_user" FROM ORDERS as orders ORDER BY 1 asc NULLS LAST',
+      'SELECT orders.id as id, PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY orders.amount) OVER (PARTITION BY orders.user_id) as p50_by_user FROM ORDERS as orders ORDER BY 1 asc NULLS LAST',
       {preserveCase: true},
     )
   })
 
   it('supports cast() expressions', () => {
-    expect('from users select cast(age as varchar)').toRenderSql('select CAST(users."age" AS VARCHAR) as "col_0" from users as users')
-    expect('from users select cast(age as float64)').toRenderSql('select CAST(users."age" AS FLOAT64) as "col_0" from users as users')
+    expect('from users select cast(age as varchar)').toRenderSql('select CAST(users.age AS VARCHAR) as col_0 from users as users')
+    expect('from users select cast(age as float64)').toRenderSql('select CAST(users.age AS FLOAT64) as col_0 from users as users')
   })
 
   it('supports :: cast syntax', () => {
-    expect('from users select age::VARCHAR').toRenderSql('select CAST(users."age" AS VARCHAR) as "col_0" from users as users')
-    expect('from users select name::int').toRenderSql('select CAST(users."name" AS INT) as "col_0" from users as users')
+    expect('from users select age::VARCHAR').toRenderSql('select CAST(users.age AS VARCHAR) as col_0 from users as users')
+    expect('from users select name::int').toRenderSql('select CAST(users.name AS INT) as col_0 from users as users')
   })
 
   it('reports diagnostic for invalid cast type', () => {
@@ -1194,7 +1175,7 @@ describe('lang', () => {
   })
 
   it('supports cast in expressions', () => {
-    expect('from users select cast(age as varchar) = name').toRenderSql('select CAST(users."age" AS VARCHAR)=users."name" as "col_0" from users as users')
+    expect('from users select cast(age as varchar) = name').toRenderSql('select CAST(users.age AS VARCHAR)=users.name as col_0 from users as users')
   })
 
   it('ignores comments within table definitions', () => {
@@ -1204,7 +1185,7 @@ describe('lang', () => {
       computed: id / 2
       -- this is a comment
       name STRING
-    ); from test select id`).toRenderSql('select test."id" as "id" from test as test')
+    ); from test select id`).toRenderSql('select test.id as id from test as test')
   })
 
   it('single join_many aggregate is fine, join_one is fine', () => {
@@ -1244,7 +1225,7 @@ describe('lang', () => {
     )
 
     expect('from orders select user_country').toRenderSql(
-      'select (users_countries."name") as "user_country" from orders as orders left join users as users on users."id"=orders."user_id" left join countries as users_countries on users_countries."id"=users."country_id"',
+      'select (users_countries.name) as user_country from orders as orders left join users as users on users.id=orders.user_id left join countries as users_countries on users_countries.id=users.country_id',
     )
   })
 
@@ -1266,13 +1247,13 @@ describe('lang', () => {
     )
 
     expect('from users select recent_orders.discounted, old_orders.discounted').toRenderSql(
-      'select (recent_orders."amount"*0.9) as "recent_orders_discounted", (old_orders."amount"*0.9) as "old_orders_discounted" from users as users left join orders as recent_orders on recent_orders."user_id"=users."id" left join orders as old_orders on old_orders."user_id"=users."id"',
+      'select (recent_orders.amount*0.9) as recent_orders_discounted, (old_orders.amount*0.9) as old_orders_discounted from users as users left join orders as recent_orders on recent_orders.user_id=users.id left join orders as old_orders on old_orders.user_id=users.id',
     )
   })
 
   it('supports subqueries in FROM', () => {
     expect('from (from users where age > 20 select id, name) as adults select name').toRenderSql(
-      'select adults."name" as "name" from ( select users."id" as "id", users."name" as "name" from users as users where users."age">20 ) as adults',
+      'select adults.name as name from ( select users.id as id, users.name as name from users as users where users.age>20 ) as adults',
     )
   })
 
@@ -1280,19 +1261,19 @@ describe('lang', () => {
     expect(`from users
       join (from orders select user_id, sum(amount) as total group by user_id) as order_totals on order_totals.user_id = users.id
       select users.name as name, order_totals.total as total`).toRenderSql(
-      'select users."name" as "name", order_totals."total" as "total" from users as users inner join ( select orders."user_id" as "user_id", sum(orders."amount") as "total" from orders as orders group by 1 order by 2 desc nulls last ) as order_totals on order_totals."user_id"=users."id"',
+      'select users.name as name, order_totals.total as total from users as users inner join ( select orders.user_id as user_id, sum(orders.amount) as total from orders as orders group by 1 order by 2 desc nulls last ) as order_totals on order_totals.user_id=users.id',
     )
   })
 
   it('supports subqueries in IN expressions', () => {
     expect('from users where id in (from orders where amount > 10 select user_id) select id').toRenderSql(
-      'select users."id" as "id" from users as users where users."id" in (select orders."user_id" as "user_id" from orders as orders where orders."amount">10)',
+      'select users.id as id from users as users where users.id in (select orders.user_id as user_id from orders as orders where orders.amount>10)',
     )
   })
 
   it('supports scalar subquery expressions in WHERE', () => {
     expect('from users where age > (from users select avg(age)) select id').toRenderSql(
-      'select users."id" as "id" from users as users where users."age">(select avg(users."age") as "col_0" from users as users)',
+      'select users.id as id from users as users where users.age>(select avg(users.age) as col_0 from users as users)',
     )
   })
 
@@ -1302,7 +1283,7 @@ describe('lang', () => {
       hv_users as (from high_value select user_id)
       from hv_users select user_id order by user_id`
     expect(q).toRenderSql(
-      'with "high_value" as ( select orders."id" as "id", orders."user_id" as "user_id", orders."amount" as "amount" from orders as orders where orders."amount">=40 ), "hv_users" as ( select high_value."user_id" as "user_id" from high_value as high_value ) select hv_users."user_id" as "user_id" from hv_users as hv_users order by 1 asc nulls last',
+      'with high_value as ( select orders.id as id, orders.user_id as user_id, orders.amount as amount from orders as orders where orders.amount>=40 ), hv_users as ( select high_value.user_id as user_id from high_value as high_value ) select hv_users.user_id as user_id from hv_users as hv_users order by 1 asc nulls last',
     )
     await expect(q).toReturnRows([1], [2])
   })
@@ -1310,7 +1291,7 @@ describe('lang', () => {
   it('CTE shadows existing table names', () => {
     // CTE named "orders" should shadow the real orders table
     expect('with orders as (from users select id, name) from orders select id, name order by id').toRenderSql(
-      'with "orders" as ( select users."id" as "id", users."name" as "name" from users as users ) select orders."id" as "id", orders."name" as "name" from orders as orders order by 1 asc nulls last',
+      'with orders as ( select users.id as id, users.name as name from users as users ) select orders.id as id, orders.name as name from orders as orders order by 1 asc nulls last',
     )
   })
 
@@ -1320,8 +1301,8 @@ describe('lang', () => {
       completed as (from orders where status = 'completed' select user_id, amount),
       summary as (with totals as (from completed select user_id, sum(amount) as total) from totals select user_id, total)
       from summary select user_id, total order by user_id`)
-      .toRenderSql(`with "completed" as ( select orders."user_id" as "user_id", orders."amount" as "amount" from orders as orders where orders."status"='completed' ),
-        "summary" as ( with "totals" as ( select completed."user_id" as "user_id", sum(completed."amount") as "total" from completed as completed group by 1 order by 2 desc nulls last ) select totals."user_id" as "user_id", totals."total" as "total" from totals as totals )
-        select summary."user_id" as "user_id", summary."total" as "total" from summary as summary order by 1 asc nulls last`)
+      .toRenderSql(`with completed as ( select orders.user_id as user_id, orders.amount as amount from orders as orders where orders.status='completed' ),
+        summary as ( with totals as ( select completed.user_id as user_id, sum(completed.amount) as total from completed as completed group by 1 order by 2 desc nulls last ) select totals.user_id as user_id, totals.total as total from totals as totals )
+        select summary.user_id as user_id, summary.total as total from summary as summary order by 1 asc nulls last`)
   })
 })

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -147,7 +147,7 @@ async function _runAll() {
   )
 }
 
-function translateData(data: any, node: QueryNode) {
+export function translateData(data: any, node: QueryNode) {
   let rows = data.rows || []
   rows.dataLoaded = true // evidence components need this to be set
   rows._evidenceColumnTypes = []
@@ -159,14 +159,33 @@ function translateData(data: any, node: QueryNode) {
 
   data.fields.forEach((field, index) => {
     let name = field.name
+    let requested = requestFields[index]
 
     // server gives names like `col_1` to unnamed expressions but we translate it back into the original expression like `avg(price)`
     if (field.name.match(/col_\d+/)) {
-      name = requestFields[index]
+      name = requested
       rows.forEach(r => {
         r[name] = r[field.name]
         delete r[field.name]
       })
+    }
+
+    // Snowflake may return unquoted identifiers uppercased in row objects. If the requested
+    // field is a simple identifier and only differs by case, remap row keys back to requested case.
+    let isSimpleIdentifier = typeof requested == 'string' && /^[A-Za-z_][A-Za-z0-9_]*$/.test(requested)
+    if (isSimpleIdentifier && rows.length > 0) {
+      let current = name
+      if (rows[0][current] === undefined) {
+        let matched = Object.keys(rows[0]).find(k => k.toLowerCase() == requested.toLowerCase())
+        if (matched) current = matched
+      }
+      if (current != requested && rows[0][current] !== undefined) {
+        name = requested
+        rows.forEach(r => {
+          r[name] = r[current]
+          delete r[current]
+        })
+      }
     }
 
     // map graphene types down to the ones evidence expects
@@ -198,12 +217,14 @@ function evidenceType(type: string | undefined) {
   return 'string'
 }
 
-Object.assign(window.$GRAPHENE, {
-  registerQuery,
-  updateParam,
-  query,
-  unsubscribe,
-  resetQueryEngine,
-  isQueryLoading,
-  queryResults,
-})
+if (typeof window !== 'undefined') {
+  Object.assign(window.$GRAPHENE, {
+    registerQuery,
+    updateParam,
+    query,
+    unsubscribe,
+    resetQueryEngine,
+    isQueryLoading,
+    queryResults,
+  })
+}

--- a/ui/tests/queryEngine.test.ts
+++ b/ui/tests/queryEngine.test.ts
@@ -1,0 +1,33 @@
+import {beforeAll, test, expect} from 'vitest'
+
+let translateData: (data: any, node: any) => {rows: any[]}
+
+beforeAll(async () => {
+  ;(globalThis as any).window = {
+    $GRAPHENE: {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }
+  ;({translateData} = await import('../internal/queryEngine.ts'))
+})
+
+test('translateData remaps Snowflake-style uppercase row keys to requested field casing', () => {
+  let data = {
+    rows: [{LOCATION_STATE_CODE: 'CA', NUM: 3}],
+    fields: [
+      {name: 'location_state_code', type: 'string'},
+      {name: 'num', type: 'number'},
+    ],
+  }
+  let node = {
+    fields: new Map([
+      ['x', 'location_state_code'],
+      ['y', 'num'],
+    ]),
+  }
+
+  let result = translateData(data, node)
+
+  expect(result.rows[0]).toEqual({location_state_code: 'CA', num: 3})
+  expect((result.rows as any)._evidenceColumnTypes.map((c: any) => c.name)).toEqual(['location_state_code', 'num'])
+})


### PR DESCRIPTION
This was a malloy holdover, but it's kinda non-standard and was causing issues with snowflake, so stop doing it.

This also means that snowflake will give us back every field name uppercased, so we need to map it back to what was requested.