### PR TITLE
Ignore output fields when analyzing computed columns

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -433,17 +433,12 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       let fieldNode = pathNodes.pop()!
       let fieldName = txt(fieldNode)
 
-      // Check output fields first (for referencing aliases in HAVING)
-      if (scope.query && pathNodes.length == 0) {
+      // Check output fields first when we're at the query root (e.g. HAVING/post-agg filters).
+      // Don't do this while resolving table expressions, or we can accidentally bind to sibling
+      // SELECT aliases instead of the table's computed columns.
+      if (scope.query && !scope.table && pathNodes.length == 0) {
         let outField = scope.query.fields.find(f => f.name == fieldName)
-        if (outField) {
-          return {
-            sql: outField.isAgg ? fieldName : outField.sql,
-            type: outField.type,
-            isAgg: outField.isAgg,
-            fanout: outField.fanout,
-          }
-        }
+        if (outField) return {sql: outField.sql, type: outField.type, isAgg: outField.isAgg, fanout: outField.fanout}
       }
 
       // Follow any dot path (e.g., `users.orders` in `users.orders.amount`), then find the field

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -238,6 +238,21 @@ describe('lang', () => {
     await expect('from users select name, total_orders').toReturnRows(['Alice', 2], ['Bob', 1])
   })
 
+  it('ignores output fields when analyzing computed columns', () => {
+    updateFile(
+      `table sales (
+        amount int
+        cost int
+        revenue: sum(amount)
+        cogs: sum(cost)
+        gross_profit: revenue - cogs
+      )`,
+      'sales.gsql',
+    )
+
+    expect('from sales select revenue, gross_profit').toRenderSql('select (sum(sales.amount)) as revenue, ((sum(sales.amount))-(sum(sales.cost))) as gross_profit from sales as sales')
+  })
+
   it('handles expressions with aggregates', async () => {
     expect('from orders select user_id, avg_order_value').toRenderSql(
       'select orders.user_id as user_id, (sum(orders.amount)/count(1)) as avg_order_value from orders as orders group by 1 order by 2 desc nulls last',


### PR DESCRIPTION
This was bugged if a query selected both computed column A, and computed column B that derived from A. Instead of expanding the computed expression inline, it would try referencing A from B. In some dialects that works, but I don't think it's ever what we want graphene to do, we should simply fully expand all expressions.

# Conflicts:
#	lang/analyze.ts