### PR TITLE
sync inputs with url

### DIFF
--- a/cli/esbuild.mjs
+++ b/cli/esbuild.mjs
@@ -1,4 +1,4 @@
-import {build} from 'esbuild'
+import {build, transform} from 'esbuild'
 import {cp, mkdir, readdir, readFile, rm, writeFile} from 'node:fs/promises'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
@@ -52,7 +52,45 @@ ${(await readdir(path.resolve(__dirname, '../docs/references'))).map(f => `- ref
 )
 await cp(path.resolve(__dirname, '../docs/references'), path.resolve(skillDir, 'references'), {recursive: true})
 await cp(path.resolve(__dirname, '../ui'), path.resolve(__dirname, 'dist/ui'), {recursive: true})
+await transpileSvelteModules(path.resolve(__dirname, 'dist/ui'))
 await rm(path.resolve(__dirname, 'dist/ui/node_modules'), {recursive: true, force: true})
 await rm(path.resolve(__dirname, 'dist/ui/package.json'))
 await rm(path.resolve(__dirname, 'dist/ui/tests'), {recursive: true, force: true})
 await rm(path.resolve(__dirname, 'dist/cli/cli.js.map'))
+
+async function transpileSvelteModules(root) {
+  let files = await collectFiles(root)
+  let svelteModuleFiles = files.filter(file => file.endsWith('.svelte.ts'))
+
+  await Promise.all(
+    files.map(async file => {
+      let contents = await readFile(file, 'utf8')
+      if (!contents.includes('.svelte.ts')) return
+      await writeFile(file, contents.replaceAll('.svelte.ts', '.svelte.js'))
+    }),
+  )
+
+  await Promise.all(
+    svelteModuleFiles.map(async file => {
+      let contents = await readFile(file, 'utf8')
+      let output = await transform(contents, {
+        loader: 'ts',
+        format: 'esm',
+        target: 'es2022',
+      })
+      await writeFile(file.replace(/\.ts$/, '.js'), output.code)
+      await rm(file)
+    }),
+  )
+}
+
+async function collectFiles(root) {
+  let entries = await readdir(root, {withFileTypes: true})
+  let files = []
+  for (let entry of entries) {
+    let fullPath = path.join(root, entry.name)
+    if (entry.isDirectory()) files.push(...(await collectFiles(fullPath)))
+    else if (entry.isFile()) files.push(fullPath)
+  }
+  return files
+}

--- a/docs/base.md
+++ b/docs/base.md
@@ -106,6 +106,8 @@ Queries can be referenced by other queries in the `from` or `join` to form DAGs 
 ## Tying input components to SQL
 Inject input values into queries by referring to their `name` attribute as $name. 
 
+Input values also sync into the page URL query string, so reloads and shared links preserve the same dashboard state.
+
 ````md
 <Dropdown name=status .../>
 ```sql my_query

--- a/docs/references/dropdown.md
+++ b/docs/references/dropdown.md
@@ -24,6 +24,8 @@ from orders
 where status = $status_dropdown
 ```
 
+Dropdown selections also sync into the page URL query string. Single-select dropdowns use one key, and multi-select dropdowns repeat the key for each selected value.
+
 # Attributes
 
 | Attribute | Description | Required | Options | Default |
@@ -31,7 +33,7 @@ where status = $status_dropdown
 | name | Name of the dropdown, used to reference the selected value elsewhere as `"$name"` | true | - | - |
 | data | GSQL query or table name | false | query name | - |
 | value | Column name from the query containing values to pick from | false | column name | - |
-| multiple | Enables multi-select which returns a list | false | `true`, `false` | `false` |
+| multiple | Enables multi-select which returns a list and syncs repeated values into the URL query string | false | `true`, `false` | `false` |
 | defaultValue | Value to use when the dropdown is first loaded. Must be one of the options in the dropdown. Lists supported for multi-select. | false | value from dropdown, list of values e.g. `"Value 1, Value 2"` | - |
 | selectAllByDefault | Selects and returns all values, multiple attribute required | false | `true`, `false` | `false` |
 | noDefault | Stops any default from being selected. Overrides any set `defaultValue`. | false | boolean | `false` |

--- a/docs/references/text-input.md
+++ b/docs/references/text-input.md
@@ -17,6 +17,8 @@ from users
 where email ilike concat('%', $name_of_input, '%')
 ```
 
+Text input values also sync into the page URL query string so a reload or shared link preserves the same filter state.
+
 # Attributes
 
 | Attribute | Description | Required | Options | Default |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,22 @@ export default [
     },
   },
   {
+    files: ['**/*.svelte.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+      globals: {
+        ...globals.browser,
+      },
+    },
+    rules: {
+      'svelte/prefer-svelte-reactivity': 'off',
+    },
+  },
+  {
     files: ['**/*.svelte'],
     languageOptions: {
       parserOptions: {

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {onMount} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
-  import {getPageInputs, initOnce} from '../internal/pageInputs.svelte.ts'
+  import {captureInitial, getPageInputs} from '../internal/pageInputs.svelte.ts'
 
   interface Props {
     name: string
@@ -29,7 +29,7 @@
   let queryKey = ''
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
   let pageInputs = getPageInputs()
-  let field = initOnce(() => pageInputs.dateRange(name))
+  let field = captureInitial(() => pageInputs.dateRange(name))
 
   let domainStart: string | null = $state(null)
   let domainEnd: string | null = $state(null)

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -49,10 +49,10 @@
 
   onMount(() => {
     mounted = true
-    currentStart = field.controlled ? field.value.start : normalizeInput(start)
-    currentEnd = field.controlled ? field.value.end : normalizeInput(end)
+    currentStart = field.hasExternalValue ? field.value.start : normalizeInput(start)
+    currentEnd = field.hasExternalValue ? field.value.end : normalizeInput(end)
     currentPreset = inferPreset(currentStart, currentEnd)
-    if (field.controlled) updateParams()
+    if (field.hasExternalValue) updateParams()
     else if (defaultValue && presetList.includes(defaultValue)) applyPreset(defaultValue, false)
     else updateParams()
     refreshQuery()
@@ -73,7 +73,7 @@
   $effect(() => {
     if (currentStart === field.value.start && currentEnd === field.value.end) return
     if (!mounted) return
-    setRange(field.value.start, field.value.end, inferPreset(field.value.start, field.value.end), {syncParam: false})
+    setRange(field.value.start, field.value.end, inferPreset(field.value.start, field.value.end), {persist: false})
   })
 
   function refreshQuery() {
@@ -95,7 +95,7 @@
       values.sort()
       domainStart = values[0]
       domainEnd = values[values.length - 1]
-      if (field.controlled) {
+      if (field.hasExternalValue) {
         currentPreset = inferPreset(currentStart, currentEnd)
       } else if (!touched) {
         if (defaultValue && presetList.includes(defaultValue)) {
@@ -103,7 +103,7 @@
         } else {
           let startCandidate = currentStart ?? domainStart
           let endCandidate = currentEnd ?? (domainEnd ? addDaysString(domainEnd, 1) : null)
-          setRange(startCandidate, endCandidate, currentPreset, {markTouched: false, syncParam: true})
+          setRange(startCandidate, endCandidate, currentPreset, {markTouched: false, persist: true})
         }
       }
     }
@@ -182,12 +182,12 @@
     return ''
   }
 
-  function setRange(startValue: string | null, endValue: string | null, preset: string, {markTouched = false, syncParam = true}: {markTouched?: boolean; syncParam?: boolean} = {}) {
+  function setRange(startValue: string | null, endValue: string | null, preset: string, {markTouched = false, persist = true}: {markTouched?: boolean; persist?: boolean} = {}) {
     currentStart = startValue
     currentEnd = endValue
     currentPreset = preset
     if (markTouched) touched = true
-    if (syncParam) updateParams()
+    if (persist) updateParams()
   }
 
   function updateParams() {
@@ -196,12 +196,12 @@
 
   function onStartChange(event: Event) {
     let value = (event.currentTarget as HTMLInputElement).value || null
-    setRange(value, currentEnd, '', {markTouched: true, syncParam: true})
+    setRange(value, currentEnd, '', {markTouched: true, persist: true})
   }
 
   function onEndChange(event: Event) {
     let value = (event.currentTarget as HTMLInputElement).value || null
-    setRange(currentStart, value, '', {markTouched: true, syncParam: true})
+    setRange(currentStart, value, '', {markTouched: true, persist: true})
   }
 
   function applyPreset(preset: string, markTouched = true) {
@@ -215,7 +215,7 @@
     if (!range) return
     let startVal = range.start ? formatDate(range.start) : null
     let endVal = range.end ? formatDate(range.end) : null
-    setRange(startVal, endVal, preset, {markTouched, syncParam: true})
+    setRange(startVal, endVal, preset, {markTouched, persist: true})
   }
 
   function computePresetRange(preset: string, baseEndInclusive: Date): {start: Date | null; end: Date | null} | null {

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {onMount} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
+  import {usePageInputs} from '../internal/pageInputs.svelte.ts'
 
   interface Props {
     name: string
@@ -27,6 +28,11 @@
   let mounted = false
   let queryKey = ''
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
+  let pageInputs = usePageInputs()
+  function createField() {
+    return pageInputs.dateRange(name)
+  }
+  let field = createField()
 
   let domainStart: string | null = $state(null)
   let domainEnd: string | null = $state(null)
@@ -34,7 +40,6 @@
   let currentStart: string | null = $state(null)
   let currentEnd: string | null = $state(null)
   let currentPreset: string = $state('')
-  let hasExternalRange = false
   let touched = false
 
   let hidePrint = $derived(toBoolean(hideDuringPrint))
@@ -47,25 +52,16 @@
 
   onMount(() => {
     mounted = true
-    let startKey = `${name}_start`
-    let endKey = `${name}_end`
-    let externalStart = readParamValue(window.$GRAPHENE?.getParam?.(startKey))
-    let externalEnd = readParamValue(window.$GRAPHENE?.getParam?.(endKey))
-    hasExternalRange = externalStart !== undefined || externalEnd !== undefined
-    currentStart = externalStart === undefined ? normalizeInput(start) : externalStart
-    currentEnd = externalEnd === undefined ? normalizeInput(end) : externalEnd
+    currentStart = field.controlled ? field.value.start : normalizeInput(start)
+    currentEnd = field.controlled ? field.value.end : normalizeInput(end)
     currentPreset = inferPreset(currentStart, currentEnd)
-    if (hasExternalRange) updateParams()
+    if (field.controlled) updateParams()
     else if (defaultValue && presetList.includes(defaultValue)) applyPreset(defaultValue, false)
     else updateParams()
     refreshQuery()
-    let unsubscribeParams = window.$GRAPHENE?.subscribeParams?.((params, event: {changed: Set<string>}) => {
-      if (!event.changed.has(startKey) && !event.changed.has(endKey)) return
-      applyExternalRange(params[startKey], params[endKey])
-    })
     return () => {
       mounted = false
-      unsubscribeParams?.()
+      field.destroy()
       if (queryHandler) {
         window.$GRAPHENE?.unsubscribe?.(queryHandler)
         queryHandler = null
@@ -75,6 +71,12 @@
 
   $effect(() => {
     refreshQuery()
+  })
+
+  $effect(() => {
+    if (currentStart === field.value.start && currentEnd === field.value.end) return
+    if (!mounted) return
+    setRange(field.value.start, field.value.end, inferPreset(field.value.start, field.value.end), {syncParam: false})
   })
 
   function refreshQuery() {
@@ -96,7 +98,7 @@
       values.sort()
       domainStart = values[0]
       domainEnd = values[values.length - 1]
-      if (hasExternalRange) {
+      if (field.controlled) {
         currentPreset = inferPreset(currentStart, currentEnd)
       } else if (!touched) {
         if (defaultValue && presetList.includes(defaultValue)) {
@@ -161,13 +163,6 @@
     return copy
   }
 
-  function readParamValue(rawValue: unknown): string | null | undefined {
-    if (rawValue === undefined) return undefined
-    if (rawValue === null) return null
-    if (Array.isArray(rawValue)) return normalizeInput(rawValue[0] as string | Date | null | undefined)
-    return normalizeInput(rawValue as string | Date | null | undefined)
-  }
-
   function inferPreset(startValue: string | null, endValue: string | null): string {
     if (!startValue && !endValue) return ''
     let baseEnd = (() => {
@@ -197,18 +192,7 @@
   }
 
   function updateParams() {
-    window.$GRAPHENE.updateParams({
-      [`${name}_start`]: currentStart,
-      [`${name}_end`]: currentEnd,
-    })
-  }
-
-  function applyExternalRange(startRaw: unknown, endRaw: unknown) {
-    if (!mounted) return
-    hasExternalRange = true
-    let nextStart = readParamValue(startRaw)
-    let nextEnd = readParamValue(endRaw)
-    setRange(nextStart ?? null, nextEnd ?? null, inferPreset(nextStart ?? null, nextEnd ?? null), {syncParam: false})
+    field.set({start: currentStart, end: currentEnd})
   }
 
   function onStartChange(event: Event) {

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -36,7 +36,7 @@
 
   let currentStart: string | null = $state(null)
   let currentEnd: string | null = $state(null)
-  let currentPreset: string = $state('')
+  let currentPreset: string | null = $state(null)
   let touched = false
 
   let hidePrint = $derived(toBoolean(hideDuringPrint))
@@ -162,8 +162,8 @@
 
   // We only persist start/end in URL state, so the preset label is inferred by matching
   // the current range against the configured preset definitions.
-  function inferPreset(startValue: string | null, endValue: string | null): string {
-    if (!startValue && !endValue) return ''
+  function inferPreset(startValue: string | null, endValue: string | null): string | null {
+    if (!startValue && !endValue) return null
     let baseEnd = (() => {
       if (endValue) {
         let parsed = new Date(endValue)
@@ -172,17 +172,17 @@
       if (domainEnd) return new Date(domainEnd)
       return new Date()
     })()
-    if (Number.isNaN(baseEnd.getTime())) return ''
+    if (Number.isNaN(baseEnd.getTime())) return null
     for (let preset of presetList) {
       let range = computePresetRange(preset, baseEnd)
       let presetStart = range?.start ? formatDate(range.start) : null
       let presetEnd = range?.end ? formatDate(range.end) : null
       if (presetStart === startValue && presetEnd === endValue) return preset
     }
-    return ''
+    return null
   }
 
-  function setRange(startValue: string | null, endValue: string | null, preset: string, {markTouched = false, persist = true}: {markTouched?: boolean; persist?: boolean} = {}) {
+  function setRange(startValue: string | null, endValue: string | null, preset: string | null, {markTouched = false, persist = true}: {markTouched?: boolean; persist?: boolean} = {}) {
     currentStart = startValue
     currentEnd = endValue
     currentPreset = preset
@@ -196,12 +196,12 @@
 
   function onStartChange(event: Event) {
     let value = (event.currentTarget as HTMLInputElement).value || null
-    setRange(value, currentEnd, '', {markTouched: true, persist: true})
+    setRange(value, currentEnd, null, {markTouched: true, persist: true})
   }
 
   function onEndChange(event: Event) {
     let value = (event.currentTarget as HTMLInputElement).value || null
-    setRange(currentStart, value, '', {markTouched: true, persist: true})
+    setRange(currentStart, value, null, {markTouched: true, persist: true})
   }
 
   function applyPreset(preset: string, markTouched = true) {
@@ -289,7 +289,7 @@
   function onPresetChange(event: Event) {
     let value = (event.currentTarget as HTMLSelectElement).value
     if (!value) {
-      currentPreset = ''
+      currentPreset = null
       touched = true
       return
     }

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -160,6 +160,8 @@
     return copy
   }
 
+  // We only persist start/end in URL state, so the preset label is inferred by matching
+  // the current range against the configured preset definitions.
   function inferPreset(startValue: string | null, endValue: string | null): string {
     if (!startValue && !endValue) return ''
     let baseEnd = (() => {

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {onMount} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
-  import {usePageInputs} from '../internal/pageInputs.svelte.ts'
+  import {getPageInputs} from '../internal/pageInputs.svelte.ts'
 
   interface Props {
     name: string
@@ -28,7 +28,7 @@
   let mounted = false
   let queryKey = ''
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
-  let pageInputs = usePageInputs()
+  let pageInputs = getPageInputs()
   function createField() {
     return pageInputs.dateRange(name)
   }

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {onMount} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
-  import {getPageInputs} from '../internal/pageInputs.svelte.ts'
+  import {getPageInputs, initOnce} from '../internal/pageInputs.svelte.ts'
 
   interface Props {
     name: string
@@ -29,10 +29,7 @@
   let queryKey = ''
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
   let pageInputs = getPageInputs()
-  function createField() {
-    return pageInputs.dateRange(name)
-  }
-  let field = createField()
+  let field = initOnce(() => pageInputs.dateRange(name))
 
   let domainStart: string | null = $state(null)
   let domainEnd: string | null = $state(null)

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -34,6 +34,7 @@
   let currentStart: string | null = $state(null)
   let currentEnd: string | null = $state(null)
   let currentPreset: string = $state('')
+  let hasExternalRange = false
   let touched = false
 
   let hidePrint = $derived(toBoolean(hideDuringPrint))
@@ -46,16 +47,25 @@
 
   onMount(() => {
     mounted = true
-    currentStart = normalizeInput(start)
-    currentEnd = normalizeInput(end)
-    if (defaultValue && presetList.includes(defaultValue)) {
-      applyPreset(defaultValue, false)
-    } else {
-      updateParams()
-    }
+    let startKey = `${name}_start`
+    let endKey = `${name}_end`
+    let externalStart = readParamValue(window.$GRAPHENE?.getParam?.(startKey))
+    let externalEnd = readParamValue(window.$GRAPHENE?.getParam?.(endKey))
+    hasExternalRange = externalStart !== undefined || externalEnd !== undefined
+    currentStart = externalStart === undefined ? normalizeInput(start) : externalStart
+    currentEnd = externalEnd === undefined ? normalizeInput(end) : externalEnd
+    currentPreset = inferPreset(currentStart, currentEnd)
+    if (hasExternalRange) updateParams()
+    else if (defaultValue && presetList.includes(defaultValue)) applyPreset(defaultValue, false)
+    else updateParams()
     refreshQuery()
+    let unsubscribeParams = window.$GRAPHENE?.subscribeParams?.((params, event: {changed: Set<string>}) => {
+      if (!event.changed.has(startKey) && !event.changed.has(endKey)) return
+      applyExternalRange(params[startKey], params[endKey])
+    })
     return () => {
       mounted = false
+      unsubscribeParams?.()
       if (queryHandler) {
         window.$GRAPHENE?.unsubscribe?.(queryHandler)
         queryHandler = null
@@ -86,13 +96,15 @@
       values.sort()
       domainStart = values[0]
       domainEnd = values[values.length - 1]
-      if (!touched) {
+      if (hasExternalRange) {
+        currentPreset = inferPreset(currentStart, currentEnd)
+      } else if (!touched) {
         if (defaultValue && presetList.includes(defaultValue)) {
           applyPreset(defaultValue, false)
         } else {
           let startCandidate = currentStart ?? domainStart
           let endCandidate = currentEnd ?? (domainEnd ? addDaysString(domainEnd, 1) : null)
-          setRange(startCandidate, endCandidate, currentPreset, false)
+          setRange(startCandidate, endCandidate, currentPreset, {markTouched: false, syncParam: true})
         }
       }
     }
@@ -149,27 +161,64 @@
     return copy
   }
 
-  function setRange(startValue: string | null, endValue: string | null, preset: string, markTouched: boolean) {
+  function readParamValue(rawValue: unknown): string | null | undefined {
+    if (rawValue === undefined) return undefined
+    if (rawValue === null) return null
+    if (Array.isArray(rawValue)) return normalizeInput(rawValue[0] as string | Date | null | undefined)
+    return normalizeInput(rawValue as string | Date | null | undefined)
+  }
+
+  function inferPreset(startValue: string | null, endValue: string | null): string {
+    if (!startValue && !endValue) return ''
+    let baseEnd = (() => {
+      if (endValue) {
+        let parsed = new Date(endValue)
+        if (!Number.isNaN(parsed.getTime())) return addDays(parsed, -1)
+      }
+      if (domainEnd) return new Date(domainEnd)
+      return new Date()
+    })()
+    if (Number.isNaN(baseEnd.getTime())) return ''
+    for (let preset of presetList) {
+      let range = computePresetRange(preset, baseEnd)
+      let presetStart = range?.start ? formatDate(range.start) : null
+      let presetEnd = range?.end ? formatDate(range.end) : null
+      if (presetStart === startValue && presetEnd === endValue) return preset
+    }
+    return ''
+  }
+
+  function setRange(startValue: string | null, endValue: string | null, preset: string, {markTouched = false, syncParam = true}: {markTouched?: boolean; syncParam?: boolean} = {}) {
     currentStart = startValue
     currentEnd = endValue
     currentPreset = preset
     if (markTouched) touched = true
-    updateParams()
+    if (syncParam) updateParams()
   }
 
   function updateParams() {
-    window.$GRAPHENE.updateParam(`${name}_start`, currentStart)
-    window.$GRAPHENE.updateParam(`${name}_end`, currentEnd)
+    window.$GRAPHENE.updateParams({
+      [`${name}_start`]: currentStart,
+      [`${name}_end`]: currentEnd,
+    })
+  }
+
+  function applyExternalRange(startRaw: unknown, endRaw: unknown) {
+    if (!mounted) return
+    hasExternalRange = true
+    let nextStart = readParamValue(startRaw)
+    let nextEnd = readParamValue(endRaw)
+    setRange(nextStart ?? null, nextEnd ?? null, inferPreset(nextStart ?? null, nextEnd ?? null), {syncParam: false})
   }
 
   function onStartChange(event: Event) {
     let value = (event.currentTarget as HTMLInputElement).value || null
-    setRange(value, currentEnd, '', true)
+    setRange(value, currentEnd, '', {markTouched: true, syncParam: true})
   }
 
   function onEndChange(event: Event) {
     let value = (event.currentTarget as HTMLInputElement).value || null
-    setRange(currentStart, value, '', true)
+    setRange(currentStart, value, '', {markTouched: true, syncParam: true})
   }
 
   function applyPreset(preset: string, markTouched = true) {
@@ -183,7 +232,7 @@
     if (!range) return
     let startVal = range.start ? formatDate(range.start) : null
     let endVal = range.end ? formatDate(range.end) : null
-    setRange(startVal, endVal, preset, markTouched)
+    setRange(startVal, endVal, preset, {markTouched, syncParam: true})
   }
 
   function computePresetRange(preset: string, baseEndInclusive: Date): {start: Date | null; end: Date | null} | null {

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -39,6 +39,7 @@
   let queryOptions: Option[] = $state([])
   let manualOptions: Option[] = $state([])
   let selection: any[] = $state([])
+  let hasExternalSelection = false
   let touched = false
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
   let queryKey = ''
@@ -273,12 +274,12 @@
       let exists = selection.some(val => optionKey(val) === key)
       if (exists) {
         let next = selection.filter(val => optionKey(val) !== key)
-        setSelection(next, true)
+        setSelection(next, {fromUser: true, syncParam: true})
       } else {
-        setSelection([...selection, opt.value], true)
+        setSelection([...selection, opt.value], {fromUser: true, syncParam: true})
       }
     } else {
-      setSelection([opt.value], true)
+      setSelection([opt.value], {fromUser: true, syncParam: true})
       closeMenu(fromKeyboard)
     }
   }
@@ -295,16 +296,25 @@
 
   onMount(() => {
     mounted = true
-    let defaults = ensureArray(defaultValue)
-    if (!hasNoDefault && defaults.length) setSelection(defaults, false)
+    let externalValue = window.$GRAPHENE?.getParam?.(name)
+    if (externalValue !== undefined) applyExternalSelection(externalValue)
+    else {
+      let defaults = ensureArray(defaultValue)
+      if (!hasNoDefault && defaults.length) setSelection(defaults, {syncParam: true})
+    }
     syncSelection(false)
     setupQuery()
+    let unsubscribeParams = window.$GRAPHENE?.subscribeParams?.((params, event: {changed: Set<string>}) => {
+      if (!event.changed.has(name)) return
+      applyExternalSelection(params[name])
+    })
     if (typeof document !== 'undefined') {
       document.addEventListener('pointerdown', handlePointerDown)
       window.addEventListener('resize', updateTriggerWidth)
     }
     return () => {
       mounted = false
+      unsubscribeParams?.()
       if (queryHandler) {
         window.$GRAPHENE?.unsubscribe?.(queryHandler)
         queryHandler = null
@@ -329,13 +339,15 @@
   function syncSelection(fromUser: boolean) {
     let opts = availableOptions
     if (!opts.length) {
-      if (selection.length) updateInputPayload(selection)
+      updateInputPayload(selection)
       return
     }
     let nextSelection = selection.filter(val => valueMap.has(optionKey(val)))
     if (!fromUser) {
       let defaults = ensureArray(defaultValue)
-      if (multi && selectAllDefault) {
+      if (hasExternalSelection) {
+        nextSelection = nextSelection
+      } else if (multi && selectAllDefault) {
         nextSelection = opts.map(o => o.value)
       } else if (!touched) {
         if (defaults.length && !hasNoDefault) {
@@ -345,20 +357,28 @@
         }
       }
     }
-    setSelection(nextSelection, fromUser)
+    setSelection(nextSelection, {fromUser, syncParam: true})
   }
 
-  function setSelection(values: any[], fromUser: boolean) {
+  function setSelection(values: any[], {fromUser = false, syncParam = true}: {fromUser?: boolean; syncParam?: boolean} = {}) {
     let keys = values.map(optionKey)
     let existingKeys = selection.map(optionKey)
     let changed = keys.length !== existingKeys.length || keys.some((k, idx) => k !== existingKeys[idx])
     if (!changed) {
-      if (!fromUser) updateInputPayload(selection)
+      if (syncParam && !fromUser) updateInputPayload(selection)
       return
     }
     selection = values
     if (fromUser) touched = true
-    updateInputPayload(selection)
+    if (syncParam) updateInputPayload(selection)
+  }
+
+  function applyExternalSelection(rawValue: unknown) {
+    if (!mounted) return
+    hasExternalSelection = true
+    let values = rawValue === undefined || rawValue === null ? [] : ensureArray(rawValue)
+    if (!multi && values.length > 1) values = values.slice(0, 1)
+    setSelection(values, {syncParam: false})
   }
 
   function updateInputPayload(values: any[]) {
@@ -370,11 +390,11 @@
 
   function selectAll() {
     if (!multi) return
-    setSelection(availableOptions.map(opt => opt.value), true)
+    setSelection(availableOptions.map(opt => opt.value), {fromUser: true, syncParam: true})
   }
 
   function clearSelection() {
-    setSelection([], true)
+    setSelection([], {fromUser: true, syncParam: true})
   }
 
   let elementId = $derived(`dropdown-${name}`)

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -2,7 +2,7 @@
   import {onMount, setContext, tick, type Snippet} from 'svelte'
   import {DROPDOWN_CONTEXT} from '../component-utilities/dropdownContext'
   import {ensureArray, toBoolean} from '../component-utilities/inputUtils'
-  import {getPageInputs, initOnce} from '../internal/pageInputs.svelte.ts'
+  import {captureInitial, getPageInputs} from '../internal/pageInputs.svelte.ts'
 
   interface Option {
     value: any
@@ -44,7 +44,7 @@
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
   let queryKey = ''
   let pageInputs = getPageInputs()
-  let field = initOnce(() => pageInputs.dropdown(name, toBoolean(multiple)))
+  let field = captureInitial(() => pageInputs.dropdown(name, toBoolean(multiple)))
 
   let isOpen = $state(false)
   let searchTerm = $state('')

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -2,6 +2,7 @@
   import {onMount, setContext, tick, type Snippet} from 'svelte'
   import {DROPDOWN_CONTEXT} from '../component-utilities/dropdownContext'
   import {ensureArray, toBoolean} from '../component-utilities/inputUtils'
+  import {usePageInputs} from '../internal/pageInputs.svelte.ts'
 
   interface Option {
     value: any
@@ -39,10 +40,14 @@
   let queryOptions: Option[] = $state([])
   let manualOptions: Option[] = $state([])
   let selection: any[] = $state([])
-  let hasExternalSelection = false
   let touched = false
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
   let queryKey = ''
+  let pageInputs = usePageInputs()
+  function createField() {
+    return pageInputs.dropdown(name, toBoolean(multiple))
+  }
+  let field = createField()
 
   let isOpen = $state(false)
   let searchTerm = $state('')
@@ -103,6 +108,11 @@
 
   $effect(() => {
     if (isOpen) activeIndex = ensureActiveIndex(activeIndex, filteredOptions)
+  })
+
+  $effect(() => {
+    if (sameSelection(selection, field.value)) return
+    setSelection(field.value, {syncParam: false})
   })
 
   function setupQuery() {
@@ -296,25 +306,20 @@
 
   onMount(() => {
     mounted = true
-    let externalValue = window.$GRAPHENE?.getParam?.(name)
-    if (externalValue !== undefined) applyExternalSelection(externalValue)
+    if (field.controlled) setSelection(field.value, {syncParam: false})
     else {
       let defaults = ensureArray(defaultValue)
       if (!hasNoDefault && defaults.length) setSelection(defaults, {syncParam: true})
     }
     syncSelection(false)
     setupQuery()
-    let unsubscribeParams = window.$GRAPHENE?.subscribeParams?.((params, event: {changed: Set<string>}) => {
-      if (!event.changed.has(name)) return
-      applyExternalSelection(params[name])
-    })
     if (typeof document !== 'undefined') {
       document.addEventListener('pointerdown', handlePointerDown)
       window.addEventListener('resize', updateTriggerWidth)
     }
     return () => {
       mounted = false
-      unsubscribeParams?.()
+      field.destroy()
       if (queryHandler) {
         window.$GRAPHENE?.unsubscribe?.(queryHandler)
         queryHandler = null
@@ -345,7 +350,7 @@
     let nextSelection = selection.filter(val => valueMap.has(optionKey(val)))
     if (!fromUser) {
       let defaults = ensureArray(defaultValue)
-      if (hasExternalSelection) {
+      if (field.controlled) {
         nextSelection = nextSelection
       } else if (multi && selectAllDefault) {
         nextSelection = opts.map(o => o.value)
@@ -360,11 +365,14 @@
     setSelection(nextSelection, {fromUser, syncParam: true})
   }
 
+  function sameSelection(left: any[], right: any[]) {
+    let leftKeys = left.map(optionKey)
+    let rightKeys = right.map(optionKey)
+    return leftKeys.length === rightKeys.length && leftKeys.every((key, index) => key === rightKeys[index])
+  }
+
   function setSelection(values: any[], {fromUser = false, syncParam = true}: {fromUser?: boolean; syncParam?: boolean} = {}) {
-    let keys = values.map(optionKey)
-    let existingKeys = selection.map(optionKey)
-    let changed = keys.length !== existingKeys.length || keys.some((k, idx) => k !== existingKeys[idx])
-    if (!changed) {
+    if (sameSelection(values, selection)) {
       if (syncParam && !fromUser) updateInputPayload(selection)
       return
     }
@@ -373,19 +381,8 @@
     if (syncParam) updateInputPayload(selection)
   }
 
-  function applyExternalSelection(rawValue: unknown) {
-    if (!mounted) return
-    hasExternalSelection = true
-    let values = rawValue === undefined || rawValue === null ? [] : ensureArray(rawValue)
-    if (!multi && values.length > 1) values = values.slice(0, 1)
-    setSelection(values, {syncParam: false})
-  }
-
   function updateInputPayload(values: any[]) {
-    let paramValue = null
-    if (multi) paramValue = values.length ? [...values] : null
-    else paramValue = values.length ? values[0] : null
-    window.$GRAPHENE.updateParam(name, paramValue)
+    field.set(values)
   }
 
   function selectAll() {

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -56,10 +56,10 @@
 
   const registerOption = (opt: Option) => {
     manualOptions = [...manualOptions, opt]
-    reconcileSelection(false)
+    syncSelection(false)
     return () => {
       manualOptions = manualOptions.filter(o => optionKey(o.value) !== optionKey(opt.value))
-      reconcileSelection(false)
+      syncSelection(false)
     }
   }
   setContext(DROPDOWN_CONTEXT, registerOption)
@@ -124,7 +124,7 @@
     queryKey = key
     if (!data) {
       queryOptions = []
-      reconcileSelection(false)
+      syncSelection(false)
       return
     }
     let columns = [value]
@@ -136,7 +136,7 @@
         value: row[value],
         label: resolvedLabelField ? row[resolvedLabelField] : row[value],
       }))
-      reconcileSelection(false)
+      syncSelection(false)
     }
     if (typeof window !== 'undefined' && window.$GRAPHENE?.query) {
       window.$GRAPHENE.query(data, columns, handler)
@@ -309,7 +309,7 @@
       let defaults = ensureArray(defaultValue)
       if (!hasNoDefault && defaults.length) setSelection(defaults, {persist: true})
     }
-    reconcileSelection(false)
+    syncSelection(false)
     setupQuery()
     if (typeof document !== 'undefined') {
       document.addEventListener('pointerdown', handlePointerDown)
@@ -339,7 +339,7 @@
     if (triggerEl) updateTriggerWidth()
   })
 
-  function reconcileSelection(fromUser: boolean) {
+  function syncSelection(fromUser: boolean) {
     // Reconcile persisted selection with the current option set, while keeping external values
     // authoritative and only applying defaults/select-all before the user has interacted.
     let opts = availableOptions

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -2,7 +2,7 @@
   import {onMount, setContext, tick, type Snippet} from 'svelte'
   import {DROPDOWN_CONTEXT} from '../component-utilities/dropdownContext'
   import {ensureArray, toBoolean} from '../component-utilities/inputUtils'
-  import {getPageInputs} from '../internal/pageInputs.svelte.ts'
+  import {getPageInputs, initOnce} from '../internal/pageInputs.svelte.ts'
 
   interface Option {
     value: any
@@ -44,10 +44,7 @@
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
   let queryKey = ''
   let pageInputs = getPageInputs()
-  function createField() {
-    return pageInputs.dropdown(name, toBoolean(multiple))
-  }
-  let field = createField()
+  let field = initOnce(() => pageInputs.dropdown(name, toBoolean(multiple)))
 
   let isOpen = $state(false)
   let searchTerm = $state('')

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -2,7 +2,7 @@
   import {onMount, setContext, tick, type Snippet} from 'svelte'
   import {DROPDOWN_CONTEXT} from '../component-utilities/dropdownContext'
   import {ensureArray, toBoolean} from '../component-utilities/inputUtils'
-  import {usePageInputs} from '../internal/pageInputs.svelte.ts'
+  import {getPageInputs} from '../internal/pageInputs.svelte.ts'
 
   interface Option {
     value: any
@@ -43,7 +43,7 @@
   let touched = false
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
   let queryKey = ''
-  let pageInputs = usePageInputs()
+  let pageInputs = getPageInputs()
   function createField() {
     return pageInputs.dropdown(name, toBoolean(multiple))
   }

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -339,6 +339,8 @@
   })
 
   function syncSelection(fromUser: boolean) {
+    // Reconcile persisted selection with the current option set, while keeping external values
+    // authoritative and only applying defaults/select-all before the user has interacted.
     let opts = availableOptions
     if (!opts.length) {
       updateInputPayload(selection)

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -108,8 +108,9 @@
   })
 
   $effect(() => {
-    if (sameSelection(selection, field.value)) return
-    setSelection(field.value, {persist: false})
+    if (!sameSelection(selection, field.value)) {
+      setSelection(field.value, {persist: false})
+    }
   })
 
   function setupQuery() {

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -56,10 +56,10 @@
 
   const registerOption = (opt: Option) => {
     manualOptions = [...manualOptions, opt]
-    syncSelection(false)
+    reconcileSelection(false)
     return () => {
       manualOptions = manualOptions.filter(o => optionKey(o.value) !== optionKey(opt.value))
-      syncSelection(false)
+      reconcileSelection(false)
     }
   }
   setContext(DROPDOWN_CONTEXT, registerOption)
@@ -109,7 +109,7 @@
 
   $effect(() => {
     if (sameSelection(selection, field.value)) return
-    setSelection(field.value, {syncParam: false})
+    setSelection(field.value, {persist: false})
   })
 
   function setupQuery() {
@@ -123,7 +123,7 @@
     queryKey = key
     if (!data) {
       queryOptions = []
-      syncSelection(false)
+      reconcileSelection(false)
       return
     }
     let columns = [value]
@@ -135,7 +135,7 @@
         value: row[value],
         label: resolvedLabelField ? row[resolvedLabelField] : row[value],
       }))
-      syncSelection(false)
+      reconcileSelection(false)
     }
     if (typeof window !== 'undefined' && window.$GRAPHENE?.query) {
       window.$GRAPHENE.query(data, columns, handler)
@@ -281,12 +281,12 @@
       let exists = selection.some(val => optionKey(val) === key)
       if (exists) {
         let next = selection.filter(val => optionKey(val) !== key)
-        setSelection(next, {fromUser: true, syncParam: true})
+        setSelection(next, {fromUser: true, persist: true})
       } else {
-        setSelection([...selection, opt.value], {fromUser: true, syncParam: true})
+        setSelection([...selection, opt.value], {fromUser: true, persist: true})
       }
     } else {
-      setSelection([opt.value], {fromUser: true, syncParam: true})
+      setSelection([opt.value], {fromUser: true, persist: true})
       closeMenu(fromKeyboard)
     }
   }
@@ -303,12 +303,12 @@
 
   onMount(() => {
     mounted = true
-    if (field.controlled) setSelection(field.value, {syncParam: false})
+    if (field.hasExternalValue) setSelection(field.value, {persist: false})
     else {
       let defaults = ensureArray(defaultValue)
-      if (!hasNoDefault && defaults.length) setSelection(defaults, {syncParam: true})
+      if (!hasNoDefault && defaults.length) setSelection(defaults, {persist: true})
     }
-    syncSelection(false)
+    reconcileSelection(false)
     setupQuery()
     if (typeof document !== 'undefined') {
       document.addEventListener('pointerdown', handlePointerDown)
@@ -338,7 +338,7 @@
     if (triggerEl) updateTriggerWidth()
   })
 
-  function syncSelection(fromUser: boolean) {
+  function reconcileSelection(fromUser: boolean) {
     // Reconcile persisted selection with the current option set, while keeping external values
     // authoritative and only applying defaults/select-all before the user has interacted.
     let opts = availableOptions
@@ -349,7 +349,7 @@
     let nextSelection = selection.filter(val => valueMap.has(optionKey(val)))
     if (!fromUser) {
       let defaults = ensureArray(defaultValue)
-      if (field.controlled) {
+      if (field.hasExternalValue) {
         nextSelection = nextSelection
       } else if (multi && selectAllDefault) {
         nextSelection = opts.map(o => o.value)
@@ -361,7 +361,7 @@
         }
       }
     }
-    setSelection(nextSelection, {fromUser, syncParam: true})
+    setSelection(nextSelection, {fromUser, persist: true})
   }
 
   function sameSelection(left: any[], right: any[]) {
@@ -370,14 +370,14 @@
     return leftKeys.length === rightKeys.length && leftKeys.every((key, index) => key === rightKeys[index])
   }
 
-  function setSelection(values: any[], {fromUser = false, syncParam = true}: {fromUser?: boolean; syncParam?: boolean} = {}) {
+  function setSelection(values: any[], {fromUser = false, persist = true}: {fromUser?: boolean; persist?: boolean} = {}) {
     if (sameSelection(values, selection)) {
-      if (syncParam && !fromUser) updateInputPayload(selection)
+      if (persist && !fromUser) updateInputPayload(selection)
       return
     }
     selection = values
     if (fromUser) touched = true
-    if (syncParam) updateInputPayload(selection)
+    if (persist) updateInputPayload(selection)
   }
 
   function updateInputPayload(values: any[]) {
@@ -386,11 +386,11 @@
 
   function selectAll() {
     if (!multi) return
-    setSelection(availableOptions.map(opt => opt.value), {fromUser: true, syncParam: true})
+    setSelection(availableOptions.map(opt => opt.value), {fromUser: true, persist: true})
   }
 
   function clearSelection() {
-    setSelection([], {fromUser: true, syncParam: true})
+    setSelection([], {fromUser: true, persist: true})
   }
 
   let elementId = $derived(`dropdown-${name}`)

--- a/ui/components/TextInput.svelte
+++ b/ui/components/TextInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {onMount} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
-  import {getPageInputs, initOnce} from '../internal/pageInputs.svelte.ts'
+  import {captureInitial, getPageInputs} from '../internal/pageInputs.svelte.ts'
 
   interface Props {
     name: string
@@ -20,7 +20,7 @@
   }: Props = $props()
 
   let pageInputs = getPageInputs()
-  let field = initOnce(() => pageInputs.text(name))
+  let field = captureInitial(() => pageInputs.text(name))
 
   let hidePrint = $derived(toBoolean(hideDuringPrint))
   let allowUnsafe = $derived(toBoolean(unsafe))

--- a/ui/components/TextInput.svelte
+++ b/ui/components/TextInput.svelte
@@ -27,7 +27,7 @@
   let displayLabel = $derived(title || label)
 
   onMount(() => {
-    if (!field.controlled) field.set(defaultValue ?? '')
+    if (!field.hasExternalValue) field.set(defaultValue ?? '')
     return () => field.destroy()
   })
 

--- a/ui/components/TextInput.svelte
+++ b/ui/components/TextInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {onMount} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
-  import {usePageInputs} from '../internal/pageInputs.svelte.ts'
+  import {getPageInputs} from '../internal/pageInputs.svelte.ts'
 
   interface Props {
     name: string
@@ -19,7 +19,7 @@
     placeholder = 'Type to search', defaultValue = undefined, hideDuringPrint = true, unsafe = false,
   }: Props = $props()
 
-  let pageInputs = usePageInputs()
+  let pageInputs = getPageInputs()
   function createField() {
     return pageInputs.text(name)
   }

--- a/ui/components/TextInput.svelte
+++ b/ui/components/TextInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {onMount} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
-  import {getPageInputs} from '../internal/pageInputs.svelte.ts'
+  import {getPageInputs, initOnce} from '../internal/pageInputs.svelte.ts'
 
   interface Props {
     name: string
@@ -20,10 +20,7 @@
   }: Props = $props()
 
   let pageInputs = getPageInputs()
-  function createField() {
-    return pageInputs.text(name)
-  }
-  let field = createField()
+  let field = initOnce(() => pageInputs.text(name))
 
   let hidePrint = $derived(toBoolean(hideDuringPrint))
   let allowUnsafe = $derived(toBoolean(unsafe))

--- a/ui/components/TextInput.svelte
+++ b/ui/components/TextInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import {onMount} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
 
   interface Props {
@@ -17,21 +18,32 @@
     placeholder = 'Type to search', defaultValue = undefined, hideDuringPrint = true, unsafe = false,
   }: Props = $props()
 
-  // svelte-ignore state_referenced_locally - intentionally capturing initial value only
-  let value = $state(defaultValue ?? '')
+  let value = $state('')
 
   let hidePrint = $derived(toBoolean(hideDuringPrint))
   let allowUnsafe = $derived(toBoolean(unsafe))
   let displayLabel = $derived(title || label)
 
-  // Push value changes to parent
-  $effect(() => {
+  onMount(() => {
+    value = readExternalValue(window.$GRAPHENE?.getParam?.(name), defaultValue ?? '')
     pushValue(value)
+    return window.$GRAPHENE?.subscribeParams?.((params, event: {changed: Set<string>}) => {
+      if (!event.changed.has(name)) return
+      let nextValue = readExternalValue(params[name], '')
+      if (nextValue !== value) value = nextValue
+    })
   })
 
   function sanitize(input: string): string {
     if (allowUnsafe) return input
     return input.replace(/'/g, "''")
+  }
+
+  function readExternalValue(raw: unknown, fallback: string) {
+    if (raw === undefined) return fallback
+    if (raw === null) return ''
+    if (Array.isArray(raw)) return raw.length ? String(raw[0] ?? '') : ''
+    return String(raw)
   }
 
   function pushValue(input: string) {

--- a/ui/components/TextInput.svelte
+++ b/ui/components/TextInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {onMount} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
+  import {usePageInputs} from '../internal/pageInputs.svelte.ts'
 
   interface Props {
     name: string
@@ -18,20 +19,19 @@
     placeholder = 'Type to search', defaultValue = undefined, hideDuringPrint = true, unsafe = false,
   }: Props = $props()
 
-  let value = $state('')
+  let pageInputs = usePageInputs()
+  function createField() {
+    return pageInputs.text(name)
+  }
+  let field = createField()
 
   let hidePrint = $derived(toBoolean(hideDuringPrint))
   let allowUnsafe = $derived(toBoolean(unsafe))
   let displayLabel = $derived(title || label)
 
   onMount(() => {
-    value = readExternalValue(window.$GRAPHENE?.getParam?.(name), defaultValue ?? '')
-    pushValue(value)
-    return window.$GRAPHENE?.subscribeParams?.((params, event: {changed: Set<string>}) => {
-      if (!event.changed.has(name)) return
-      let nextValue = readExternalValue(params[name], '')
-      if (nextValue !== value) value = nextValue
-    })
+    if (!field.controlled) field.set(defaultValue ?? '')
+    return () => field.destroy()
   })
 
   function sanitize(input: string): string {
@@ -39,23 +39,14 @@
     return input.replace(/'/g, "''")
   }
 
-  function readExternalValue(raw: unknown, fallback: string) {
-    if (raw === undefined) return fallback
-    if (raw === null) return ''
-    if (Array.isArray(raw)) return raw.length ? String(raw[0] ?? '') : ''
-    return String(raw)
-  }
-
   function pushValue(input: string) {
     let trimmed = input ?? ''
-    let _safe = sanitize(trimmed)
-    let paramValue = trimmed === '' ? null : trimmed
-    window.$GRAPHENE.updateParam(name, paramValue)
+    sanitize(trimmed)
+    field.set(trimmed)
   }
 
   function onInput(event: Event) {
-    value = (event.currentTarget as HTMLInputElement).value
-    pushValue(value)
+    pushValue((event.currentTarget as HTMLInputElement).value)
   }
 </script>
 
@@ -70,7 +61,7 @@
     id={`text-input-${name}`}
     class="text-input"
     type="text"
-    value={value}
+    value={field.value}
     placeholder={placeholder}
     oninput={onInput}
   />

--- a/ui/internal/LocalApp.svelte
+++ b/ui/internal/LocalApp.svelte
@@ -1,8 +1,14 @@
-<script>
+<script lang="ts">
+  import {onDestroy} from 'svelte'
   import {errorProvider} from './telemetry.ts'
+  import {PageInputs, activatePageInputs, releasePageInputs, setPageInputsContext} from './pageInputs.svelte.ts'
   import navFiles from 'virtual:nav'
   import NavSidebar from './NavSidebar.svelte'
   import ErrorDisplay from './ErrorDisplay.svelte'
+
+  let pageInputs = activatePageInputs(new PageInputs())
+  setPageInputsContext(pageInputs)
+  onDestroy(() => releasePageInputs(pageInputs))
 
   // Nav sidebar with HMR support for the virtual file list
   let navData = $state(navFiles)

--- a/ui/internal/pageInputs.svelte.ts
+++ b/ui/internal/pageInputs.svelte.ts
@@ -248,6 +248,8 @@ export class PageInputs {
   }
 
   private applySnapshot(nextParams: ParamSnapshot, source: UpdateSource) {
+    // Central reconciliation point for persisted inputs: update the snapshot, sync affected
+    // fields, notify compatibility subscribers, and rerun queries from the final param state.
     let cloned = cloneParams(nextParams)
     let changed = getChangedKeys(this.params, cloned)
     if (changed.size === 0) return

--- a/ui/internal/pageInputs.svelte.ts
+++ b/ui/internal/pageInputs.svelte.ts
@@ -1,0 +1,330 @@
+import {createContext} from 'svelte'
+
+type ParamScalar = string | number | boolean
+export type ParamValue = ParamScalar | null | ParamScalar[]
+export type ParamSnapshot = Record<string, ParamValue>
+export type ParamEvent = {changed: Set<string>}
+export type ParamSubscriber = (params: ParamSnapshot, event: ParamEvent) => void
+
+interface ReadResult<T> {
+  present: boolean
+  value: T
+}
+
+interface ParamCodec<T> {
+  keys(name: string): string[]
+  empty(): T
+  read(params: ParamSnapshot, name: string): ReadResult<T>
+  write(name: string, value: T): ParamSnapshot
+}
+
+type UpdateSource = 'init' | 'local' | 'external'
+
+class BoundField<T> {
+  value: T
+  present: boolean
+  controlled: boolean
+
+  constructor(
+    private controller: PageInputs,
+    private name: string,
+    private codec: ParamCodec<T>,
+  ) {
+    this.value = $state(codec.empty())
+    this.present = $state(false)
+    this.controlled = $state(false)
+    this.controller.registerField(this)
+    this.sync(this.controller.getParams(), 'init')
+  }
+
+  keys() {
+    return this.codec.keys(this.name)
+  }
+
+  sync(params: ParamSnapshot, source: UpdateSource) {
+    let next = this.codec.read(params, this.name)
+    this.present = next.present
+    this.value = next.value
+    if (source === 'init') this.controlled = next.present
+    else if (source === 'external') this.controlled = true
+  }
+
+  set(next: T) {
+    let nextParams = this.codec.write(this.name, next)
+    if (typeof window !== 'undefined' && window.$GRAPHENE?.updateParams) window.$GRAPHENE.updateParams(nextParams)
+    else this.controller.updateParams(nextParams)
+  }
+
+  destroy() {
+    this.controller.unregisterField(this)
+  }
+}
+
+const textCodec: ParamCodec<string> = {
+  keys: name => [name],
+  empty: () => '',
+  read(params, name) {
+    let raw = params[name]
+    if (raw === undefined || raw === null) return {present: false, value: ''}
+    if (Array.isArray(raw)) return {present: raw.length > 0, value: raw.length ? String(raw[0] ?? '') : ''}
+    return {present: true, value: String(raw)}
+  },
+  write(name, value) {
+    return {[name]: value === '' ? null : value}
+  },
+}
+
+const dropdownSingleCodec: ParamCodec<any[]> = {
+  keys: name => [name],
+  empty: () => [],
+  read(params, name) {
+    let raw = params[name]
+    if (raw === undefined || raw === null) return {present: false, value: []}
+    if (Array.isArray(raw)) return {present: raw.length > 0, value: raw.length ? [raw[0]] : []}
+    return {present: true, value: [raw]}
+  },
+  write(name, value) {
+    return {[name]: value.length ? value[0] : null}
+  },
+}
+
+const dropdownMultiCodec: ParamCodec<any[]> = {
+  keys: name => [name],
+  empty: () => [],
+  read(params, name) {
+    let raw = params[name]
+    if (raw === undefined || raw === null) return {present: false, value: []}
+    if (Array.isArray(raw)) return {present: raw.length > 0, value: [...raw]}
+    return {present: true, value: [raw]}
+  },
+  write(name, value) {
+    return {[name]: value.length ? [...value] : null}
+  },
+}
+
+const dateRangeCodec: ParamCodec<{start: string | null; end: string | null}> = {
+  keys: name => [`${name}_start`, `${name}_end`],
+  empty: () => ({start: null, end: null}),
+  read(params, name) {
+    let startRaw = params[`${name}_start`]
+    let endRaw = params[`${name}_end`]
+    let start = readScalar(startRaw)
+    let end = readScalar(endRaw)
+    return {present: start !== null || end !== null, value: {start, end}}
+  },
+  write(name, value) {
+    return {
+      [`${name}_start`]: value.start,
+      [`${name}_end`]: value.end,
+    }
+  },
+}
+
+function readScalar(value: ParamValue | undefined) {
+  if (value === undefined || value === null) return null
+  if (Array.isArray(value)) return value.length ? String(value[0] ?? '') : null
+  return String(value)
+}
+
+function cloneParamValue(value: ParamValue): ParamValue {
+  if (Array.isArray(value)) return [...value]
+  return value
+}
+
+function cloneParams(params: ParamSnapshot) {
+  return Object.fromEntries(Object.entries(params).map(([name, value]) => [name, cloneParamValue(value)])) as ParamSnapshot
+}
+
+function paramValueEqual(left: ParamValue | undefined, right: ParamValue | undefined) {
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false
+    if (left.length !== right.length) return false
+    return left.every((value, index) => value === right[index])
+  }
+  return left === right
+}
+
+function getChangedKeys(left: ParamSnapshot, right: ParamSnapshot) {
+  let changed = new Set<string>()
+  let keys = new Set([...Object.keys(left), ...Object.keys(right)])
+  keys.forEach(key => {
+    if (!paramValueEqual(left[key], right[key])) changed.add(key)
+  })
+  return changed
+}
+
+export class PageInputs {
+  private params: ParamSnapshot
+  private subscribers: Set<ParamSubscriber>
+  private fieldsByKey: Map<string, Set<BoundField<any>>>
+  private onPopState?: () => void
+
+  constructor() {
+    this.params = $state.raw({}) as ParamSnapshot
+    this.subscribers = new Set()
+    this.fieldsByKey = new Map()
+    this.params = cloneParams(this.readFromUrl())
+    if (typeof window !== 'undefined') {
+      this.onPopState = () => this.syncFromUrl()
+      window.addEventListener('popstate', this.onPopState)
+    }
+  }
+
+  destroy() {
+    if (this.onPopState) window.removeEventListener('popstate', this.onPopState)
+    this.subscribers.clear()
+    this.fieldsByKey.clear()
+  }
+
+  registerField(field: BoundField<any>) {
+    field.keys().forEach(key => {
+      let fields = this.fieldsByKey.get(key)
+      if (!fields) {
+        fields = new Set()
+        this.fieldsByKey.set(key, fields)
+      }
+      fields.add(field)
+    })
+  }
+
+  unregisterField(field: BoundField<any>) {
+    field.keys().forEach(key => {
+      let fields = this.fieldsByKey.get(key)
+      if (!fields) return
+      fields.delete(field)
+      if (fields.size === 0) this.fieldsByKey.delete(key)
+    })
+  }
+
+  text(name: string) {
+    return new BoundField(this, name, textCodec)
+  }
+
+  dropdown(name: string, multiple: boolean) {
+    return new BoundField(this, name, multiple ? dropdownMultiCodec : dropdownSingleCodec)
+  }
+
+  dateRange(name: string) {
+    return new BoundField(this, name, dateRangeCodec)
+  }
+
+  getParam(name: string) {
+    return this.params[name]
+  }
+
+  getParams() {
+    return cloneParams(this.params)
+  }
+
+  subscribeParams(subscriber: ParamSubscriber) {
+    this.subscribers.add(subscriber)
+    return () => this.subscribers.delete(subscriber)
+  }
+
+  updateParam(name: string, value: ParamValue) {
+    this.updateParams({[name]: value})
+  }
+
+  updateParams(nextParams: Record<string, any>) {
+    let merged = {...this.params} as ParamSnapshot
+    Object.entries(nextParams).forEach(([name, value]) => {
+      merged[name] = Array.isArray(value) ? [...value] : value
+    })
+    this.applySnapshot(merged, 'local')
+  }
+
+  reset() {
+    let changed = new Set(Object.keys(this.params))
+    if (changed.size === 0) return
+    this.params = {}
+    this.syncUrl()
+    this.syncFields(changed, 'local')
+    let snapshot = this.getParams()
+    this.subscribers.forEach(subscriber => subscriber(snapshot, {changed}))
+  }
+
+  syncFromUrl() {
+    this.applySnapshot(this.readFromUrl(), 'external')
+  }
+
+  private applySnapshot(nextParams: ParamSnapshot, source: UpdateSource) {
+    let cloned = cloneParams(nextParams)
+    let changed = getChangedKeys(this.params, cloned)
+    if (changed.size === 0) return
+    this.params = cloned
+    if (source !== 'external') this.syncUrl()
+    this.syncFields(changed, source)
+    let snapshot = this.getParams()
+    this.subscribers.forEach(subscriber => subscriber(snapshot, {changed}))
+    window.$GRAPHENE?.rerunQueries?.()
+  }
+
+  private syncFields(changed: Set<string>, source: UpdateSource) {
+    let fields = new Set<BoundField<any>>()
+    changed.forEach(key => {
+      this.fieldsByKey.get(key)?.forEach(field => fields.add(field))
+    })
+    fields.forEach(field => field.sync(this.params, source))
+  }
+
+  private syncUrl() {
+    if (typeof window === 'undefined') return
+    let search = new URLSearchParams()
+    Object.entries(this.params).forEach(([name, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach(item => search.append(name, String(item)))
+        return
+      }
+      if (value === null || value === undefined || value === '') return
+      search.append(name, String(value))
+    })
+    let nextSearch = search.toString()
+    let currentSearch = window.location.search.replace(/^\?/, '')
+    if (nextSearch === currentSearch) return
+    let nextUrl = window.location.pathname + (nextSearch ? `?${nextSearch}` : '') + window.location.hash
+    window.history.replaceState(window.history.state, '', nextUrl)
+  }
+
+  private readFromUrl() {
+    if (typeof window === 'undefined') return {} as ParamSnapshot
+    let next = {} as ParamSnapshot
+    for (let [name, value] of new URLSearchParams(window.location.search).entries()) {
+      let existing = next[name]
+      if (existing === undefined) next[name] = value
+      else if (Array.isArray(existing)) existing.push(value)
+      else next[name] = [String(existing), value]
+    }
+    return next
+  }
+}
+
+const [getPageInputsContext, setPageInputsContext] = createContext<PageInputs>()
+
+let activePageInputs: PageInputs | null = null
+
+export function activatePageInputs(pageInputs: PageInputs) {
+  if (activePageInputs && activePageInputs !== pageInputs) activePageInputs.destroy()
+  activePageInputs = pageInputs
+  return pageInputs
+}
+
+export function getActivePageInputs() {
+  if (!activePageInputs) activePageInputs = new PageInputs()
+  return activePageInputs
+}
+
+export function releasePageInputs(pageInputs: PageInputs) {
+  if (activePageInputs !== pageInputs) return
+  pageInputs.destroy()
+  activePageInputs = null
+}
+
+export function usePageInputs() {
+  try {
+    return getPageInputsContext()
+  } catch {
+    return getActivePageInputs()
+  }
+}
+
+export {setPageInputsContext}

--- a/ui/internal/pageInputs.svelte.ts
+++ b/ui/internal/pageInputs.svelte.ts
@@ -23,7 +23,7 @@ type UpdateSource = 'init' | 'local' | 'external'
 class BoundField<T> {
   value: T
   present: boolean
-  controlled: boolean
+  hasExternalValue: boolean
 
   constructor(
     private controller: PageInputs,
@@ -32,7 +32,7 @@ class BoundField<T> {
   ) {
     this.value = $state(codec.empty())
     this.present = $state(false)
-    this.controlled = $state(false)
+    this.hasExternalValue = $state(false)
     this.controller.registerField(this)
     this.sync(this.controller.getParams(), 'init')
   }
@@ -45,8 +45,8 @@ class BoundField<T> {
     let next = this.codec.read(params, this.name)
     this.present = next.present
     this.value = next.value
-    if (source === 'init') this.controlled = next.present
-    else if (source === 'external') this.controlled = true
+    if (source === 'init') this.hasExternalValue = next.present
+    else if (source === 'external') this.hasExternalValue = true
   }
 
   set(next: T) {

--- a/ui/internal/pageInputs.svelte.ts
+++ b/ui/internal/pageInputs.svelte.ts
@@ -16,13 +16,13 @@ interface ParamCodec<T> {
   empty(): T
   read(params: ParamSnapshot, name: string): ReadResult<T>
   write(name: string, value: T): ParamSnapshot
+  normalize?(params: ParamSnapshot, name: string): void
 }
 
 type UpdateSource = 'init' | 'local' | 'external'
 
 class BoundField<T> {
   value: T
-  present: boolean
   hasExternalValue: boolean
 
   constructor(
@@ -31,7 +31,6 @@ class BoundField<T> {
     private codec: ParamCodec<T>,
   ) {
     this.value = $state(codec.empty())
-    this.present = $state(false)
     this.hasExternalValue = $state(false)
     this.controller.registerField(this)
     this.sync(this.controller.getParams(), 'init')
@@ -43,10 +42,13 @@ class BoundField<T> {
 
   sync(params: ParamSnapshot, source: UpdateSource) {
     let next = this.codec.read(params, this.name)
-    this.present = next.present
     this.value = next.value
     if (source === 'init') this.hasExternalValue = next.present
     else if (source === 'external') this.hasExternalValue = true
+  }
+
+  normalize(params: ParamSnapshot) {
+    this.codec.normalize?.(params, this.name)
   }
 
   set(next: T) {
@@ -99,6 +101,11 @@ const dropdownMultiCodec: ParamCodec<any[]> = {
   },
   write(name, value) {
     return {[name]: value.length ? [...value] : null}
+  },
+  normalize(params, name) {
+    let raw = params[name]
+    if (raw === undefined || raw === null || Array.isArray(raw)) return
+    params[name] = [raw]
   },
 }
 
@@ -251,6 +258,7 @@ export class PageInputs {
     // Central reconciliation point for persisted inputs: update the snapshot, sync affected
     // fields, notify compatibility subscribers, and rerun queries from the final param state.
     let cloned = cloneParams(nextParams)
+    this.normalizeSnapshot(cloned)
     let changed = getChangedKeys(this.params, cloned)
     if (changed.size === 0) return
     this.params = cloned
@@ -267,6 +275,14 @@ export class PageInputs {
       this.fieldsByKey.get(key)?.forEach(field => fields.add(field))
     })
     fields.forEach(field => field.sync(this.params, source))
+  }
+
+  private normalizeSnapshot(params: ParamSnapshot) {
+    let fields = new Set<BoundField<any>>()
+    this.fieldsByKey.forEach(keyFields => {
+      keyFields.forEach(field => fields.add(field))
+    })
+    fields.forEach(field => field.normalize(params))
   }
 
   private syncUrl() {

--- a/ui/internal/pageInputs.svelte.ts
+++ b/ui/internal/pageInputs.svelte.ts
@@ -327,4 +327,11 @@ export function getPageInputs() {
   }
 }
 
+// Top-level initializers that read props capture only the initial prop value. Wrapping the
+// read in a callback makes that one-time capture explicit for cases like field setup, where
+// the prop is treated as immutable component identity rather than reactive input.
+export function initOnce<T>(factory: () => T) {
+  return factory()
+}
+
 export {setPageInputsContext}

--- a/ui/internal/pageInputs.svelte.ts
+++ b/ui/internal/pageInputs.svelte.ts
@@ -319,7 +319,7 @@ export function releasePageInputs(pageInputs: PageInputs) {
   activePageInputs = null
 }
 
-export function usePageInputs() {
+export function getPageInputs() {
   try {
     return getPageInputsContext()
   } catch {

--- a/ui/internal/pageInputs.svelte.ts
+++ b/ui/internal/pageInputs.svelte.ts
@@ -330,7 +330,7 @@ export function getPageInputs() {
 // Top-level initializers that read props capture only the initial prop value. Wrapping the
 // read in a callback makes that one-time capture explicit for cases like field setup, where
 // the prop is treated as immutable component identity rather than reactive input.
-export function initOnce<T>(factory: () => T) {
+export function captureInitial<T>(factory: () => T) {
   return factory()
 }
 

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -2,6 +2,7 @@
 // When inputs change, it takes care of notifying affected components and requesting new data.
 
 import {cacheRead, cacheWrite, getHashes} from './clientCache.ts'
+import {getActivePageInputs, type ParamSubscriber} from './pageInputs.svelte.ts'
 import {errorProvider} from './telemetry.ts'
 
 interface QueryResult {
@@ -27,16 +28,9 @@ interface QueryNode {
   errors: Error[]
 }
 
-type ParamValue = string | number | boolean | null | Array<string | number | boolean>
-type ParamSnapshot = Record<string, ParamValue>
-type ParamEvent = {changed: Set<string>}
-type ParamSubscriber = (params: ParamSnapshot, event: ParamEvent) => void
-
 let runPending: Promise<void> | null = null
-let params = {} as ParamSnapshot
 let queries = [] as QueryNode[]
 let queryResults = {} as Record<string, {rows: any[]; fields?: Field[]}>
-let paramSubscribers = new Set<ParamSubscriber>()
 
 function registerQuery(name: string, contents: string) {
   queries = queries.filter(q => q.name !== name)
@@ -44,118 +38,6 @@ function registerQuery(name: string, contents: string) {
 }
 
 const getRoutePath = () => (typeof window === 'undefined' ? '/' : window.location.pathname || '/')
-
-function cloneParamValue(value: any): ParamValue {
-  if (Array.isArray(value)) return value.map(v => v as string | number | boolean)
-  return value as ParamValue
-}
-
-function paramsEqual(left: ParamSnapshot, right: ParamSnapshot) {
-  let leftKeys = Object.keys(left).sort()
-  let rightKeys = Object.keys(right).sort()
-  if (leftKeys.length !== rightKeys.length) return false
-  for (let i = 0; i < leftKeys.length; i++) {
-    if (leftKeys[i] !== rightKeys[i]) return false
-    if (!paramValueEqual(left[leftKeys[i]], right[rightKeys[i]])) return false
-  }
-  return true
-}
-
-function paramValueEqual(left: ParamValue | undefined, right: ParamValue | undefined) {
-  if (Array.isArray(left) || Array.isArray(right)) {
-    if (!Array.isArray(left) || !Array.isArray(right)) return false
-    if (left.length !== right.length) return false
-    return left.every((value, index) => value === right[index])
-  }
-  return left === right
-}
-
-function snapshotParams() {
-  return Object.fromEntries(Object.entries(params).map(([name, value]) => [name, cloneParamValue(value)])) as ParamSnapshot
-}
-
-function notifyParamSubscribers(event: ParamEvent) {
-  let next = snapshotParams()
-  paramSubscribers.forEach(subscriber => subscriber(next, event))
-}
-
-function getChangedParamNames(left: ParamSnapshot, right: ParamSnapshot) {
-  let changed = new Set<string>()
-  let names = new Set([...Object.keys(left), ...Object.keys(right)])
-  names.forEach(name => {
-    if (!paramValueEqual(left[name], right[name])) changed.add(name)
-  })
-  return changed
-}
-
-function serializeParam(value: ParamValue) {
-  if (Array.isArray(value)) return value.map(item => String(item))
-  if (value === null || value === undefined) return []
-  return [String(value)]
-}
-
-function syncUrlFromParams() {
-  if (typeof window === 'undefined') return
-  let search = new URLSearchParams()
-  Object.entries(params).forEach(([name, value]) => {
-    serializeParam(value).forEach(item => {
-      if (item === '') return
-      search.append(name, item)
-    })
-  })
-  let nextSearch = search.toString()
-  let currentSearch = window.location.search.replace(/^\?/, '')
-  if (nextSearch === currentSearch) return
-  let nextUrl = window.location.pathname + (nextSearch ? `?${nextSearch}` : '') + window.location.hash
-  window.history.replaceState(window.history.state, '', nextUrl)
-}
-
-function readParamsFromUrl() {
-  if (typeof window === 'undefined') return {} as ParamSnapshot
-  let next = {} as ParamSnapshot
-  for (let [name, value] of new URLSearchParams(window.location.search).entries()) {
-    let existing = next[name]
-    if (existing === undefined) next[name] = value
-    else if (Array.isArray(existing)) existing.push(value)
-    else next[name] = [String(existing), value]
-  }
-  return next
-}
-
-function applyParams(nextParams: ParamSnapshot, {skipUrlSync = false}: {skipUrlSync?: boolean} = {}) {
-  let cloned = Object.fromEntries(Object.entries(nextParams).map(([name, value]) => [name, cloneParamValue(value)])) as ParamSnapshot
-  if (paramsEqual(params, cloned)) return
-  let changed = getChangedParamNames(params, cloned)
-  params = cloned
-  if (!skipUrlSync) syncUrlFromParams()
-  notifyParamSubscribers({changed})
-  runAll() // for now, do the easy thing and reload it all
-}
-
-function updateParam(name: string, value: any) {
-  applyParams({...params, [name]: cloneParamValue(value)})
-}
-
-function updateParams(nextParams: Record<string, any>) {
-  let merged = {...params} as ParamSnapshot
-  Object.entries(nextParams).forEach(([name, value]) => {
-    merged[name] = cloneParamValue(value)
-  })
-  applyParams(merged)
-}
-
-function getParam(name: string) {
-  return params[name]
-}
-
-function subscribeParams(subscriber: ParamSubscriber) {
-  paramSubscribers.add(subscriber)
-  return () => paramSubscribers.delete(subscriber)
-}
-
-function syncParamsFromUrl() {
-  applyParams(readParamsFromUrl(), {skipUrlSync: true})
-}
 
 function query(source: string, fields: Record<string, string | string[]>, callback: ResultHandler) {
   // using Map here because it preserves the order in which we add fields to the select, which we use when we get the result.
@@ -179,10 +61,9 @@ function unsubscribe(callback: ResultHandler) {
 }
 
 function resetQueryEngine() {
-  params = {}
   queries = []
-  queryResults = {}
-  notifyParamSubscribers({changed: new Set()})
+  Object.keys(queryResults).forEach(key => delete queryResults[key])
+  getActivePageInputs().reset()
 }
 
 async function runNode(n: QueryNode) {
@@ -196,6 +77,7 @@ async function runNode(n: QueryNode) {
   let gsql = [...tables.map(q => `table ${q.name} as (${q.contents})`), n.contents].join('\n')
 
   try {
+    let params = getActivePageInputs().getParams()
     let response = await fetch('/_api/query', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
@@ -332,18 +214,17 @@ function evidenceType(type: string | undefined) {
 }
 
 if (typeof window !== 'undefined') {
-  params = readParamsFromUrl()
-  window.addEventListener('popstate', syncParamsFromUrl)
   Object.assign(window.$GRAPHENE, {
-    getParam,
+    getParam: (name: string) => getActivePageInputs().getParam(name),
     registerQuery,
-    subscribeParams,
-    syncParamsFromUrl,
-    updateParam,
-    updateParams,
+    subscribeParams: (subscriber: ParamSubscriber) => getActivePageInputs().subscribeParams(subscriber),
+    syncParamsFromUrl: () => getActivePageInputs().syncFromUrl(),
+    updateParam: (name: string, value: any) => getActivePageInputs().updateParam(name, value),
+    updateParams: (nextParams: Record<string, any>) => getActivePageInputs().updateParams(nextParams),
     query,
     unsubscribe,
     resetQueryEngine,
+    rerunQueries: runAll,
     isQueryLoading,
     queryResults,
   })

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -27,10 +27,16 @@ interface QueryNode {
   errors: Error[]
 }
 
+type ParamValue = string | number | boolean | null | Array<string | number | boolean>
+type ParamSnapshot = Record<string, ParamValue>
+type ParamEvent = {changed: Set<string>}
+type ParamSubscriber = (params: ParamSnapshot, event: ParamEvent) => void
+
 let runPending: Promise<void> | null = null
-let params = {} as Record<string, any>
+let params = {} as ParamSnapshot
 let queries = [] as QueryNode[]
 let queryResults = {} as Record<string, {rows: any[]; fields?: Field[]}>
+let paramSubscribers = new Set<ParamSubscriber>()
 
 function registerQuery(name: string, contents: string) {
   queries = queries.filter(q => q.name !== name)
@@ -39,9 +45,116 @@ function registerQuery(name: string, contents: string) {
 
 const getRoutePath = () => (typeof window === 'undefined' ? '/' : window.location.pathname || '/')
 
-function updateParam(name: string, value: any) {
-  params[name] = value
+function cloneParamValue(value: any): ParamValue {
+  if (Array.isArray(value)) return value.map(v => v as string | number | boolean)
+  return value as ParamValue
+}
+
+function paramsEqual(left: ParamSnapshot, right: ParamSnapshot) {
+  let leftKeys = Object.keys(left).sort()
+  let rightKeys = Object.keys(right).sort()
+  if (leftKeys.length !== rightKeys.length) return false
+  for (let i = 0; i < leftKeys.length; i++) {
+    if (leftKeys[i] !== rightKeys[i]) return false
+    if (!paramValueEqual(left[leftKeys[i]], right[rightKeys[i]])) return false
+  }
+  return true
+}
+
+function paramValueEqual(left: ParamValue | undefined, right: ParamValue | undefined) {
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false
+    if (left.length !== right.length) return false
+    return left.every((value, index) => value === right[index])
+  }
+  return left === right
+}
+
+function snapshotParams() {
+  return Object.fromEntries(Object.entries(params).map(([name, value]) => [name, cloneParamValue(value)])) as ParamSnapshot
+}
+
+function notifyParamSubscribers(event: ParamEvent) {
+  let next = snapshotParams()
+  paramSubscribers.forEach(subscriber => subscriber(next, event))
+}
+
+function getChangedParamNames(left: ParamSnapshot, right: ParamSnapshot) {
+  let changed = new Set<string>()
+  let names = new Set([...Object.keys(left), ...Object.keys(right)])
+  names.forEach(name => {
+    if (!paramValueEqual(left[name], right[name])) changed.add(name)
+  })
+  return changed
+}
+
+function serializeParam(value: ParamValue) {
+  if (Array.isArray(value)) return value.map(item => String(item))
+  if (value === null || value === undefined) return []
+  return [String(value)]
+}
+
+function syncUrlFromParams() {
+  if (typeof window === 'undefined') return
+  let search = new URLSearchParams()
+  Object.entries(params).forEach(([name, value]) => {
+    serializeParam(value).forEach(item => {
+      if (item === '') return
+      search.append(name, item)
+    })
+  })
+  let nextSearch = search.toString()
+  let currentSearch = window.location.search.replace(/^\?/, '')
+  if (nextSearch === currentSearch) return
+  let nextUrl = window.location.pathname + (nextSearch ? `?${nextSearch}` : '') + window.location.hash
+  window.history.replaceState(window.history.state, '', nextUrl)
+}
+
+function readParamsFromUrl() {
+  if (typeof window === 'undefined') return {} as ParamSnapshot
+  let next = {} as ParamSnapshot
+  for (let [name, value] of new URLSearchParams(window.location.search).entries()) {
+    let existing = next[name]
+    if (existing === undefined) next[name] = value
+    else if (Array.isArray(existing)) existing.push(value)
+    else next[name] = [String(existing), value]
+  }
+  return next
+}
+
+function applyParams(nextParams: ParamSnapshot, {skipUrlSync = false}: {skipUrlSync?: boolean} = {}) {
+  let cloned = Object.fromEntries(Object.entries(nextParams).map(([name, value]) => [name, cloneParamValue(value)])) as ParamSnapshot
+  if (paramsEqual(params, cloned)) return
+  let changed = getChangedParamNames(params, cloned)
+  params = cloned
+  if (!skipUrlSync) syncUrlFromParams()
+  notifyParamSubscribers({changed})
   runAll() // for now, do the easy thing and reload it all
+}
+
+function updateParam(name: string, value: any) {
+  applyParams({...params, [name]: cloneParamValue(value)})
+}
+
+function updateParams(nextParams: Record<string, any>) {
+  let merged = {...params} as ParamSnapshot
+  Object.entries(nextParams).forEach(([name, value]) => {
+    merged[name] = cloneParamValue(value)
+  })
+  applyParams(merged)
+}
+
+function getParam(name: string) {
+  return params[name]
+}
+
+function subscribeParams(subscriber: ParamSubscriber) {
+  paramSubscribers.add(subscriber)
+  return () => paramSubscribers.delete(subscriber)
+}
+
+function syncParamsFromUrl() {
+  applyParams(readParamsFromUrl(), {skipUrlSync: true})
 }
 
 function query(source: string, fields: Record<string, string | string[]>, callback: ResultHandler) {
@@ -69,6 +182,7 @@ function resetQueryEngine() {
   params = {}
   queries = []
   queryResults = {}
+  notifyParamSubscribers({changed: new Set()})
 }
 
 async function runNode(n: QueryNode) {
@@ -218,9 +332,15 @@ function evidenceType(type: string | undefined) {
 }
 
 if (typeof window !== 'undefined') {
+  params = readParamsFromUrl()
+  window.addEventListener('popstate', syncParamsFromUrl)
   Object.assign(window.$GRAPHENE, {
+    getParam,
     registerQuery,
+    subscribeParams,
+    syncParamsFromUrl,
     updateParam,
+    updateParams,
     query,
     unsubscribe,
     resetQueryEngine,

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -2,7 +2,7 @@
 // When inputs change, it takes care of notifying affected components and requesting new data.
 
 import {cacheRead, cacheWrite, getHashes} from './clientCache.ts'
-import {getActivePageInputs, type ParamSubscriber} from './pageInputs.svelte.ts'
+import {getActivePageInputs} from './pageInputs.svelte.ts'
 import {errorProvider} from './telemetry.ts'
 
 interface QueryResult {
@@ -217,7 +217,7 @@ if (typeof window !== 'undefined') {
   Object.assign(window.$GRAPHENE, {
     getParam: (name: string) => getActivePageInputs().getParam(name),
     registerQuery,
-    subscribeParams: (subscriber: ParamSubscriber) => getActivePageInputs().subscribeParams(subscriber),
+    subscribeParams: subscriber => getActivePageInputs().subscribeParams(subscriber),
     syncParamsFromUrl: () => getActivePageInputs().syncFromUrl(),
     updateParam: (name: string, value: any) => getActivePageInputs().updateParam(name, value),
     updateParams: (nextParams: Record<string, any>) => getActivePageInputs().updateParams(nextParams),

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -481,7 +481,7 @@ test('inputs resync from url changes after navigation events', async ({server, p
     .poll(() => queryBodies[queryBodies.length - 1]?.params)
     .toEqual({
       search_text: 'sigma',
-      carrier_multi: 'DL',
+      carrier_multi: ['DL'],
       window_start: '2024-01-10',
       window_end: '2024-01-20',
     })

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -35,10 +35,19 @@ async function startParamTracking(page: any) {
   await page.evaluate(() => {
     let w = window as any
     w.__paramUpdates = []
-    let original = w.$GRAPHENE.updateParam.bind(w.$GRAPHENE)
+    let originalUpdateParam = w.$GRAPHENE.updateParam.bind(w.$GRAPHENE)
+    let originalUpdateParams = w.$GRAPHENE.updateParams?.bind(w.$GRAPHENE)
     w.$GRAPHENE.updateParam = (name: string, value: unknown) => {
       w.__paramUpdates.push({name, value})
-      return original(name, value)
+      return originalUpdateParam(name, value)
+    }
+    if (originalUpdateParams) {
+      w.$GRAPHENE.updateParams = (values: Record<string, unknown>) => {
+        Object.entries(values).forEach(([name, value]) => {
+          w.__paramUpdates.push({name, value})
+        })
+        return originalUpdateParams(values)
+      }
     }
   })
 }
@@ -54,6 +63,19 @@ function lastParamUpdate(page: any, name?: string): Promise<{name: string; value
 
 function allParamUpdates(page: any): Promise<Array<{name: string; value: unknown}>> {
   return page.evaluate(() => (window as any).__paramUpdates ?? [])
+}
+
+function readSearchParams(page: any): Promise<Record<string, string | string[]>> {
+  return page.evaluate(() => {
+    let values = {} as Record<string, string | string[]>
+    for (let [name, value] of new URLSearchParams(window.location.search).entries()) {
+      let existing = values[name]
+      if (existing === undefined) values[name] = value
+      else if (Array.isArray(existing)) existing.push(value)
+      else values[name] = [existing, value]
+    }
+    return values
+  })
 }
 
 test('dropdown single-select supports open, select, and close behaviors', async ({server, page}) => {
@@ -327,4 +349,140 @@ test('text input updates params and date range applies preset', async ({mount, p
   await expect(page.locator('#daterange-window-start')).toHaveValue('2024-01-25')
   await expect(page.locator('#daterange-window-end')).toHaveValue('2024-02-01')
   await expect(page.locator('#component-test')).screenshot('date-range-preset')
+})
+
+test('inputs sync url state on load, change, and reload', async ({server, page}) => {
+  let queryBodies: any[] = []
+  server.mockFile(
+    '/index.md',
+    `
+    # Synced Inputs
+
+    \`\`\`sql carrier_options
+    from flights select carrier as code, carrier as label group by 1 order by 1
+    \`\`\`
+
+    <TextInput name="search_text" title="Search Text" defaultValue="alpha" />
+    <Dropdown name="carrier_multi" data="carrier_options" value="code" label="label" title="Carriers" multiple=true />
+    <DateRange name="window" title="Window" start="2024-01-01" end="2024-01-31" />
+
+    \`\`\`sql filtered_flights
+    from flights select carrier
+    where ($search_text is null or carrier = carrier)
+      and ($carrier_multi is null or carrier in ($carrier_multi))
+      and ($window_start is null or dep_time >= $window_start)
+      and ($window_end is null or dep_time < $window_end)
+    limit 5
+    \`\`\`
+
+    <Table data="filtered_flights" />
+  `,
+  )
+
+  await page.route('**/_api/query', async route => {
+    queryBodies.push(route.request().postDataJSON())
+    await route.continue()
+  })
+
+  await page.goto(server.url() + '/?search_text=delta&carrier_multi=AA&carrier_multi=UA&window_start=2024-01-05&window_end=2024-01-12')
+  await waitForGrapheneLoad(page)
+
+  await expect(page.getByLabel('Search Text')).toHaveValue('delta')
+  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('AA')
+  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('UA')
+  await expect(page.locator('#daterange-window-start')).toHaveValue('2024-01-05')
+  await expect(page.locator('#daterange-window-end')).toHaveValue('2024-01-12')
+  await expect(page.locator('.preset-select')).toHaveValue('Last 7 Days')
+  expect(
+    queryBodies.some(
+      body =>
+        JSON.stringify(body.params) ===
+        JSON.stringify({
+          search_text: 'delta',
+          carrier_multi: ['AA', 'UA'],
+          window_start: '2024-01-05',
+          window_end: '2024-01-12',
+        }),
+    ),
+  ).toBe(true)
+
+  await page.getByLabel('Search Text').fill('omega')
+  await page.getByRole('combobox', {name: 'Carriers'}).click()
+  await page.getByRole('option', {name: 'DL'}).click()
+  await page.locator('#daterange-window-start').evaluate((el: HTMLInputElement) => {
+    el.value = '2024-01-08'
+    el.dispatchEvent(new Event('change', {bubbles: true}))
+  })
+  await expect
+    .poll(() => readSearchParams(page))
+    .toEqual({
+      search_text: 'omega',
+      carrier_multi: ['AA', 'UA', 'DL'],
+      window_start: '2024-01-08',
+      window_end: '2024-01-12',
+    })
+
+  await page.reload()
+  await waitForGrapheneLoad(page)
+  await expect(page.getByLabel('Search Text')).toHaveValue('omega')
+  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('AA')
+  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('UA')
+  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('DL')
+  await expect(page.locator('#daterange-window-start')).toHaveValue('2024-01-08')
+  await expect(page.locator('#daterange-window-end')).toHaveValue('2024-01-12')
+})
+
+test('inputs resync from url changes after navigation events', async ({server, page}) => {
+  let queryBodies: any[] = []
+  server.mockFile(
+    '/index.md',
+    `
+    # Synced Inputs
+
+    \`\`\`sql carrier_options
+    from flights select carrier as code, carrier as label group by 1 order by 1
+    \`\`\`
+
+    <TextInput name="search_text" title="Search Text" defaultValue="alpha" />
+    <Dropdown name="carrier_multi" data="carrier_options" value="code" label="label" title="Carriers" multiple=true />
+    <DateRange name="window" title="Window" start="2024-01-01" end="2024-01-31" />
+
+    \`\`\`sql filtered_flights
+    from flights select carrier
+    where ($search_text is null or carrier = carrier)
+      and ($carrier_multi is null or carrier in ($carrier_multi))
+      and ($window_start is null or dep_time >= $window_start)
+      and ($window_end is null or dep_time < $window_end)
+    limit 5
+    \`\`\`
+
+    <Table data="filtered_flights" />
+  `,
+  )
+
+  await page.route('**/_api/query', async route => {
+    queryBodies.push(route.request().postDataJSON())
+    await route.continue()
+  })
+
+  await page.goto(server.url() + '/')
+  await waitForGrapheneLoad(page)
+
+  await page.evaluate(() => {
+    history.pushState({}, '', '?search_text=sigma&carrier_multi=DL&window_start=2024-01-10&window_end=2024-01-20')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+  })
+
+  await expect(page.getByLabel('Search Text')).toHaveValue('sigma')
+  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('DL')
+  await expect(page.locator('#daterange-window-start')).toHaveValue('2024-01-10')
+  await expect(page.locator('#daterange-window-end')).toHaveValue('2024-01-20')
+  await expect
+    .poll(() => queryBodies[queryBodies.length - 1]?.params)
+    .toEqual({
+      search_text: 'sigma',
+      carrier_multi: 'DL',
+      window_start: '2024-01-10',
+      window_end: '2024-01-20',
+    })
 })


### PR DESCRIPTION
This PR adds a system to sync dashboard inputs with the URL, so that app state can be shared. There's a fair amount of state management logic in the various input components, but I tried to consolidate the syncing logic into `pageInputs.svelte.ts`

fixes #189