### PR TITLE
fix multi-select bug

### DIFF
--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -362,7 +362,9 @@
   }
 
   function updateInputPayload(values: any[]) {
-    let paramValue = values.length ? values[0] : null
+    let paramValue = null
+    if (multi) paramValue = values.length ? [...values] : null
+    else paramValue = values.length ? values[0] : null
     window.$GRAPHENE.updateParam(name, paramValue)
   }
 

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -97,6 +97,7 @@ test('dropdown multi-select supports select-all and clear', async ({server, page
   await page.getByRole('button', {name: 'Select all'}).click()
   await expect(trigger).toContainText('selected')
   await expect(menu.locator('.dropdown-option.is-selected')).toHaveCount(optionLabels.length)
+  expect(await lastParamUpdate(page, 'carrier_multi')).toEqual({name: 'carrier_multi', value: optionLabels})
   await lockOpenDropdownWidth(page)
   await expect(menu).screenshot('dropdown-multi-select-all')
 


### PR DESCRIPTION
This PR fixes a bug where we were not updating params with all multi-select Dropdown selections, only the first one. I verified things seem to work downstream of this - for example I updated the `delays.md` example to multi-select `carrier`, and updated all the queries to do `where carrier in  ($carrier)` instead of `where carrier = $carrier` and the queries work.