### PR TITLE
Make schema tool case-insensitive

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -84,6 +84,7 @@ program
   .action(async (tableArg: string) => {
     let connection = await getConnection()
     let datasets = await connection.listDatasets()
+    let matchedDataset = tableArg ? findCaseInsensitive(datasets, tableArg) : null
 
     // if there's no arg and more than one dataset, just list the datasets
     if (!tableArg && datasets.length > 1) {
@@ -94,19 +95,22 @@ program
     let dsToList: string | null = null
     let parts = tableArg ? tableArg.split('.') : []
 
-    if (tableArg && connection.listSchemas && parts.length == 1 && datasets.includes(tableArg)) {
-      let schemas = await connection.listSchemas(tableArg)
-      return console.log(`Schemas in ${tableArg}:\n${schemas.join('\n')}`)
+    if (tableArg && connection.listSchemas && parts.length == 1 && matchedDataset) {
+      let schemas = await connection.listSchemas(matchedDataset)
+      return console.log(`Schemas in ${matchedDataset}:\n${schemas.join('\n')}`)
     }
 
-    if (datasets.includes(tableArg))
-      dsToList = tableArg // you gave the name of a dataset
+    if (matchedDataset)
+      dsToList = matchedDataset // you gave the name of a dataset
     else if (!tableArg && config.defaultNamespace)
       dsToList = config.defaultNamespace // default namespace configured
     else if (!tableArg && datasets.length == 1)
       dsToList = datasets[0] // only one dataset, and no args
     else if (!tableArg && config.dialect == 'duckdb') dsToList = '<default>'
-    else if (tableArg && config.dialect == 'snowflake' && parts.length == 2) dsToList = tableArg
+    else if (tableArg && config.dialect == 'snowflake' && parts.length == 2) {
+      let db = findCaseInsensitive(datasets, parts[0]) || parts[0]
+      dsToList = `${db}.${parts.slice(1).join('.')}`
+    }
 
     if (dsToList) {
       let tables = await connection.listTables(dsToList)
@@ -115,8 +119,9 @@ program
 
     // otherwise, assume you're wanting to see tables
     let cols = await connection.describeTable(tableArg)
-    if (!cols.length) return console.log(`Table ${tableArg} not found`)
-    console.log(`table ${tableArg} (`)
+    let tableLabel = config.dialect == 'snowflake' ? String(tableArg || '').toLowerCase() : tableArg
+    if (!cols.length) return console.log(`Table ${tableLabel} not found`)
+    console.log(`table ${tableLabel} (`)
     cols.forEach(col => console.log(`  ${col.name} ${col.dataType}`))
     console.log(')')
   })
@@ -198,4 +203,8 @@ function validQuery(queries: Query[]): boolean {
     process.exit(1)
   }
   return true
+}
+
+function findCaseInsensitive(values: string[], needle: string): string | null {
+  return values.find(value => value.toLowerCase() == needle.toLowerCase()) || null
 }

--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -39,18 +39,19 @@ export class BigQueryConnection implements QueryConnection {
 
   async listDatasets(): Promise<string[]> {
     let [datasets] = await this.client.getDatasets()
-    return datasets.map(d => d.id || d.metadata.datasetReference?.datasetId)
+    return datasets.map(d => String(d.id || d.metadata.datasetReference?.datasetId || '').toLowerCase())
   }
 
   async listTables(dataset?: string): Promise<string[]> {
     if (!dataset) throw new Error('BigQuery requires a dataset')
     validateBigQueryIdent(dataset)
 
+    let resolvedDataset = await this.resolveDatasetName(dataset)
     let res = await this.runQuery(`select table_name as table_name
-      from \`${dataset}.INFORMATION_SCHEMA.TABLES\`
+      from \`${resolvedDataset}.INFORMATION_SCHEMA.TABLES\`
       where table_type in ('BASE TABLE', 'VIEW') order by table_name`)
 
-    return res.rows.map(r => `${dataset}.${r['table_name']}`)
+    return res.rows.map(r => `${resolvedDataset.toLowerCase()}.${String(r['table_name']).toLowerCase()}`)
   }
 
   async describeTable(target: string): Promise<SchemaColumn[]> {
@@ -59,15 +60,21 @@ export class BigQueryConnection implements QueryConnection {
     let dataset = parts.join('.') || this.defaultNamespace
     if (!dataset) throw new Error('No dataset specified and no default namespace configured')
     validateBigQueryIdent(dataset)
+    let resolvedDataset = await this.resolveDatasetName(dataset)
     let sql = `
       select column_name as column_name, data_type as data_type, ordinal_position as ordinal_position
-      from \`${dataset}.INFORMATION_SCHEMA.COLUMNS\`
+      from \`${resolvedDataset}.INFORMATION_SCHEMA.COLUMNS\`
       where lower(table_name) = lower(@table)
       order by ordinal_position
     `.trim()
     let res = await this.runQuery(sql, {table})
     return res.rows.map(row => {
-      return {name: String(row['column_name']), dataType: String(row['data_type'])}
+      return {name: String(row['column_name']).toLowerCase(), dataType: String(row['data_type'])}
     })
+  }
+
+  async resolveDatasetName(name: string): Promise<string> {
+    let datasets = await this.listDatasets()
+    return datasets.find(ds => ds.toLowerCase() == name.toLowerCase()) || name
   }
 }

--- a/cli/connections/duckdb.ts
+++ b/cli/connections/duckdb.ts
@@ -67,7 +67,7 @@ export class DuckDBConnection implements QueryConnection {
       order by table_schema, table_name
     `.trim()
     let res = await this.runQuery(sql)
-    return res.rows.map(row => String(row['table_name']))
+    return res.rows.map(row => String(row['table_name']).toLowerCase())
   }
 
   async describeTable(target: string): Promise<SchemaColumn[]> {
@@ -84,7 +84,7 @@ export class DuckDBConnection implements QueryConnection {
     let params = schema ? [table, schema] : [table]
     let res = await this.runQuery(sql, params)
     return res.rows.map(row => {
-      return {name: String(row['column_name']), dataType: String(row['data_type'])}
+      return {name: String(row['column_name']).toLowerCase(), dataType: String(row['data_type'])}
     })
   }
 }

--- a/cli/connections/snowflake.ts
+++ b/cli/connections/snowflake.ts
@@ -92,35 +92,36 @@ export class SnowflakeConnection implements QueryConnection {
   }
 
   async listSchemas(database: string): Promise<string[]> {
+    let resolvedDatabase = await this.resolveDatabaseName(database)
     let res = await this.runQuery(`
       select schema_name as "schema_name"
-      from ${snowflakeIdent(database)}.INFORMATION_SCHEMA.SCHEMATA
+      from ${snowflakeIdent(resolvedDatabase)}.INFORMATION_SCHEMA.SCHEMATA
       where schema_name != 'INFORMATION_SCHEMA'
       order by schema_name
     `)
-    return res.rows.map(row => String(row['schema_name']))
+    return res.rows.map(row => String(row['schema_name']).toLowerCase())
   }
 
   async listTables(dataset: string): Promise<string[]> {
     let parts = dataset.split('.')
-    let database = parts.shift() || ''
+    let database = await this.resolveDatabaseName(parts.shift() || '')
     let schema = parts.join('.')
 
     let res = await this.runQuery(
       `
       select table_schema as "table_schema", table_name as "table_name"
       from ${snowflakeIdent(database)}.INFORMATION_SCHEMA.TABLES
-      where table_type in ('BASE TABLE', 'VIEW') and table_schema = ?
+      where table_type in ('BASE TABLE', 'VIEW') and upper(table_schema) = upper(?)
       order by table_name
     `,
       [schema],
     )
-    return res.rows.map(row => `${row['table_schema']}.${row['table_name']}`)
+    return res.rows.map(row => `${String(row['table_schema']).toLowerCase()}.${String(row['table_name']).toLowerCase()}`)
   }
 
   async describeTable(target: string): Promise<SchemaColumn[]> {
     let parts = target.split('.')
-    let database = parts.shift() || ''
+    let database = await this.resolveDatabaseName(parts.shift() || '')
     let table = parts.pop() || ''
     let schema = parts.join('.')
 
@@ -136,6 +137,11 @@ export class SnowflakeConnection implements QueryConnection {
     return res.rows.map(row => {
       return {name: String(row['column_name']).toLowerCase(), dataType: String(row['data_type'])}
     })
+  }
+
+  async resolveDatabaseName(name: string): Promise<string> {
+    let databases = await this.listDatasets()
+    return databases.find(db => db.toLowerCase() == name.toLowerCase()) || name
   }
 }
 

--- a/cli/schema.test.ts
+++ b/cli/schema.test.ts
@@ -98,18 +98,19 @@ describe.skipIf(!hasSnowflakeAuth)('snowflake', () => {
     expectCliSuccess(res, 'schema list schemas (snowflake)')
     let schemas = parseSchemaOutput(res.stdout)
     expect(schemas.length).toBeGreaterThan(0)
-    expect(schemas).toContain('V02')
+    expect(schemas).toContain('v02')
   })
 
-  it('lists tables in the configured namespace', async () => {
-    let res = await runCli(['schema', 'FOOD__BEVERAGE_ESTABLISHMENT__MENU_DATA.V02'], snowflakeDir)
+  it('lists tables in the configured namespace using case-insensitive input', async () => {
+    let res = await runCli(['schema', 'food__beverage_establishment__menu_data.v02'], snowflakeDir)
     expectCliSuccess(res, 'schema list tables (snowflake)')
     let tables = parseSchemaOutput(res.stdout)
     expect(tables.length).toBeGreaterThan(0)
+    expect(tables.every(table => table == table.toLowerCase())).toBe(true)
   })
 
-  it('describes a table from the namespace', async () => {
-    let res = await runCli(['schema', 'FOOD__BEVERAGE_ESTABLISHMENT__MENU_DATA.V02.MENUS'], snowflakeDir)
+  it('describes a table from the namespace using case-insensitive input', async () => {
+    let res = await runCli(['schema', 'food__beverage_establishment__menu_data.v02.menus'], snowflakeDir)
     expectCliSuccess(res, 'schema describe table (snowflake)')
     let output = res.stdout.toLowerCase()
     expect(output).toContain('table food__beverage_establishment__menu_data.v02.menus (')


### PR DESCRIPTION
This will find schemas/tables regardless of their actual case in the warehouse, and prints them as lowercase.