### PR TITLE
update language server to support definitions & references

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -18,7 +18,21 @@ import {
 import {analyzeFunction} from './functions.ts'
 import {extractLeadingMetadata} from './metadata.ts'
 import {parseTemporalLiteral, parseIntervalLiteral, parseIntervalUnit, renderTemporalArithmetic, renderStandaloneInterval} from './temporal.ts'
-import {type Table, type Query, type QueryJoin, type Column, type FieldType, type FileInfo, type Diagnostic, type Expr, type CteTable, type JoinType, type Scope} from './types.ts'
+import {
+  type Table,
+  type Query,
+  type QueryJoin,
+  type Column,
+  type FieldType,
+  type FileInfo,
+  type Diagnostic,
+  type Expr,
+  type CteTable,
+  type JoinType,
+  type Scope,
+  type Location,
+  type NavigationSymbolKind,
+} from './types.ts'
 import {txt, getFile, getPosition} from './util.ts'
 
 // Analyze is the heart of gsql processing. It works in 2 phases:
@@ -39,24 +53,50 @@ export let diagnostics: Diagnostic[] = [] // Tracks errors/warnings
 let analysisStack = new Set<Column>() // Track computed columns being analyzed to detect cycles
 let NODE_ENTITY_MAP = new NodeWeakMap<any>() // Points syntax nodes back to entities for ide hover tips
 
+function locationForNode(node: SyntaxNode): Location {
+  let file = getFile(node)
+  return {file: file.path, from: getPosition(node.from, file), to: getPosition(node.to, file)}
+}
+
+function symbolId(kind: NavigationSymbolKind, location: Location, scopeKey = '') {
+  let suffix = scopeKey ? `:${scopeKey}` : ''
+  return `${kind}:${location.file}:${location.from.offset}:${location.to.offset}${suffix}`
+}
+
+function addSymbol(kind: NavigationSymbolKind, node: SyntaxNode, name: string, opts: {tableId?: string; scopeKey?: string} = {}) {
+  let file = getFile(node)
+  let location = locationForNode(node)
+  let id = symbolId(kind, location, opts.scopeKey)
+  file.navigation.symbols.push({id, kind, name, location, tableId: opts.tableId})
+  return {symbolId: id, location}
+}
+
+function addReference(kind: NavigationSymbolKind, node: SyntaxNode, targetId?: string) {
+  if (!targetId) return
+  let file = getFile(node)
+  file.navigation.references.push({kind, targetId, location: locationForNode(node)})
+}
+
 // Creates tables without analyzing them.
 export function findTables(fi: FileInfo) {
   let tn = fi.tree!.topNode
   fi.tables = []
   let nodes = tn.getChildren('TableStatement').concat(tn.getChildren('ViewStatement'))
   for (let syntaxNode of nodes) {
-    let name = txt(syntaxNode.getChild('Ref'))
+    let refNode = syntaxNode.getChild('Ref')!
+    let name = txt(refNode)
 
     let existing = Object.values(FILE_MAP).find(f => {
       if (f.path.endsWith('.md') && f.path != fi.path) return
       return f.tables.find(t => t.name == name)
     })
-    if (existing) diag(syntaxNode.getChild('Ref')!, `Table "${name}" is already defined`)
+    if (existing) diag(refNode, `Table "${name}" is already defined`)
 
     let hasNamespace = name.includes('.')
     let tablePath = !hasNamespace && config.defaultNamespace ? `${config.defaultNamespace}.${name}` : name
     let type = syntaxNode.getChild('QueryStatement') ? 'view' : ('table' as const)
     let table = {name, type, tablePath, columns: [], joins: [], metadata: extractLeadingMetadata(syntaxNode), syntaxNode} as Table
+    Object.assign(table, addSymbol('table', refNode, name))
 
     syntaxNode.getChildren('ColumnDef').forEach(cn => addColumn(table, cn))
     syntaxNode.getChildren('JoinDef').forEach(jn => addJoin(table, jn))
@@ -77,10 +117,12 @@ export function applyExtends(fi: FileInfo) {
 }
 
 function addColumn(table: Table, node: SyntaxNode) {
-  let name = txt(node.getChild('ColumnName'))
+  let nameNode = node.getChild('ColumnName')!
+  let name = txt(nameNode)
   let type = convertDataType(txt(node.getChild('DataType')))
   if (!type) return diag(node, `Unsupported data type: ${txt(node.getChild('DataType'))}`)
   let col: Column = {name, type, metadata: extractLeadingMetadata(node)}
+  Object.assign(col, addSymbol('column', nameNode, name, {tableId: table.symbolId}))
   if (getField(name, table)) return diag(node, `Table already has a field called "${name}"`)
   table.columns.push(col)
 }
@@ -103,8 +145,10 @@ function addJoin(table: Table, node: SyntaxNode) {
 }
 
 function addComputedColumn(table: Table, node: SyntaxNode) {
-  let name = txt(node.getChild('Alias'))
+  let nameNode = node.getChild('Alias')!
+  let name = txt(nameNode)
   let col: Column = {name, type: 'string', exprNode: node.getChild('Expression')!, metadata: extractLeadingMetadata(node)}
+  Object.assign(col, addSymbol('column', nameNode, name, {tableId: table.symbolId}))
   if (getField(name, table)) return diag(node, `Table already has a field called "${name}"`)
   table.columns.push(col)
 }
@@ -120,7 +164,15 @@ function analyzeView(table: Table) {
   if (table.type != 'view') return
   if (table.query) return // already analyzed
   let query = analyzeQuery(table.syntaxNode!.getChild('QueryStatement')!)
-  let viewCols = query?.fields.map(f => ({name: f.name, type: f.type, metadata: f.metadata}) as Column) || []
+  let viewCols =
+    query?.fields.map(f => {
+      let col = {name: f.name, type: f.type, metadata: f.metadata, location: f.definitionLocation} as Column
+      if (f.definitionLocation) {
+        col.symbolId = symbolId('column', f.definitionLocation, `${table.symbolId}:${f.name}`)
+        getFile(table.syntaxNode!).navigation.symbols.push({id: col.symbolId, kind: 'column', name: col.name, location: f.definitionLocation, tableId: table.symbolId})
+      }
+      return col
+    }) || []
   table.columns.push(...viewCols)
   table.query = query!
 }
@@ -165,9 +217,17 @@ function expandColumns(table: Table | null, alias: string, query: Query, scope: 
         type: expr.type,
         metadata: col.metadata,
         fanout: expr.fanout,
+        definitionLocation: col.location,
       })
     } else {
-      query.fields.push({name: outName, sql: `${alias}.${col.name}`, type: col.type, metadata: col.metadata, fanout: normalizeExprFanout({path: scope.fanoutPath})})
+      query.fields.push({
+        name: outName,
+        sql: `${alias}.${col.name}`,
+        type: col.type,
+        metadata: col.metadata,
+        fanout: normalizeExprFanout({path: scope.fanoutPath}),
+        definitionLocation: col.location,
+      })
     }
   }
 }
@@ -254,9 +314,11 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
       if (!targetScope.table) continue
       expandColumns(targetScope.table, targetScope.alias, query, targetScope)
     } else {
-      let expr = analyzeExpr(s.getChild('Expression')!, scope)
-      if (expr.type == 'interval' && expr.interval?.form == 'scaled') diag(s.getChild('Expression')!, 'Multiplied intervals are only supported inside date/time arithmetic')
-      let name = s.getChild('Alias') ? txt(s.getChild('Alias')) : inferName(s.getChild('Expression')!, scope)
+      let exprNode = s.getChild('Expression')!
+      let aliasNode = s.getChild('Alias')
+      let expr = analyzeExpr(exprNode, scope)
+      if (expr.type == 'interval' && expr.interval?.form == 'scaled') diag(exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
+      let name = aliasNode ? txt(aliasNode) : inferName(exprNode, scope)
       isAgg ||= !!expr.isAgg
       query.fields.push({
         name,
@@ -264,8 +326,9 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
         type: expr.type,
         isAgg: expr.isAgg,
         fanout: expr.fanout,
+        definitionLocation: locationForNode(aliasNode || exprNode),
       })
-      fanoutExprs.push({node: s.getChild('Expression')!, expr})
+      fanoutExprs.push({node: exprNode, expr})
     }
   }
 
@@ -301,7 +364,7 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
 
       // If it's not in there, add it to the select.
       if (!query.fields.find(f => f.name == name)) {
-        query.fields.unshift({name, sql: expr.sql, type: expr.type, fanout: expr.fanout})
+        query.fields.unshift({name, sql: expr.sql, type: expr.type, fanout: expr.fanout, definitionLocation: locationForNode(g.getChild('Alias') || exprNode)})
       }
       fanoutExprs.push({node: g.getChild('Expression')!, expr})
     }
@@ -468,6 +531,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       let {table, alias} = matches[0]
       let col = table.columns.find(c => c.name == fieldName)!
       NODE_ENTITY_MAP.set(fieldNode, {entityType: 'field', field: col, table})
+      addReference('column', fieldNode, col.symbolId)
 
       // Simple case: this is just a regular column on a table
       if (!col.exprNode) return {sql: `${alias}.${col.name}`, type: col.type, fanout: normalizeExprFanout({path: matches[0].fanoutPath})}
@@ -891,6 +955,7 @@ function followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
     let table = pointsAtTarget ? scope.joinTarget.table : scope.table!
     let alias = pointsAtTarget ? scope.joinTarget.alias : scope.alias
     NODE_ENTITY_MAP.set(pathNodes[0], {entityType: 'table', table})
+    addReference('table', pathNodes[0], table.symbolId)
     return {query: scope.query, table, alias, fanoutPath: scope.fanoutPath, otherTables: scope.otherTables}
   }
 
@@ -902,6 +967,7 @@ function followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
     let existing = scope.query!.joins.find(j => j.alias == name)
     if (existing) {
       NODE_ENTITY_MAP.set(part, {entityType: 'table', table: existing.table})
+      addReference('table', part, existing.table?.symbolId)
       scope = {...scope, table: existing.table!, alias: existing.alias, fanoutPath: existing.fanoutPath}
       pathNodes.shift() // remove, since we're updating scope
     } else {
@@ -938,6 +1004,7 @@ function followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
     }
 
     NODE_ENTITY_MAP.set(part, {entityType: 'table', table: next.table})
+    addReference('table', part, next.table.symbolId)
     scope = {...scope, table: next.table, alias: newAlias, fanoutPath}
   }
 
@@ -1085,6 +1152,7 @@ function lookupTable(node: SyntaxNode, scope?: Scope): Table | undefined {
   }
   if (!table) return diag(node, `Unknown table "${name}"`)
   analyzeView(table)
+  addReference('table', node, table.symbolId)
   return table
 }
 

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -187,7 +187,12 @@ export function analyzeTableFully(table: Table) {
     c.isAgg = expr.isAgg
     analyzeComputedFieldExpr(c.exprNode, expr)
   })
-  table.joins.forEach(j => (j.table = lookupTable(j.targetNode!)))
+  table.joins.forEach(j => {
+    j.table = lookupTable(j.targetNode!)
+    if (!j.table || !j.onExpr) return
+    let joinTarget = {name: j.alias, table: j.table, alias: j.alias}
+    analyzeExpr(j.onExpr, {table, alias: table.name, fanoutPath: [], joinTarget})
+  })
 }
 
 // Expand non-aggregate columns into query fields.

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -7,8 +7,8 @@ import {config, loadConfig} from './config.ts'
 import {parseMarkdown} from './markdown.ts'
 import {fillInParams} from './params.ts'
 import {parser} from './parser.js'
-import {type Query} from './types.ts'
-import {getOffset} from './util.ts'
+import {type Query, type Location} from './types.ts'
+import {getOffset, getSourceOffset} from './util.ts'
 
 export {clearWorkspace}
 export {config, loadConfig}
@@ -43,9 +43,10 @@ export async function loadWorkspace(dir: string, includeMd: boolean) {
 }
 
 export function updateFile(contents: string, path: string) {
-  FILE_MAP[path] ||= {path, contents, tree: null, tables: [], queries: []}
+  FILE_MAP[path] ||= {path, contents, tree: null, tables: [], queries: [], navigation: {symbols: [], references: []}}
   FILE_MAP[path].contents = contents
   FILE_MAP[path].tree = null
+  FILE_MAP[path].navigation = {symbols: [], references: []}
   return FILE_MAP[path]
 }
 
@@ -62,6 +63,7 @@ export function analyze(contents?: string, contentType?: 'gsql' | 'md'): Query[]
 
   Object.values(FILE_MAP).forEach(fi => {
     let isMd = fi.path.endsWith('.md') || (fi.path == 'input' && contentType == 'md')
+    fi.navigation = {symbols: [], references: []}
     fi.tree ||= isMd ? parseMarkdown(fi) : parser.parse(fi.contents)
     fi.tree!.fileInfo = fi
     recordSyntaxErrors(fi)
@@ -80,6 +82,10 @@ export function analyze(contents?: string, contentType?: 'gsql' | 'md'): Query[]
   Object.values(FILE_MAP)
     .flatMap(f => f.tables)
     .forEach(analyzeTableFully)
+  Object.values(FILE_MAP).forEach(fi => {
+    let nodes = fi.tree!.topNode.getChildren('QueryStatement') || []
+    fi.queries = nodes.map(n => analyzeQuery(n)).filter((q): q is Query => !!q)
+  })
   return []
 }
 
@@ -113,4 +119,37 @@ export function getHover(path: string, line: number, col: number): string {
     return `#### ${entity.table.name}${desc}`
   }
   return ''
+}
+
+export function getDefinition(path: string, line: number, col: number): Location | null {
+  let symbol = getNavigationTarget(path, line, col)
+  return symbol?.location || null
+}
+
+export function getReferences(path: string, line: number, col: number, includeDeclaration = false): Location[] {
+  let symbol = getNavigationTarget(path, line, col)
+  if (!symbol) return []
+
+  let references = Object.values(FILE_MAP).flatMap(file => file.navigation.references.filter(ref => ref.targetId == symbol.id).map(ref => ref.location))
+  if (includeDeclaration) return [symbol.location, ...references]
+  return references
+}
+
+function getNavigationTarget(path: string, line: number, col: number) {
+  let fi = FILE_MAP[path]
+  if (!fi) return null
+
+  let offset = getSourceOffset(line, col, fi)
+  let reference = fi.navigation.references.find(ref => containsOffset(ref.location, offset))
+  if (reference) {
+    return Object.values(FILE_MAP)
+      .flatMap(file => file.navigation.symbols)
+      .find(symbol => symbol.id == reference.targetId)
+  }
+
+  return fi.navigation.symbols.find(symbol => containsOffset(symbol.location, offset)) || null
+}
+
+function containsOffset(location: Location, offset: number) {
+  return offset >= location.from.offset && offset <= location.to.offset
 }

--- a/lang/features.test.ts
+++ b/lang/features.test.ts
@@ -1,7 +1,24 @@
 import {expect} from 'vitest'
 
 /// <reference types="vitest/globals" />
-import {analyze, getHover, clearWorkspace} from './core.ts'
+import {analyze, getDefinition, getHover, getReferences, clearWorkspace, updateFile} from './core.ts'
+
+function simple(location: ReturnType<typeof getDefinition>) {
+  if (!location) return null
+  return {
+    file: location.file,
+    from: [location.from.line, location.from.col],
+    to: [location.to.line, location.to.col],
+  }
+}
+
+function simpleList(locations: ReturnType<typeof getReferences>) {
+  return locations.map(location => ({
+    file: location.file,
+    from: [location.from.line, location.from.col],
+    to: [location.to.line, location.to.col],
+  }))
+}
 
 describe('hover', () => {
   beforeEach(() => {
@@ -29,5 +46,103 @@ describe('hover', () => {
     // Hover over 'f' in 'from' (line 4, col 0)
     let hover = getHover('input', 3, 12)
     expect(hover).toBe('#### users\n\nall the users in our system')
+  })
+})
+
+describe('definition navigation', () => {
+  beforeEach(() => {
+    clearWorkspace()
+  })
+
+  it('returns the table definition for a FROM reference', () => {
+    analyze(`table users (id int, name text)
+from users select name`)
+
+    expect(simple(getDefinition('input', 1, 6))).toEqual({
+      file: 'input',
+      from: [0, 6],
+      to: [0, 11],
+    })
+  })
+
+  it('returns the column definition for a column reference', () => {
+    analyze(`table users (id int, name text)
+from users select name`)
+
+    expect(simple(getDefinition('input', 1, 18))).toEqual({
+      file: 'input',
+      from: [0, 21],
+      to: [0, 25],
+    })
+  })
+
+  it('returns the view output definition for a referenced view column', () => {
+    analyze(`table users (id int, name text)
+table active_users as (
+  from users select name as display_name
+)
+from active_users select display_name`)
+
+    expect(simple(getDefinition('input', 4, 25))).toEqual({
+      file: 'input',
+      from: [2, 28],
+      to: [2, 40],
+    })
+  })
+
+  it('maps markdown table definitions back to the fence header', () => {
+    analyze(
+      `\`\`\`gsql users
+select 1 as id
+\`\`\`
+
+<Value data="users" value="id" />`,
+      'md',
+    )
+
+    expect(simple(getDefinition('input', 4, 13))).toEqual({
+      file: 'input',
+      from: [0, 8],
+      to: [0, 13],
+    })
+  })
+})
+
+describe('reference navigation', () => {
+  beforeEach(() => {
+    clearWorkspace()
+  })
+
+  it('finds references across files for a table definition', () => {
+    updateFile('table users (id int, name text)', 'schema.gsql')
+    updateFile('from users select name', 'page1.gsql')
+    updateFile('from users select users.name', 'page2.gsql')
+    analyze()
+
+    expect(simpleList(getReferences('schema.gsql', 0, 7))).toEqual([
+      {file: 'page1.gsql', from: [0, 5], to: [0, 10]},
+      {file: 'page2.gsql', from: [0, 5], to: [0, 10]},
+      {file: 'page2.gsql', from: [0, 18], to: [0, 23]},
+    ])
+  })
+
+  it('finds references across files for a column definition', () => {
+    updateFile('table users (id int, name text)', 'schema.gsql')
+    updateFile('from users select name', 'page1.gsql')
+    updateFile('from users select users.name', 'page2.gsql')
+    analyze()
+
+    expect(simpleList(getReferences('schema.gsql', 0, 22, true))).toEqual([
+      {file: 'schema.gsql', from: [0, 21], to: [0, 25]},
+      {file: 'page1.gsql', from: [0, 18], to: [0, 22]},
+      {file: 'page2.gsql', from: [0, 24], to: [0, 28]},
+    ])
+  })
+
+  it('does not navigate query-local aliases', () => {
+    analyze(`table users (id int, name text)
+from users as u select u.name as display_name`)
+
+    expect(getDefinition('input', 1, 33)).toBeNull()
   })
 })

--- a/lang/features.test.ts
+++ b/lang/features.test.ts
@@ -90,6 +90,31 @@ from active_users select display_name`)
     })
   })
 
+  it('returns definitions for join condition references', () => {
+    analyze(`table users (id int, name text)
+table orders (
+  id int,
+  user_id int,
+  join one users on users.id = user_id
+)`)
+
+    expect(simple(getDefinition('input', 4, 11))).toEqual({
+      file: 'input',
+      from: [0, 6],
+      to: [0, 11],
+    })
+    expect(simple(getDefinition('input', 4, 26))).toEqual({
+      file: 'input',
+      from: [0, 13],
+      to: [0, 15],
+    })
+    expect(simple(getDefinition('input', 4, 31))).toEqual({
+      file: 'input',
+      from: [3, 2],
+      to: [3, 9],
+    })
+  })
+
   it('maps markdown table definitions back to the fence header', () => {
     analyze(
       `\`\`\`gsql users

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -681,6 +681,16 @@ describe('lang', () => {
     expect('from orders select users.does_not_exist').toHaveDiagnostic(/unknown field "does_not_exist" on users/i)
   })
 
+  it('reports diagnostics for unknown columns in table join conditions', () => {
+    expect(`
+      table users (id int)
+      table orders (
+        user_id int,
+        join one users on users.does_not_exist = user_id
+      )
+    `).toHaveDiagnostic(/unknown field "does_not_exist" on users/i)
+  })
+
   it('reports not being able to find a join on a query', () => {
     expect(`
       table t (oid int, join one users as usr on usr.id = oid);

--- a/lang/markdown.ts
+++ b/lang/markdown.ts
@@ -30,6 +30,7 @@ interface FenceMatch {
   contentStart: number
   content: string
   name?: string
+  nameStart?: number
 }
 
 interface ComponentMatch {
@@ -104,7 +105,12 @@ export function parseMarkdown(fi: FileInfo) {
       let contentStart = fence.contentStart
       let content = fence.content
       if (fence.name) {
-        appendMapped(`table ${fence.name} as (\n`, () => contentStart, {reset: contentStart - 1})
+        let name = fence.name
+        appendMapped('table ', () => fence.start, {reset: fence.start - 1})
+        let nameStart = fence.nameStart ?? contentStart
+        appendMapped(name, i => nameStart + i, {reset: nameStart - 1})
+        appendMapped(' ', () => nameStart + name.length, {reset: nameStart + name.length - 1})
+        appendMapped('as (\n', () => contentStart, {reset: contentStart - 1})
         appendContent(content, contentStart)
         if (!content.endsWith('\n')) appendMapped('\n', () => contentStart + content.length, {reset: contentStart + content.length - 1})
         appendMapped(')\n', () => fence.end - 1, {reset: fence.end - 2})
@@ -170,8 +176,8 @@ function collectFences(source: string): FenceMatch[] {
     headerLength += 1
     let content = match[3] || ''
     let contentStart = start + headerLength
-    let name = extractFenceName(full.slice(0, headerLength))
-    matches.push({start, end: start + full.length, headerLength, contentStart, content, name})
+    let {name, index} = extractFenceName(full.slice(0, headerLength))
+    matches.push({start, end: start + full.length, headerLength, contentStart, content, name, nameStart: index == null ? undefined : start + index})
   }
   return matches
 }
@@ -194,10 +200,10 @@ function collectComponents(source: string, fences: FenceMatch[]): ComponentMatch
   return matches
 }
 
-function extractFenceName(header: string): string | undefined {
+function extractFenceName(header: string): {name?: string; index?: number} {
   let parts = header.trim().split(/\s+/)
-  if (parts.length > 1) return parts[1]
-  return undefined
+  if (parts.length > 1) return {name: parts[1], index: header.indexOf(parts[1])}
+  return {}
 }
 
 function extractAttributes(fragment: string, baseStart: number): Record<string, AttrMatch> {

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -25,6 +25,7 @@ export interface Expr {
 export interface QueryField extends Expr {
   name: string // output column name
   metadata?: Record<string, string>
+  definitionLocation?: Location // where this field is defined when materialized into a view
 }
 
 // A filter (WHERE or HAVING)
@@ -87,6 +88,8 @@ export interface Column {
   isAgg?: boolean // for computed columns that are aggregates
   exprNode?: SyntaxNode // for computed columns, the expression AST node (analyzed lazily in query context)
   metadata?: Record<string, string>
+  symbolId?: string
+  location?: Location
 }
 
 // A table definition - discriminated union so views guarantee a query
@@ -97,6 +100,8 @@ interface TableBase {
   joins: QueryJoin[]
   metadata?: Record<string, string>
   syntaxNode?: SyntaxNode
+  symbolId?: string
+  location?: Location
 }
 export interface PhysicalTable extends TableBase {
   type: 'table'
@@ -129,12 +134,40 @@ export interface Diagnostic {
   severity: 'error' | 'warn'
 }
 
+export interface Location {
+  file: string
+  from: Position
+  to: Position
+}
+
+export type NavigationSymbolKind = 'table' | 'column'
+
+export interface NavigationSymbol {
+  id: string
+  kind: NavigationSymbolKind
+  name: string
+  location: Location
+  tableId?: string
+}
+
+export interface NavigationReference {
+  kind: NavigationSymbolKind
+  location: Location
+  targetId: string
+}
+
+export interface FileNavigation {
+  symbols: NavigationSymbol[]
+  references: NavigationReference[]
+}
+
 export interface FileInfo {
   path: string
   contents: string
   tree: Tree | null
   tables: Table[]
   queries: Query[]
+  navigation: FileNavigation
   virtualContents?: string
   virtualToMarkdownOffset?: number[]
 }

--- a/lang/util.ts
+++ b/lang/util.ts
@@ -42,14 +42,19 @@ export function getPosition(offset: number, file: FileInfo) {
   return {offset: mdOffset, line: 1, col: 0}
 }
 
-export function getOffset(line: number, col: number, file: FileInfo) {
+export function getSourceOffset(line: number, col: number, file: FileInfo) {
   let lines = file.contents.split(/\r?\n/)
   let acc = 0
   for (let i = 0; i < line; i++) {
     acc += lines[i].length + 1
   }
-  if (file.virtualContents) return virtualOffset(acc + col, file)
   return acc + col
+}
+
+export function getOffset(line: number, col: number, file: FileInfo) {
+  let offset = getSourceOffset(line, col, file)
+  if (file.virtualContents) return virtualOffset(offset, file)
+  return offset
 }
 
 export function getFile(node: SyntaxNode | SyntaxNodeRef): FileInfo {

--- a/language-server/src/service.ts
+++ b/language-server/src/service.ts
@@ -9,11 +9,13 @@ import {
   type Disposable,
   type WorkspaceDocumentDiagnosticReport,
   type DocumentUri,
+  type Location,
+  type LocationLink,
 } from 'vscode-languageserver-protocol'
 import {URI, Utils as URIs} from 'vscode-uri'
 
-import {deleteFile, updateFile, analyze, getDiagnostics, getFiles, getHover, loadConfig, loadWorkspace} from '../../lang/core.ts'
-import {type Diagnostic as GrapheneDiagnostic} from '../../lang/types.ts'
+import {deleteFile, updateFile, analyze, getDefinition, getDiagnostics, getFiles, getHover, getReferences, loadConfig, loadWorkspace} from '../../lang/core.ts'
+import {type Diagnostic as GrapheneDiagnostic, type Location as GrapheneLocation} from '../../lang/types.ts'
 
 export function createGrapheneService(server: ReturnType<typeof createServer>): LanguageServicePlugin {
   return {
@@ -24,6 +26,8 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         workspaceDiagnostics: true,
       },
       hoverProvider: true,
+      definitionProvider: true,
+      referencesProvider: true,
     },
     create(context): LanguageServicePluginInstance {
       let [workspace] = context.env.workspaceFolders
@@ -49,6 +53,19 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
 
           let path = workspacePath(document.uri)
           return path ? {contents: getHover(path, position.line, position.character)} : null
+        },
+        async provideDefinition(document, position, _token) {
+          await analysis.pending
+
+          let path = workspacePath(document.uri)
+          let location = path ? getDefinition(path, position.line, position.character) : null
+          return location ? [toLocationLink(workspace, location)] : []
+        },
+        async provideReferences(document, position, context, _token) {
+          await analysis.pending
+
+          let path = workspacePath(document.uri)
+          return path ? getReferences(path, position.line, position.character, context.includeDeclaration).map(location => toLocation(workspace, location)) : []
         },
         async provideDiagnostics(document) {
           await analysis.pending
@@ -191,4 +208,23 @@ function toDiagnostic(diagnostic: GrapheneDiagnostic): Diagnostic {
     message: diagnostic.message,
     source: 'graphene',
   }
+}
+
+function toLocation(workspace: URI, location: GrapheneLocation): Location {
+  return {
+    uri: URIs.joinPath(workspace, location.file).toString(),
+    range: {
+      start: {line: location.from.line, character: location.from.col},
+      end: {line: location.to.line, character: location.to.col},
+    },
+  }
+}
+
+function toLocationLink(workspace: URI, location: GrapheneLocation): LocationLink {
+  let uri = URIs.joinPath(workspace, location.file).toString()
+  let range = {
+    start: {line: location.from.line, character: location.from.col},
+    end: {line: location.to.line, character: location.to.col},
+  }
+  return {targetUri: uri, targetRange: range, targetSelectionRange: range}
 }

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -59,7 +59,7 @@ test('check with mdFile reports analysis errors', async ({server, page}) => {
     '/mock.md',
     `
     \`\`\`sql error_query
-    from flights select not_a_function() as explode
+    from flights select 1 as origin, not_a_function() as explode
     \`\`\`
     <BarChart data="error_query" x="origin" y="explode" />
   `,
@@ -70,8 +70,8 @@ test('check with mdFile reports analysis errors', async ({server, page}) => {
   expect(outputLines()).toEqual(
     `
     ERROR: mock.md line 3: Unknown function: not_a_function
-   | from flights select not_a_function() as explode
-   |                     ^^^^^^^^^^^^^^^^
+   | from flights select 1 as origin, not_a_function() as explode
+   |                                  ^^^^^^^^^^^^^^^^
   `.trim(),
   )
 })


### PR DESCRIPTION
This PR builds on the refactored language server from #209 to support go-to-definition and find-references on table and column references in the language server. It also fixes a bug where we were not analyzing column references in join conditions (e.g. `graphene check` would not flag references to columns that don't exist in the model)