### PR TITLE
lower dynamic interval syntax to dialect-correct SQL

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -3,7 +3,7 @@ import {NodeWeakMap, type SyntaxNode, type SyntaxNodeRef} from '@lezer/common'
 import {config} from './config.ts'
 import {analyzeFunction} from './functions.ts'
 import {extractLeadingMetadata} from './metadata.ts'
-import {parseTemporalLiteral, parseIntervalLiteral, parseIntervalUnit} from './temporalLiterals.ts'
+import {parseTemporalLiteral, parseIntervalLiteral, parseIntervalUnit, renderTemporalArithmetic, renderStandaloneInterval} from './temporal.ts'
 import {type Table, type Query, type QueryJoin, type Column, type FieldType, type FileInfo, type Diagnostic, type Expr, type CteTable, type JoinType, type Scope} from './types.ts'
 import {txt, getFile, getPosition} from './util.ts'
 
@@ -143,7 +143,7 @@ function expandColumns(table: Table | null, alias: string, query: Query, scope: 
       if (col.isAgg == null) col.isAgg = analyzeExpr(col.exprNode, {table, alias}).isAgg
       if (col.isAgg) continue
       let expr = analyzeExpr(col.exprNode, {query: scope.query, table, alias, otherTables: scope.otherTables})
-      if (expr.type == 'interval' && expr.interval?.kind == 'scaled') diag(col.exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
+      if (expr.type == 'interval' && expr.interval?.form == 'scaled') diag(col.exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
       query.fields.push({name: outName, sql: expr.sql, type: expr.type, metadata: col.metadata})
     } else {
       query.fields.push({name: outName, sql: `${alias}.${col.name}`, type: col.type, metadata: col.metadata})
@@ -232,7 +232,7 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
       expandColumns(targetScope.table, targetScope.alias, query, targetScope)
     } else {
       let expr = analyzeExpr(s.getChild('Expression')!, scope)
-      if (expr.type == 'interval' && expr.interval?.kind == 'scaled') diag(s.getChild('Expression')!, 'Multiplied intervals are only supported inside date/time arithmetic')
+      if (expr.type == 'interval' && expr.interval?.form == 'scaled') diag(s.getChild('Expression')!, 'Multiplied intervals are only supported inside date/time arithmetic')
       let name = s.getChild('Alias') ? txt(s.getChild('Alias')) : inferName(s.getChild('Expression')!, scope)
       query.fields.push({name, sql: expr.sql, type: expr.type, isAgg: expr.isAgg})
     }
@@ -658,7 +658,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
         return {
           sql: `interval ${parsed.quantity} ${parsed.unit}`,
           type: 'interval',
-          interval: {quantitySql: String(parsed.quantity), unit: parsed.unit, kind: 'simple', canScale: true, isConstant: true},
+          interval: {quantitySql: String(parsed.quantity), unit: parsed.unit, form: 'constant'},
         }
       }
       let quantityNode = node.getChild('Number') || node.getChild('Ref')
@@ -671,7 +671,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
         sql: `interval ${quantity.sql} ${unit}`,
         type: 'interval',
         isAgg: quantity.isAgg,
-        interval: {quantitySql: quantity.sql, unit, kind: 'simple', canScale: quantityNode.name == 'Number', isConstant: quantityNode.name == 'Number'},
+        interval: {quantitySql: quantity.sql, unit, form: quantityNode.name == 'Number' ? 'constant' : 'dynamic'},
       }
     }
 
@@ -706,52 +706,39 @@ function analyzeDateArithmetic(op: '+' | '-', left: Expr, right: Expr, node: Syn
   // date +/- interval
   if ((left.type == 'date' || left.type == 'timestamp') && right.type == 'interval') {
     if (!right.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
-    return {sql: renderTemporalArithmetic(left.sql, left.type, op, right.interval.quantitySql, right.interval.unit, right.interval), type: left.type, isAgg: left.isAgg || right.isAgg}
+    return {sql: renderTemporalArithmetic(config.dialect, left.sql, left.type, op, right.interval), type: left.type, isAgg: left.isAgg || right.isAgg}
   }
 
   // interval + date (normalize to date + interval)
   if (left.type == 'interval' && (right.type == 'date' || right.type == 'timestamp')) {
     if (op == '-') return diag(node, 'Cannot subtract date from interval', {sql: 'NULL', type: 'error'})
     if (!left.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
-    return {sql: renderTemporalArithmetic(right.sql, right.type, '+', left.interval.quantitySql, left.interval.unit, left.interval), type: right.type, isAgg: left.isAgg || right.isAgg}
+    return {sql: renderTemporalArithmetic(config.dialect, right.sql, right.type, '+', left.interval), type: right.type, isAgg: left.isAgg || right.isAgg}
   }
 
   return diag(node, 'Invalid date arithmetic', {sql: 'NULL', type: 'error'})
 }
 
 function analyzeIntervalMultiplication(left: Expr, right: Expr, node: SyntaxNode): Expr | null {
-  if (left.type == 'number' && right.type == 'interval') return scaleInterval(left, right, node.lastChild!)
-  if (left.type == 'interval' && right.type == 'number') return scaleInterval(right, left, node.firstChild!)
+  if (left.type == 'number' && right.type == 'interval') {
+    return scaleInterval(left, right, node.lastChild!)
+  }
+  if (left.type == 'interval' && right.type == 'number') {
+    return scaleInterval(right, left, node.firstChild!)
+  }
   return null
 }
 
 function scaleInterval(multiplier: Expr, intervalExpr: Expr, node: SyntaxNode): Expr {
   if (!intervalExpr.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
-  if (!intervalExpr.interval.canScale) return diag(node, 'Only literal intervals can be multiplied', {sql: 'NULL', type: 'error'})
+  if (intervalExpr.interval.form != 'constant') return diag(node, 'Only literal intervals can be multiplied', {sql: 'NULL', type: 'error'})
   let quantitySql = intervalExpr.interval.quantitySql == '1' ? multiplier.sql : `${multiplier.sql}*${intervalExpr.interval.quantitySql}`
   return {
-    sql: renderStandaloneInterval(quantitySql, intervalExpr.interval.unit),
+    sql: renderStandaloneInterval(config.dialect, {quantitySql, unit: intervalExpr.interval.unit, form: 'scaled'}),
     type: 'interval',
     isAgg: multiplier.isAgg || intervalExpr.isAgg,
-    interval: {quantitySql, unit: intervalExpr.interval.unit, kind: 'scaled', canScale: false, isConstant: intervalExpr.interval.isConstant && quantitySql == intervalExpr.interval.quantitySql},
+    interval: {quantitySql, unit: intervalExpr.interval.unit, form: 'scaled'},
   }
-}
-
-function renderTemporalArithmetic(leftSql: string, leftType: 'date' | 'timestamp', op: '+' | '-', quantitySql: string, unit: string, intervalExpr?: Expr['interval']) {
-  if (config.dialect == 'snowflake') {
-    let signedQuantity = op == '+' ? quantitySql : `-(${quantitySql})`
-    let fnName = leftType == 'date' ? 'DATEADD' : 'TIMESTAMPADD'
-    return `${fnName}(${unit}, ${signedQuantity}, ${leftSql})`
-  }
-  return `${leftSql} ${op} ${renderStandaloneInterval(quantitySql, unit, intervalExpr)}`
-}
-
-function renderStandaloneInterval(quantitySql: string, unit: string, intervalExpr?: Expr['interval']) {
-  if (config.dialect == 'duckdb') {
-    if (intervalExpr?.kind == 'simple' && intervalExpr.isConstant) return `interval ${quantitySql} ${unit}`
-    return `(${quantitySql} * (interval 1 ${unit}))`
-  }
-  return `interval ${quantitySql} ${unit}`
 }
 
 function coerceToTemporal(expr: Expr, targetType: 'date' | 'timestamp', node: SyntaxNode): Expr {

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -143,6 +143,7 @@ function expandColumns(table: Table | null, alias: string, query: Query, scope: 
       if (col.isAgg == null) col.isAgg = analyzeExpr(col.exprNode, {table, alias}).isAgg
       if (col.isAgg) continue
       let expr = analyzeExpr(col.exprNode, {query: scope.query, table, alias, otherTables: scope.otherTables})
+      if (expr.type == 'interval' && expr.interval?.kind == 'scaled') diag(col.exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
       query.fields.push({name: outName, sql: expr.sql, type: expr.type, metadata: col.metadata})
     } else {
       query.fields.push({name: outName, sql: `${alias}.${col.name}`, type: col.type, metadata: col.metadata})
@@ -231,6 +232,7 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
       expandColumns(targetScope.table, targetScope.alias, query, targetScope)
     } else {
       let expr = analyzeExpr(s.getChild('Expression')!, scope)
+      if (expr.type == 'interval' && expr.interval?.kind == 'scaled') diag(s.getChild('Expression')!, 'Multiplied intervals are only supported inside date/time arithmetic')
       let name = s.getChild('Alias') ? txt(s.getChild('Alias')) : inferName(s.getChild('Expression')!, scope)
       query.fields.push({name, sql: expr.sql, type: expr.type, isAgg: expr.isAgg})
     }
@@ -458,7 +460,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
 
     case 'Parenthetical': {
       let inner = analyzeExpr(node.getChild('Expression')!, scope)
-      return {sql: `(${inner.sql})`, type: inner.type, isAgg: inner.isAgg}
+      return {sql: `(${inner.sql})`, type: inner.type, isAgg: inner.isAgg, interval: inner.interval}
     }
 
     case 'Count': {
@@ -496,6 +498,10 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       }
 
       // Type checking for operators
+      if (op == '*') {
+        let multiplied = analyzeIntervalMultiplication(left, right, node)
+        if (multiplied) return multiplied
+      }
       if (op == '*' || op == '/' || op == '%') {
         checkTypes(left, ['number'], node.firstChild!)
         checkTypes(right, ['number'], node.lastChild!)
@@ -533,8 +539,8 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       let op = txt(node.firstChild).toLowerCase()
       let child = analyzeExpr(node.lastChild!, scope)
       if (op == 'not') return {sql: `NOT (${child.sql})`, type: 'boolean', isAgg: child.isAgg}
-      if (op == '-') return {sql: `-(${child.sql})`, type: child.type, isAgg: child.isAgg}
-      if (op == '+') return {sql: `(${child.sql})`, type: child.type, isAgg: child.isAgg}
+      if (op == '-') return {sql: `-(${child.sql})`, type: child.type, isAgg: child.isAgg, interval: child.interval}
+      if (op == '+') return {sql: `(${child.sql})`, type: child.type, isAgg: child.isAgg, interval: child.interval}
       return diag(node, `Unknown unary operator: ${op}`, {sql: 'NULL', type: 'error'})
     }
 
@@ -649,7 +655,11 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       if (stringNode) {
         let parsed = parseIntervalLiteral(txt(stringNode).slice(1, -1))
         if (!parsed) return diag(stringNode, 'Could not parse interval', {sql: 'NULL', type: 'error'})
-        return {sql: `INTERVAL ${parsed.quantity} ${parsed.unit}`, type: 'interval'}
+        return {
+          sql: `interval ${parsed.quantity} ${parsed.unit}`,
+          type: 'interval',
+          interval: {quantitySql: String(parsed.quantity), unit: parsed.unit, kind: 'simple', canScale: true, isConstant: true},
+        }
       }
       let quantityNode = node.getChild('Number') || node.getChild('Ref')
       if (!quantityNode) return diag(node, 'Interval requires a quantity before the unit', {sql: 'NULL', type: 'error'})
@@ -657,7 +667,12 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       checkTypes(quantity, ['number'], quantityNode)
       let unit = parseIntervalUnit(txt(node.getChild('IntervalUnit')!).toLowerCase())
       if (!unit) return diag(node, 'Invalid interval unit', {sql: 'NULL', type: 'error'})
-      return {sql: `INTERVAL ${quantity.sql} ${unit}`, type: 'interval', isAgg: quantity.isAgg}
+      return {
+        sql: `interval ${quantity.sql} ${unit}`,
+        type: 'interval',
+        isAgg: quantity.isAgg,
+        interval: {quantitySql: quantity.sql, unit, kind: 'simple', canScale: quantityNode.name == 'Number', isConstant: quantityNode.name == 'Number'},
+      }
     }
 
     case 'DateExpression':
@@ -690,16 +705,53 @@ function analyzeDateArithmetic(op: '+' | '-', left: Expr, right: Expr, node: Syn
 
   // date +/- interval
   if ((left.type == 'date' || left.type == 'timestamp') && right.type == 'interval') {
-    return {sql: `${left.sql} ${op} ${right.sql}`, type: left.type}
+    if (!right.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
+    return {sql: renderTemporalArithmetic(left.sql, left.type, op, right.interval.quantitySql, right.interval.unit, right.interval), type: left.type, isAgg: left.isAgg || right.isAgg}
   }
 
   // interval + date (normalize to date + interval)
   if (left.type == 'interval' && (right.type == 'date' || right.type == 'timestamp')) {
     if (op == '-') return diag(node, 'Cannot subtract date from interval', {sql: 'NULL', type: 'error'})
-    return {sql: `${right.sql} + ${left.sql}`, type: right.type}
+    if (!left.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
+    return {sql: renderTemporalArithmetic(right.sql, right.type, '+', left.interval.quantitySql, left.interval.unit, left.interval), type: right.type, isAgg: left.isAgg || right.isAgg}
   }
 
   return diag(node, 'Invalid date arithmetic', {sql: 'NULL', type: 'error'})
+}
+
+function analyzeIntervalMultiplication(left: Expr, right: Expr, node: SyntaxNode): Expr | null {
+  if (left.type == 'number' && right.type == 'interval') return scaleInterval(left, right, node.lastChild!)
+  if (left.type == 'interval' && right.type == 'number') return scaleInterval(right, left, node.firstChild!)
+  return null
+}
+
+function scaleInterval(multiplier: Expr, intervalExpr: Expr, node: SyntaxNode): Expr {
+  if (!intervalExpr.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
+  if (!intervalExpr.interval.canScale) return diag(node, 'Only literal intervals can be multiplied', {sql: 'NULL', type: 'error'})
+  let quantitySql = intervalExpr.interval.quantitySql == '1' ? multiplier.sql : `${multiplier.sql}*${intervalExpr.interval.quantitySql}`
+  return {
+    sql: renderStandaloneInterval(quantitySql, intervalExpr.interval.unit),
+    type: 'interval',
+    isAgg: multiplier.isAgg || intervalExpr.isAgg,
+    interval: {quantitySql, unit: intervalExpr.interval.unit, kind: 'scaled', canScale: false, isConstant: intervalExpr.interval.isConstant && quantitySql == intervalExpr.interval.quantitySql},
+  }
+}
+
+function renderTemporalArithmetic(leftSql: string, leftType: 'date' | 'timestamp', op: '+' | '-', quantitySql: string, unit: string, intervalExpr?: Expr['interval']) {
+  if (config.dialect == 'snowflake') {
+    let signedQuantity = op == '+' ? quantitySql : `-(${quantitySql})`
+    let fnName = leftType == 'date' ? 'DATEADD' : 'TIMESTAMPADD'
+    return `${fnName}(${unit}, ${signedQuantity}, ${leftSql})`
+  }
+  return `${leftSql} ${op} ${renderStandaloneInterval(quantitySql, unit, intervalExpr)}`
+}
+
+function renderStandaloneInterval(quantitySql: string, unit: string, intervalExpr?: Expr['interval']) {
+  if (config.dialect == 'duckdb') {
+    if (intervalExpr?.kind == 'simple' && intervalExpr.isConstant) return `interval ${quantitySql} ${unit}`
+    return `(${quantitySql} * (interval 1 ${unit}))`
+  }
+  return `interval ${quantitySql} ${unit}`
 }
 
 function coerceToTemporal(expr: Expr, targetType: 'date' | 'timestamp', node: SyntaxNode): Expr {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -855,15 +855,56 @@ describe('lang', () => {
   })
 
   it('supports interval keyword with quoted string', () => {
-    expect("from users select created_at + interval '5 minutes' as shifted").toRenderSql('select users.created_at + INTERVAL 5 minute as shifted from users as users')
+    expect("from users select created_at + interval '5 minutes' as shifted").toRenderSql('select users.created_at + interval 5 minute as shifted from users as users')
   })
 
   it('supports interval keyword with unquoted number and unit', () => {
-    expect('from users select created_at + interval 5 minutes as shifted').toRenderSql('select users.created_at + INTERVAL 5 minute as shifted from users as users')
+    expect('from users select created_at + interval 5 minutes as shifted').toRenderSql('select users.created_at + interval 5 minute as shifted from users as users')
   })
 
   it('supports interval keyword with numeric field quantity', () => {
-    expect('from users select created_at - interval age minute as shifted').toRenderSql('select users.created_at - INTERVAL users.age minute as shifted from users as users')
+    expect('from users select created_at - interval age minute as shifted').toRenderSql('select users.created_at - (users.age * (interval 1 minute)) as shifted from users as users')
+  })
+
+  it('supports multiplied literal intervals in date arithmetic', () => {
+    expect('from users select created_at - (age * interval 1 minute) as shifted').toRenderSql(
+      'select users.created_at - (users.age * (interval 1 minute)) as shifted from users as users',
+    )
+  })
+
+  it('supports multiplied literal intervals in computed columns', () => {
+    updateFile('table flights (dep_time timestamp, dep_delay int, scheduled_dep_time: dep_time - (dep_delay * interval 1 minute))', 'flights.gsql')
+    expect('from flights select scheduled_dep_time').toRenderSql(
+      'select (flights.dep_time - (flights.dep_delay * (interval 1 minute))) as scheduled_dep_time from flights as flights',
+    )
+  })
+
+  it('diagnoses multiplied dynamic intervals', () => {
+    expect('from users select created_at - (age * interval id minute) as shifted').toHaveDiagnostic(/Only literal intervals can be multiplied/i)
+  })
+
+  it('diagnoses standalone multiplied intervals', () => {
+    expect('from users select age * interval 1 minute as shifted').toHaveDiagnostic(/only supported inside date\/time arithmetic/i)
+  })
+
+  it('renders dynamic intervals for BigQuery', () => {
+    setConfig({root: '', bigquery: {}})
+    expect('from users select created_at - interval age minute as shifted').toRenderSql(
+      'select users.created_at - interval users.age minute as shifted from `users` as users',
+    )
+    expect('from users select created_at - (age * interval 1 minute) as shifted').toRenderSql(
+      'select users.created_at - interval users.age minute as shifted from `users` as users',
+    )
+  })
+
+  it('renders dynamic intervals for Snowflake via DATEADD', () => {
+    setConfig({dialect: 'snowflake', root: ''})
+    expect('from users select created_at - interval age minute as shifted').toRenderSql(
+      'SELECT TIMESTAMPADD(minute, -(users.age), users.created_at) as shifted FROM USERS as users',
+    )
+    expect('from users select created_at - (age * interval 1 minute) as shifted').toRenderSql(
+      'SELECT TIMESTAMPADD(minute, -(users.age), users.created_at) as shifted FROM USERS as users',
+    )
   })
 
   it('supports date keyword', () => {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -867,16 +867,12 @@ describe('lang', () => {
   })
 
   it('supports multiplied literal intervals in date arithmetic', () => {
-    expect('from users select created_at - (age * interval 1 minute) as shifted').toRenderSql(
-      'select users.created_at - (users.age * (interval 1 minute)) as shifted from users as users',
-    )
+    expect('from users select created_at - (age * interval 1 minute) as shifted').toRenderSql('select users.created_at - (users.age * (interval 1 minute)) as shifted from users as users')
   })
 
   it('supports multiplied literal intervals in computed columns', () => {
     updateFile('table flights (dep_time timestamp, dep_delay int, scheduled_dep_time: dep_time - (dep_delay * interval 1 minute))', 'flights.gsql')
-    expect('from flights select scheduled_dep_time').toRenderSql(
-      'select (flights.dep_time - (flights.dep_delay * (interval 1 minute))) as scheduled_dep_time from flights as flights',
-    )
+    expect('from flights select scheduled_dep_time').toRenderSql('select (flights.dep_time - (flights.dep_delay * (interval 1 minute))) as scheduled_dep_time from flights as flights')
   })
 
   it('diagnoses multiplied dynamic intervals', () => {
@@ -889,22 +885,14 @@ describe('lang', () => {
 
   it('renders dynamic intervals for BigQuery', () => {
     setConfig({root: '', bigquery: {}})
-    expect('from users select created_at - interval age minute as shifted').toRenderSql(
-      'select users.created_at - interval users.age minute as shifted from `users` as users',
-    )
-    expect('from users select created_at - (age * interval 1 minute) as shifted').toRenderSql(
-      'select users.created_at - interval users.age minute as shifted from `users` as users',
-    )
+    expect('from users select created_at - interval age minute as shifted').toRenderSql('select users.created_at - interval users.age minute as shifted from `users` as users')
+    expect('from users select created_at - (age * interval 1 minute) as shifted').toRenderSql('select users.created_at - interval users.age minute as shifted from `users` as users')
   })
 
   it('renders dynamic intervals for Snowflake via DATEADD', () => {
     setConfig({dialect: 'snowflake', root: ''})
-    expect('from users select created_at - interval age minute as shifted').toRenderSql(
-      'SELECT TIMESTAMPADD(minute, -(users.age), users.created_at) as shifted FROM USERS as users',
-    )
-    expect('from users select created_at - (age * interval 1 minute) as shifted').toRenderSql(
-      'SELECT TIMESTAMPADD(minute, -(users.age), users.created_at) as shifted FROM USERS as users',
-    )
+    expect('from users select created_at - interval age minute as shifted').toRenderSql('SELECT TIMESTAMPADD(minute, -(users.age), users.created_at) as shifted FROM USERS as users')
+    expect('from users select created_at - (age * interval 1 minute) as shifted').toRenderSql('SELECT TIMESTAMPADD(minute, -(users.age), users.created_at) as shifted FROM USERS as users')
   })
 
   it('supports date keyword', () => {

--- a/lang/params.ts
+++ b/lang/params.ts
@@ -1,6 +1,6 @@
 import type {Query} from './types.ts'
 
-import {parseTemporalLiteral} from './temporalLiterals.ts'
+import {parseTemporalLiteral} from './temporal.ts'
 
 // Fill in parameter values in a query's SQL strings
 // Params look like $paramName in the SQL

--- a/lang/temporal.ts
+++ b/lang/temporal.ts
@@ -1,4 +1,4 @@
-import type {FieldType} from './types.ts'
+import {type FieldType, type Expr} from './types.ts'
 
 export type TimestampUnit = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'
 
@@ -131,4 +131,21 @@ function isValidDate(year: number, month: number, day: number) {
 
 function pad(value: number) {
   return value.toString().padStart(2, '0')
+}
+
+export function renderTemporalArithmetic(dialect: string, leftSql: string, leftType: 'date' | 'timestamp', op: '+' | '-', intervalExpr: NonNullable<Expr['interval']>) {
+  if (dialect == 'snowflake') {
+    let signedQuantity = op == '+' ? intervalExpr.quantitySql : `-(${intervalExpr.quantitySql})`
+    let fnName = leftType == 'date' ? 'DATEADD' : 'TIMESTAMPADD'
+    return `${fnName}(${intervalExpr.unit}, ${signedQuantity}, ${leftSql})`
+  }
+  return `${leftSql} ${op} ${renderStandaloneInterval(dialect, intervalExpr)}`
+}
+
+export function renderStandaloneInterval(dialect: string, intervalExpr: NonNullable<Expr['interval']>) {
+  if (dialect == 'duckdb') {
+    if (intervalExpr.form == 'constant') return `interval ${intervalExpr.quantitySql} ${intervalExpr.unit}`
+    return `(${intervalExpr.quantitySql} * (interval 1 ${intervalExpr.unit}))`
+  }
+  return `interval ${intervalExpr.quantitySql} ${intervalExpr.unit}`
 }

--- a/lang/temporalLiterals.ts
+++ b/lang/temporalLiterals.ts
@@ -1,6 +1,6 @@
 import type {FieldType} from './types.ts'
 
-type TimestampUnit = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'
+export type TimestampUnit = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'
 
 export type TemporalLiteral = {
   literal: string

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -1,5 +1,7 @@
 import type {SyntaxNode, Tree} from '@lezer/common'
 
+import type {TimestampUnit} from './temporalLiterals.ts'
+
 declare module '@lezer/common' {
   interface Tree {
     fileInfo: FileInfo
@@ -14,6 +16,13 @@ export interface Expr {
   type: FieldType // result type for validation
   isAgg?: boolean // true if contains an aggregate function
   canWindow?: boolean // true if expression can be used with an OVER clause
+  interval?: {
+    quantitySql: string
+    unit: TimestampUnit
+    kind: 'simple' | 'scaled'
+    canScale: boolean
+    isConstant: boolean
+  }
 }
 
 // A field in a query's SELECT clause

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -1,6 +1,6 @@
 import type {SyntaxNode, Tree} from '@lezer/common'
 
-import type {TimestampUnit} from './temporalLiterals.ts'
+import type {TimestampUnit} from './temporal.ts'
 
 declare module '@lezer/common' {
   interface Tree {
@@ -16,13 +16,7 @@ export interface Expr {
   type: FieldType // result type for validation
   isAgg?: boolean // true if contains an aggregate function
   canWindow?: boolean // true if expression can be used with an OVER clause
-  interval?: {
-    quantitySql: string
-    unit: TimestampUnit
-    kind: 'simple' | 'scaled'
-    canScale: boolean
-    isConstant: boolean
-  }
+  interval?: IntervalExpr
 }
 
 // A field in a query's SELECT clause
@@ -35,6 +29,14 @@ export interface QueryField extends Expr {
 export interface Filter {
   sql: string
   isAgg?: boolean // if true, goes in HAVING; otherwise WHERE
+}
+
+// Interval lowering metadata carried on interval-typed expressions, so later analysis
+// can rewrite them into the dialect-specific syntax each warehouse expects.
+export interface IntervalExpr {
+  quantitySql: string
+  unit: TimestampUnit
+  form: 'constant' | 'dynamic' | 'scaled'
 }
 
 // Context for analyzing expressions - table/alias change as we traverse joins, but query is shared


### PR DESCRIPTION
This PR updates the dynamic interval support to make two changes:

1. Support the syntax `column_ref * interval 1 unit`, which actually already parsed, but was rejected in analysis.
2. Lower both that multiplication syntax and `interval column_ref unit` to dialect-correct SQL in each dialect. It turns out that each dialect must use different syntax:
  a. DuckDB only supports the multiplication syntax, and we lower dynamic intervals to `column_ref * interval 1 unit`
  b. BigQuery supports `interval column_ref unit` directly, and we convert the multiplication form in the other direction.
  c. Snowflake is supported with `TIMESTAMPADD(unit, numeric_ref, timestamp_ref)`