### PR TITLE
Exploration vs. dashboard layouts

### DIFF
--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -74,6 +74,7 @@ export function sanitizeMarkdown() {
         allowedTags: [...sanitizeHtml.defaults.allowedTags, ...componentNames()],
         allowedAttributes: {
           ...sanitizeHtml.defaults.allowedAttributes,
+          '*': [...(sanitizeHtml.defaults.allowedAttributes['*'] || []), 'data-raw'],
           ...Object.fromEntries(componentNames().map(n => [n, ['*']])),
         },
         parser: {
@@ -116,5 +117,17 @@ export function componentNames() {
   return cachedComponentNames || []
 }
 
-export const remarkPlugins: Array<Plugin> = [extractQueries, escapeAngles, mergeAdjacentHtml]
+// Adds data-raw to standard HTML block elements written directly in markdown (not generated from
+// markdown syntax). CSS uses this to give raw HTML elements dashboard-width alignment, while
+// markdown-generated elements stay in the narrow prose column.
+export function markRawHtmlBlocks() {
+  let blockTags = /^<(h[1-6]|p|ul|ol|blockquote|pre|hr|table)([\s>\/])/gmi
+  return function transformer(tree: any) {
+    visit(tree, 'html', (node: any) => {
+      node.value = node.value.replace(blockTags, '<$1 data-raw$2')
+    })
+  }
+}
+
+export const remarkPlugins: Array<Plugin> = [extractQueries, escapeAngles, mergeAdjacentHtml, markRawHtmlBlocks]
 export const rehypePlugins: Array<Plugin> = [sanitizeMarkdown]

--- a/ui/app.css
+++ b/ui/app.css
@@ -139,8 +139,26 @@ nav {
 main {
   flex: 1;
   min-width: 0;
+  max-width: 1200px;
+  margin: 0 auto;
   padding: 20px 48px 80px;
+  display: grid;
+  grid-template-columns: 1fr min(660px, 100%) 1fr;
 }
+
+/* Prose and standalone charts sit in the centered 660px column */
+main > * { grid-column: 2; }
+
+/* Row containers, high-cardinality standalone charts, and raw HTML block elements span full width */
+main > .row,
+main > [data-chart-size="large"],
+main > [data-raw] { grid-column: 1 / -1; }
+
+/* Low-cardinality charts are narrower than the prose column, centered */
+main > [data-chart-size="small"] { justify-self: center; width: min(480px, 100%); }
+
+/* Standalone tables use their natural column width, not the full grid cell */
+main > .table-container { justify-self: center; }
 
 /* Default border color */
 *,

--- a/ui/components/Chart.svelte
+++ b/ui/components/Chart.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {setContext, type Snippet} from 'svelte'
+  import {setContext, getContext, type Snippet} from 'svelte'
   import {type Writable, writable, get} from 'svelte/store'
   import {propKey, configKey} from '../component-utilities/chartContext.js'
   import ECharts from './ECharts.svelte'
@@ -516,7 +516,7 @@
           throw Error('chartAreaHeight must be a positive number')
         }
       } else {
-        chartAreaHeightLocal = 220
+        chartAreaHeightLocal = chartSize === 'large' ? 360 : chartSize === 'medium' ? 280 : 220
       }
 
       // Compute yType locally
@@ -971,6 +971,12 @@
       })
     }
   })
+
+  // Drive standalone chart sizing from x-axis cardinality. Inside a <Row> or <Column>, the
+  // container controls sizing so we pass 'medium' (no height scaling, no width CSS override).
+  const insideContainer = getContext('insideContainer')
+  let xCardinality = $derived(Array.isArray(data) && x ? getDistinctCount(data, x) : null)
+  let chartSize = $derived(insideContainer || xCardinality == null ? 'medium' : xCardinality < 10 ? 'small' : xCardinality < 80 ? 'medium' : 'large')
 </script>
 
 {#if !$chartProps.error}
@@ -989,6 +995,7 @@
     showAllXAxisLabels={showAllXAxisLabelsResolved}
     swapXY={swapXY_bool}
     seriesColors={$seriesColorsResolved}
+    {chartSize}
   />
 {:else}
   <div style="min-height:200px;width:100%;display:grid;align-content:center;padding:8px;box-sizing:border-box">

--- a/ui/components/ECharts.svelte
+++ b/ui/components/ECharts.svelte
@@ -17,6 +17,7 @@
     showAllXAxisLabels?: boolean
     swapXY?: boolean
     chartTitle?: string
+    chartSize?: 'small' | 'medium' | 'large'
     onclick?: (params: any) => void
   }
 
@@ -26,7 +27,7 @@
     config, height = '240px', width = '100%', data, queryID = undefined, renderer = undefined,
     echartsOptions = undefined, seriesOptions = undefined, seriesColors = undefined,
     connectGroup = undefined, xAxisLabelOverflow = undefined, showAllXAxisLabels = undefined,
-    swapXY = undefined, chartTitle = undefined, onclick = undefined,
+    swapXY = undefined, chartTitle = undefined, chartSize = undefined, onclick = undefined,
   }: Props = $props()
 
   const isBrowser = typeof window !== 'undefined'
@@ -38,7 +39,7 @@
   }
 </script>
 
-<div class="echarts-container">
+<div class="echarts-container" data-chart-size={chartSize}>
   {#if !isBrowser}
     <div class="echarts-loading" style={`height:${toDimension(height, '240px')}`}>Loading…</div>
   {:else}

--- a/ui/components/Row.svelte
+++ b/ui/components/Row.svelte
@@ -1,4 +1,9 @@
-<div><slot></slot></div>
+<script>
+  import {setContext} from 'svelte'
+  setContext('insideContainer', true)
+</script>
+
+<div class="row"><slot></slot></div>
 
 <style>
   div {


### PR DESCRIPTION
To discuss: An implementation of the proposal "[A Tale of Two Dashboards](https://docs.google.com/document/d/1Pavv2rdLSqmszCQfgEfvBB0t144Lx7hrN2Gk0QmsM34/edit?tab=t.0)"

tl;dr:
- Markdown content and "standalone" charts (not inside `<Row>`) have much more aggressive margins to optimize for readability and linear narratives ("exploration" use case)
- Standalone charts dynamically resize based on the cardinality of the x-axis (small, medium, large breakpoints)
- Content wrapped in `<Row>` spans full width to 1200px ("dashboard" use case)
- If users wants headers and other text content at the 1200px dashboard alignment, use `<h2>`, `<p>`, `<ul>`, etc.

<img width="1281" height="2633" alt="tale-of-2-dashboards-screenshot" src="https://github.com/user-attachments/assets/da274d85-85f3-4d98-b831-3d16aad1a6e5" />

Changes:
- Set 1200px max-width on main content area
- Switch main to CSS grid with centered 660px prose column for markdown content
- Raw HTML block elements (h2, p, ul, etc.) span full dashboard width via data-raw attribute stamped by a new remark plugin (markRawHtmlBlocks)
- Standalone charts scale width and height based on x-axis cardinality: small (<10 pts) → 480px centered, medium → 660px, large (80+ pts) → full width
- Cardinality sizing is suppressed inside Row/Column containers via Svelte context
- Standalone tables use natural fit-content width, centered
- Row sets insideContainer context so charts inside don't auto-scale height