### PR TITLE
unset `completionProvider` in LSP server capabilities

### DIFF
--- a/vscode/src/languageServer.ts
+++ b/vscode/src/languageServer.ts
@@ -24,7 +24,6 @@ connection.onInitialize(params => {
   return {
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Incremental,
-      completionProvider: {resolveProvider: false},
       hoverProvider: true,
       // diagnosticProvider: {interFileDependencies: true, workspaceDiagnostics: true},
     },


### PR DESCRIPTION
Providing any value for the `completionProvider` field makes the client assume we support `textDocument/completion` (hence the errors in #171). Since we don't support completion (although there are commented out handlers for it), unset it.