### PR TITLE
Add .claude to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ vscode/*.vsix
 vscode/LICENSE.md
 
 CLAUDE.md
+.claude
 .env


### PR DESCRIPTION
## Summary
- Adds `.claude` directory to `.gitignore` to prevent Claude Code project files from being committed

## Test plan
- N/A — gitignore change only