### PR TITLE
explicitly pass inputs to analysis pipeline

### DIFF
--- a/cli/run.ts
+++ b/cli/run.ts
@@ -7,8 +7,7 @@ import path from 'path'
 import {type PluginOption, type ViteDevServer} from 'vite'
 import {WebSocketServer, type WebSocket} from 'ws'
 
-import {FILE_MAP} from '../lang/analyze.ts'
-import {analyze, config, type GrapheneError, getDiagnostics, loadWorkspace, toSql, updateFile} from '../lang/core.ts'
+import {analyze, config, deleteFile, type GrapheneError, getDiagnostics, loadWorkspace, toSql, updateFile} from '../lang/core.ts'
 import {pollFor} from '../lang/util.ts'
 import {openInBrowser} from './auth.ts'
 import {isServerRunning, runServeInBackground} from './background.ts'
@@ -48,7 +47,7 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
     return false
   }
 
-  if (process.env.NODE_ENV == 'test') delete FILE_MAP[mdFile]
+  if (process.env.NODE_ENV == 'test') deleteFile(mdFile)
 
   let host = `http://localhost:${config.port}`
   let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -30,7 +30,7 @@ import {
   type Scope,
   type Location,
   type NavigationSymbolKind,
-  type AnalysisContext,
+  type Workspace,
   type AnalysisOptions,
 } from './types.ts'
 import {buildFrame, txt, getFile, getPosition, toRelativePath} from './util.ts'
@@ -48,11 +48,11 @@ import {buildFrame, txt, getFile, getPosition, toRelativePath} from './util.ts'
 // NB that while the first step of collecting tables can be used between runs, analysis kinda can't since the alias for a given
 // join could change from query to query.
 
-interface InternalAnalysisContext extends AnalysisContext {
+interface InternalWorkspace extends Workspace {
   nodeEntityMap: NodeWeakMap<any>
 }
 
-export function createAnalysisContext(files: Record<string, FileInfo>, options: AnalysisOptions): AnalysisContext {
+export function createAnalysisContext(files: Record<string, FileInfo>, options: AnalysisOptions): Workspace {
   return {
     files,
     diagnostics: [],
@@ -61,8 +61,8 @@ export function createAnalysisContext(files: Record<string, FileInfo>, options: 
   }
 }
 
-function internalizeContext(ctx: AnalysisContext): InternalAnalysisContext {
-  let internal = ctx as InternalAnalysisContext
+function internalizeContext(ctx: Workspace): InternalWorkspace {
+  let internal = ctx as InternalWorkspace
   internal.nodeEntityMap ||= new NodeWeakMap()
   return internal
 }
@@ -92,7 +92,7 @@ function addReference(kind: NavigationSymbolKind, node: SyntaxNode, targetId?: s
 }
 
 // Creates tables without analyzing them.
-export function findTables(ctx: AnalysisContext, fi: FileInfo) {
+export function findTables(ctx: Workspace, fi: FileInfo) {
   let tn = fi.tree!.topNode
   fi.tables = []
   let nodes = tn.getChildren('TableStatement').concat(tn.getChildren('ViewStatement'))
@@ -121,7 +121,7 @@ export function findTables(ctx: AnalysisContext, fi: FileInfo) {
 }
 
 // `extend` blocks add columns and joins to existing tables
-export function applyExtends(ctx: AnalysisContext, fi: FileInfo) {
+export function applyExtends(ctx: Workspace, fi: FileInfo) {
   fi.tree!.topNode.getChildren('ExtendStatement').forEach(node => {
     let target = lookupTable(ctx, node.getChild('Ref')!)
     if (!target) return
@@ -130,7 +130,7 @@ export function applyExtends(ctx: AnalysisContext, fi: FileInfo) {
   })
 }
 
-function addColumn(ctx: AnalysisContext, table: Table, node: SyntaxNode) {
+function addColumn(ctx: Workspace, table: Table, node: SyntaxNode) {
   let nameNode = node.getChild('ColumnName')!
   let name = txt(nameNode)
   let type = convertDataType(txt(node.getChild('DataType')))
@@ -141,7 +141,7 @@ function addColumn(ctx: AnalysisContext, table: Table, node: SyntaxNode) {
   table.columns.push(col)
 }
 
-function addJoin(ctx: AnalysisContext, table: Table, node: SyntaxNode) {
+function addJoin(ctx: Workspace, table: Table, node: SyntaxNode) {
   let aliasNode = node.getChild('Alias') || node.getChild('Ref')!.getChildren('Identifier').pop()
   let alias = txt(aliasNode)
 
@@ -158,7 +158,7 @@ function addJoin(ctx: AnalysisContext, table: Table, node: SyntaxNode) {
   table.joins.push(join)
 }
 
-function addComputedColumn(ctx: AnalysisContext, table: Table, node: SyntaxNode) {
+function addComputedColumn(ctx: Workspace, table: Table, node: SyntaxNode) {
   let nameNode = node.getChild('Alias')!
   let name = txt(nameNode)
   let col: Column = {name, type: 'string', exprNode: node.getChild('Expression')!, metadata: extractLeadingMetadata(node)}
@@ -174,7 +174,7 @@ function getField(name: string, table: Table) {
 // Analyze a view's underlying query to determine its output columns.
 // Converts a PhysicalTable with a QueryStatement into a ViewTable with a query.
 // Returns true if the table is (or was already) a successfully analyzed view.
-function analyzeView(ctx: AnalysisContext, table: Table) {
+function analyzeView(ctx: Workspace, table: Table) {
   if (table.type != 'view') return
   if (table.analyzed) return
   table.analyzed = true
@@ -195,7 +195,7 @@ function analyzeView(ctx: AnalysisContext, table: Table) {
 }
 
 // Analyze everything in a table - used for full project analysis (e.g., `check` command)
-export function analyzeTableFully(ctx: AnalysisContext, table: Table) {
+export function analyzeTableFully(ctx: Workspace, table: Table) {
   if (table.type == 'view') analyzeView(ctx, table)
   let scope: Scope = {table, alias: table.name, fanoutPath: []}
   table.columns.forEach(c => {
@@ -215,7 +215,7 @@ export function analyzeTableFully(ctx: AnalysisContext, table: Table) {
 // Expand non-aggregate columns into query fields.
 // When table is provided, expands that single table's columns.
 // When table is null, expands all root-visible query tables (base + ad-hoc joins).
-function expandColumns(ctx: AnalysisContext, table: Table | null, alias: string, query: Query, scope: Scope, namePrefix = '') {
+function expandColumns(ctx: Workspace, table: Table | null, alias: string, query: Query, scope: Scope, namePrefix = '') {
   if (!table) {
     let baseJoin = query.joins.find(j => j.source == 'from')
     if (!baseJoin?.table) return
@@ -255,7 +255,7 @@ function expandColumns(ctx: AnalysisContext, table: Table | null, alias: string,
 }
 
 // Main query analysis - analyzes and returns a Query with computed SQL
-export function analyzeQuery(ctx: AnalysisContext, queryNode: SyntaxNode, outerCtes?: Table[]): Query | void {
+export function analyzeQuery(ctx: Workspace, queryNode: SyntaxNode, outerCtes?: Table[]): Query | void {
   let query: Query = {sql: '', fields: [], joins: [], filters: [], groupBy: [], orderBy: []}
   let ctes = new Map<string, CteTable>()
   let scope: Scope = {query, alias: '', fanoutPath: [], otherTables: outerCtes || []}
@@ -498,7 +498,7 @@ function buildSql(query: Query, cteMap: Map<string, CteTable>, options: Analysis
 }
 
 // Analyze an expression node and return SQL + type info
-export function analyzeExpr(ctx: AnalysisContext, node: SyntaxNode, scope: Scope): Expr {
+export function analyzeExpr(ctx: Workspace, node: SyntaxNode, scope: Scope): Expr {
   if (node.type.isError) return diag(ctx, node, 'Invalid expression', {sql: 'NULL', type: 'error'})
 
   switch (node.name) {
@@ -833,7 +833,7 @@ export function analyzeExpr(ctx: AnalysisContext, node: SyntaxNode, scope: Scope
   }
 }
 
-function analyzeDateArithmetic(ctx: AnalysisContext, op: '+' | '-', left: Expr, right: Expr, node: SyntaxNode): Expr {
+function analyzeDateArithmetic(ctx: Workspace, op: '+' | '-', left: Expr, right: Expr, node: SyntaxNode): Expr {
   let merged = mergeExprAnalysis([left, right], '', 'number', left.isAgg || right.isAgg)
   let dialect = ctx.options.dialect
 
@@ -866,7 +866,7 @@ function analyzeDateArithmetic(ctx: AnalysisContext, op: '+' | '-', left: Expr, 
   return diag(ctx, node, 'Invalid date arithmetic', {sql: 'NULL', type: 'error'})
 }
 
-function analyzeIntervalMultiplication(ctx: AnalysisContext, left: Expr, right: Expr, node: SyntaxNode): Expr | null {
+function analyzeIntervalMultiplication(ctx: Workspace, left: Expr, right: Expr, node: SyntaxNode): Expr | null {
   if (left.type == 'number' && right.type == 'interval') {
     return scaleInterval(ctx, left, right, node.lastChild!)
   }
@@ -876,7 +876,7 @@ function analyzeIntervalMultiplication(ctx: AnalysisContext, left: Expr, right: 
   return null
 }
 
-function scaleInterval(ctx: AnalysisContext, multiplier: Expr, intervalExpr: Expr, node: SyntaxNode): Expr {
+function scaleInterval(ctx: Workspace, multiplier: Expr, intervalExpr: Expr, node: SyntaxNode): Expr {
   if (!intervalExpr.interval) return diag(ctx, node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
   if (intervalExpr.interval.form != 'constant') return diag(ctx, node, 'Only literal intervals can be multiplied', {sql: 'NULL', type: 'error'})
   let quantitySql = intervalExpr.interval.quantitySql == '1' ? multiplier.sql : `${multiplier.sql}*${intervalExpr.interval.quantitySql}`
@@ -888,7 +888,7 @@ function scaleInterval(ctx: AnalysisContext, multiplier: Expr, intervalExpr: Exp
   }
 }
 
-function coerceToTemporal(ctx: AnalysisContext, expr: Expr, targetType: 'date' | 'timestamp', node: SyntaxNode): Expr {
+function coerceToTemporal(ctx: Workspace, expr: Expr, targetType: 'date' | 'timestamp', node: SyntaxNode): Expr {
   // Extract the string literal value (remove quotes)
   let match = expr.sql.match(/^'(.+)'$/)
   if (!match) return expr
@@ -914,7 +914,7 @@ function isPercentileWindowSpecSupported(overClause: SyntaxNode): boolean {
   return true
 }
 
-function renderOverClause(ctx: AnalysisContext, overClause: SyntaxNode, scope: Scope): string {
+function renderOverClause(ctx: Workspace, overClause: SyntaxNode, scope: Scope): string {
   let spec = overClause.getChild('WindowSpec')
   if (!spec) return ''
   let parts: string[] = []
@@ -941,7 +941,7 @@ function renderOverClause(ctx: AnalysisContext, overClause: SyntaxNode, scope: S
   return parts.join(' ')
 }
 
-function renderWindowFrame(ctx: AnalysisContext, frame: SyntaxNode, scope: Scope): string {
+function renderWindowFrame(ctx: Workspace, frame: SyntaxNode, scope: Scope): string {
   let mode = txt(frame.getChildren('Kw')[0]).toUpperCase()
   let between = frame.getChild('WindowFrameBetween')
   if (between) {
@@ -952,7 +952,7 @@ function renderWindowFrame(ctx: AnalysisContext, frame: SyntaxNode, scope: Scope
   return `${mode} ${renderWindowBound(ctx, start, scope)}`
 }
 
-function renderWindowBound(ctx: AnalysisContext, bound: SyntaxNode, scope: Scope): string {
+function renderWindowBound(ctx: Workspace, bound: SyntaxNode, scope: Scope): string {
   let kws = bound.getChildren('Kw').map(k => txt(k).toLowerCase())
   if (kws.includes('unbounded')) {
     return `UNBOUNDED ${kws.includes('following') ? 'FOLLOWING' : 'PRECEDING'}`
@@ -963,7 +963,7 @@ function renderWindowBound(ctx: AnalysisContext, bound: SyntaxNode, scope: Scope
 }
 
 // Traverse a join path (like `tableA.tableB.`), returning a new scope pointing to the target table. Adds implied joins to the query as it goes
-function followJoins(ctx: AnalysisContext, pathNodes: SyntaxNode[], scope: Scope): Scope | null {
+function followJoins(ctx: Workspace, pathNodes: SyntaxNode[], scope: Scope): Scope | null {
   let part = pathNodes[0]
   let name = txt(part)
 
@@ -1048,7 +1048,7 @@ function mergeExprAnalysis(exprs: Expr[], sql: string, type: FieldType, isAgg?: 
   }
 }
 
-function analyzeComputedFieldExpr(ctx: AnalysisContext, node: SyntaxNode, expr: Expr) {
+function analyzeComputedFieldExpr(ctx: Workspace, node: SyntaxNode, expr: Expr) {
   if (expr.fanout?.conflict) diag(ctx, node, 'Join graph creates a chasm trap')
   if (!expr.isAgg && !isBaseFanoutPath(expr.fanout?.path)) diag(ctx, node, fanoutMessage(expr.fanout?.path, 'aggregate it first'))
   let paths = uniqueFanoutPaths(expr.fanout?.sensitivePaths || [])
@@ -1057,7 +1057,7 @@ function analyzeComputedFieldExpr(ctx: AnalysisContext, node: SyntaxNode, expr: 
   }
 }
 
-function analyzeAggregateQueryExpr(ctx: AnalysisContext, node: SyntaxNode, expr: Expr) {
+function analyzeAggregateQueryExpr(ctx: Workspace, node: SyntaxNode, expr: Expr) {
   if (expr.fanout?.conflict) diag(ctx, node, 'Join graph creates a chasm trap')
 }
 
@@ -1066,7 +1066,7 @@ function analyzeAggregateQueryExpr(ctx: AnalysisContext, node: SyntaxNode, expr:
 // aggregate grains into the more specific cases we can explain clearly (chasm trap, a base
 // aggregate fanned out by one join, an ancestor aggregate fanned out by a descendant join,
 // or the generic join-graph fanout fallback).
-function analyzeAggregateQueryFanout(ctx: AnalysisContext, exprs: {node: SyntaxNode; expr: Expr}[]) {
+function analyzeAggregateQueryFanout(ctx: Workspace, exprs: {node: SyntaxNode; expr: Expr}[]) {
   let aggExprs = exprs.filter(entry => entry.expr.isAgg)
   let paths = uniqueFanoutPaths(aggExprs.flatMap(entry => entry.expr.fanout?.sensitivePaths || []))
   if (paths.length == 0) return
@@ -1158,7 +1158,7 @@ function analyzeAggregateQueryFanout(ctx: AnalysisContext, exprs: {node: SyntaxN
 }
 
 // Find a table by Ref node, failing if it doesn't exist
-function lookupTable(ctx: AnalysisContext, node: SyntaxNode, scope?: Scope): Table | undefined {
+function lookupTable(ctx: Workspace, node: SyntaxNode, scope?: Scope): Table | undefined {
   let name = txt(node)
   let table: Table | undefined
 
@@ -1191,7 +1191,7 @@ function inferName(exprNode: SyntaxNode, scope: Scope): string {
 }
 
 // TODO: do we still need this?
-function unpackAnds(ctx: AnalysisContext, node: SyntaxNode, scope: Scope): Expr[] {
+function unpackAnds(ctx: Workspace, node: SyntaxNode, scope: Scope): Expr[] {
   if (node.name == 'BinaryExpression') {
     let op = txt(node.firstChild?.nextSibling).toLowerCase()
     if (op == 'and') {
@@ -1201,13 +1201,13 @@ function unpackAnds(ctx: AnalysisContext, node: SyntaxNode, scope: Scope): Expr[
   return [analyzeExpr(ctx, node, scope)]
 }
 
-export function recordSyntaxErrors(ctx: AnalysisContext, fi: FileInfo) {
+export function recordSyntaxErrors(ctx: Workspace, fi: FileInfo) {
   fi.tree!.topNode.cursor().iterate(n => {
     if (n.type.isError) diag(ctx, n.node, 'Syntax error')
   })
 }
 
-export function diag<T>(ctx: AnalysisContext, node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T {
+export function diag<T>(ctx: Workspace, node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T {
   let file = getFile(node)
   let from = getPosition(node.from, file)
   let to = getPosition(node.to, file)
@@ -1215,7 +1215,7 @@ export function diag<T>(ctx: AnalysisContext, node: SyntaxNode | SyntaxNodeRef, 
   return defaultReturn as T
 }
 
-export function checkTypes(ctx: AnalysisContext, expr: Expr, expected: FieldType[], node: SyntaxNode) {
+export function checkTypes(ctx: Workspace, expr: Expr, expected: FieldType[], node: SyntaxNode) {
   if (expr.type == 'error' || expr.type == 'null') return
   if (expected.includes(expr.type)) return
   diag(ctx, node, `Expected ${expected.join(' or ')}, got ${expr.type}`)

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -1,6 +1,5 @@
 import {NodeWeakMap, type SyntaxNode, type SyntaxNodeRef} from '@lezer/common'
 
-import {config} from './config.ts'
 import {
   aggregateFanoutMessage,
   normalizeExprFanout,
@@ -25,13 +24,14 @@ import {
   type Column,
   type FieldType,
   type FileInfo,
-  type GrapheneError,
   type Expr,
   type CteTable,
   type JoinType,
   type Scope,
   type Location,
   type NavigationSymbolKind,
+  type AnalysisContext,
+  type AnalysisOptions,
 } from './types.ts'
 import {buildFrame, txt, getFile, getPosition, toRelativePath} from './util.ts'
 
@@ -48,10 +48,24 @@ import {buildFrame, txt, getFile, getPosition, toRelativePath} from './util.ts'
 // NB that while the first step of collecting tables can be used between runs, analysis kinda can't since the alias for a given
 // join could change from query to query.
 
-export let FILE_MAP: Record<string, FileInfo> = {} // All the files in the workspace and their tables/queries
-export let diagnostics: GrapheneError[] = [] // Tracks errors/warnings
-let analysisStack = new Set<Column>() // Track computed columns being analyzed to detect cycles
-let NODE_ENTITY_MAP = new NodeWeakMap<any>() // Points syntax nodes back to entities for ide hover tips
+interface InternalAnalysisContext extends AnalysisContext {
+  nodeEntityMap: NodeWeakMap<any>
+}
+
+export function createAnalysisContext(files: Record<string, FileInfo>, options: AnalysisOptions): AnalysisContext {
+  return {
+    files,
+    diagnostics: [],
+    options,
+    analysisStack: new Set<Column>(),
+  }
+}
+
+function internalizeContext(ctx: AnalysisContext): InternalAnalysisContext {
+  let internal = ctx as InternalAnalysisContext
+  internal.nodeEntityMap ||= new NodeWeakMap()
+  return internal
+}
 
 function locationForNode(node: SyntaxNode): Location {
   let file = getFile(node)
@@ -78,7 +92,7 @@ function addReference(kind: NavigationSymbolKind, node: SyntaxNode, targetId?: s
 }
 
 // Creates tables without analyzing them.
-export function findTables(fi: FileInfo) {
+export function findTables(ctx: AnalysisContext, fi: FileInfo) {
   let tn = fi.tree!.topNode
   fi.tables = []
   let nodes = tn.getChildren('TableStatement').concat(tn.getChildren('ViewStatement'))
@@ -86,70 +100,70 @@ export function findTables(fi: FileInfo) {
     let refNode = syntaxNode.getChild('Ref')!
     let name = txt(refNode)
 
-    let existing = Object.values(FILE_MAP).find(f => {
+    let existing = Object.values(ctx.files).find(f => {
       if (f.path.endsWith('.md') && f.path != fi.path) return
       return f.tables.find(t => t.name == name)
     })
-    if (existing) diag(refNode, `Table "${name}" is already defined`)
+    if (existing) diag(ctx, refNode, `Table "${name}" is already defined`)
 
     let hasNamespace = name.includes('.')
-    let tablePath = !hasNamespace && config.defaultNamespace ? `${config.defaultNamespace}.${name}` : name
+    let tablePath = !hasNamespace && ctx.options.defaultNamespace ? `${ctx.options.defaultNamespace}.${name}` : name
     let type = syntaxNode.getChild('QueryStatement') ? 'view' : ('table' as const)
     let table = {name, type, tablePath, columns: [], joins: [], metadata: extractLeadingMetadata(syntaxNode), syntaxNode} as Table
     Object.assign(table, addSymbol('table', refNode, name))
 
-    syntaxNode.getChildren('ColumnDef').forEach(cn => addColumn(table, cn))
-    syntaxNode.getChildren('JoinDef').forEach(jn => addJoin(table, jn))
-    syntaxNode.getChildren('ComputedDef').forEach(cn => addComputedColumn(table, cn))
+    syntaxNode.getChildren('ColumnDef').forEach(cn => addColumn(ctx, table, cn))
+    syntaxNode.getChildren('JoinDef').forEach(jn => addJoin(ctx, table, jn))
+    syntaxNode.getChildren('ComputedDef').forEach(cn => addComputedColumn(ctx, table, cn))
 
     fi.tables.push(table)
   }
 }
 
 // `extend` blocks add columns and joins to existing tables
-export function applyExtends(fi: FileInfo) {
+export function applyExtends(ctx: AnalysisContext, fi: FileInfo) {
   fi.tree!.topNode.getChildren('ExtendStatement').forEach(node => {
-    let target = lookupTable(node.getChild('Ref')!)
+    let target = lookupTable(ctx, node.getChild('Ref')!)
     if (!target) return
-    node.getChildren('JoinDef').forEach(jn => addJoin(target, jn))
-    node.getChildren('ComputedDef').forEach(cn => addComputedColumn(target, cn))
+    node.getChildren('JoinDef').forEach(jn => addJoin(ctx, target, jn))
+    node.getChildren('ComputedDef').forEach(cn => addComputedColumn(ctx, target, cn))
   })
 }
 
-function addColumn(table: Table, node: SyntaxNode) {
+function addColumn(ctx: AnalysisContext, table: Table, node: SyntaxNode) {
   let nameNode = node.getChild('ColumnName')!
   let name = txt(nameNode)
   let type = convertDataType(txt(node.getChild('DataType')))
-  if (!type) return diag(node, `Unsupported data type: ${txt(node.getChild('DataType'))}`)
+  if (!type) return diag(ctx, node, `Unsupported data type: ${txt(node.getChild('DataType'))}`)
   let col: Column = {name, type, metadata: extractLeadingMetadata(node)}
   Object.assign(col, addSymbol('column', nameNode, name, {tableId: table.symbolId}))
-  if (getField(name, table)) return diag(node, `Table already has a field called "${name}"`)
+  if (getField(name, table)) return diag(ctx, node, `Table already has a field called "${name}"`)
   table.columns.push(col)
 }
 
-function addJoin(table: Table, node: SyntaxNode) {
+function addJoin(ctx: AnalysisContext, table: Table, node: SyntaxNode) {
   let aliasNode = node.getChild('Alias') || node.getChild('Ref')!.getChildren('Identifier').pop()
   let alias = txt(aliasNode)
 
   let joinTypeStr = txt(node.getChild('JoinType')).replace(/\s+/g, ' ')
   let cardinality = {'join many': 'many', 'join one': 'one'}[joinTypeStr] as 'one' | 'many'
-  if (!cardinality) return diag(node, 'Unknown join type')
+  if (!cardinality) return diag(ctx, node, 'Unknown join type')
 
   let targetNode = node.getChild('Ref')!
   let targetTable = txt(targetNode)
   let onExpr = node.getChild('BinaryExpression')!
 
   let join: QueryJoin = {alias, source: 'implicit', targetTable, cardinality, onExpr, targetNode}
-  if (getField(alias, table)) return diag(node, `Table already has a field called "${alias}"`)
+  if (getField(alias, table)) return diag(ctx, node, `Table already has a field called "${alias}"`)
   table.joins.push(join)
 }
 
-function addComputedColumn(table: Table, node: SyntaxNode) {
+function addComputedColumn(ctx: AnalysisContext, table: Table, node: SyntaxNode) {
   let nameNode = node.getChild('Alias')!
   let name = txt(nameNode)
   let col: Column = {name, type: 'string', exprNode: node.getChild('Expression')!, metadata: extractLeadingMetadata(node)}
   Object.assign(col, addSymbol('column', nameNode, name, {tableId: table.symbolId}))
-  if (getField(name, table)) return diag(node, `Table already has a field called "${name}"`)
+  if (getField(name, table)) return diag(ctx, node, `Table already has a field called "${name}"`)
   table.columns.push(col)
 }
 
@@ -160,12 +174,12 @@ function getField(name: string, table: Table) {
 // Analyze a view's underlying query to determine its output columns.
 // Converts a PhysicalTable with a QueryStatement into a ViewTable with a query.
 // Returns true if the table is (or was already) a successfully analyzed view.
-function analyzeView(table: Table) {
+function analyzeView(ctx: AnalysisContext, table: Table) {
   if (table.type != 'view') return
   if (table.analyzed) return
   table.analyzed = true
 
-  let query = analyzeQuery(table.syntaxNode!.getChild('QueryStatement')!)
+  let query = analyzeQuery(ctx, table.syntaxNode!.getChild('QueryStatement')!)
   if (!query) return
 
   let viewCols = query.fields.map(f => {
@@ -181,33 +195,33 @@ function analyzeView(table: Table) {
 }
 
 // Analyze everything in a table - used for full project analysis (e.g., `check` command)
-export function analyzeTableFully(table: Table) {
-  if (table.type == 'view') analyzeView(table)
+export function analyzeTableFully(ctx: AnalysisContext, table: Table) {
+  if (table.type == 'view') analyzeView(ctx, table)
   let scope: Scope = {table, alias: table.name, fanoutPath: []}
   table.columns.forEach(c => {
     if (!c.exprNode) return
-    let expr = analyzeExpr(c.exprNode, scope)
+    let expr = analyzeExpr(ctx, c.exprNode, scope)
     c.isAgg = expr.isAgg
-    analyzeComputedFieldExpr(c.exprNode, expr)
+    analyzeComputedFieldExpr(ctx, c.exprNode, expr)
   })
   table.joins.forEach(j => {
-    j.table = lookupTable(j.targetNode!)
+    j.table = lookupTable(ctx, j.targetNode!)
     if (!j.table || !j.onExpr) return
     let joinTarget = {name: j.alias, table: j.table, alias: j.alias}
-    analyzeExpr(j.onExpr, {table, alias: table.name, fanoutPath: [], joinTarget})
+    analyzeExpr(ctx, j.onExpr, {table, alias: table.name, fanoutPath: [], joinTarget})
   })
 }
 
 // Expand non-aggregate columns into query fields.
 // When table is provided, expands that single table's columns.
 // When table is null, expands all root-visible query tables (base + ad-hoc joins).
-function expandColumns(table: Table | null, alias: string, query: Query, scope: Scope, namePrefix = '') {
+function expandColumns(ctx: AnalysisContext, table: Table | null, alias: string, query: Query, scope: Scope, namePrefix = '') {
   if (!table) {
     let baseJoin = query.joins.find(j => j.source == 'from')
     if (!baseJoin?.table) return
-    expandColumns(baseJoin.table, baseJoin.alias, query, scope)
+    expandColumns(ctx, baseJoin.table, baseJoin.alias, query, scope)
     for (let join of query.joins.filter(j => j.source == 'ad-hoc')) {
-      if (join.table) expandColumns(join.table, join.alias, query, scope, join.alias)
+      if (join.table) expandColumns(ctx, join.table, join.alias, query, scope, join.alias)
     }
     return
   }
@@ -215,10 +229,10 @@ function expandColumns(table: Table | null, alias: string, query: Query, scope: 
     let outName = namePrefix ? `${namePrefix}_${col.name}` : col.name
     if (col.exprNode) {
       // Determine if aggregate (without query context to avoid side-effect diagnostics), then skip measures
-      if (col.isAgg == null) col.isAgg = analyzeExpr(col.exprNode, {table, alias, fanoutPath: scope.fanoutPath}).isAgg
+      if (col.isAgg == null) col.isAgg = analyzeExpr(ctx, col.exprNode, {table, alias, fanoutPath: scope.fanoutPath}).isAgg
       if (col.isAgg) continue
-      let expr = analyzeExpr(col.exprNode, {query: scope.query, table, alias, otherTables: scope.otherTables, fanoutPath: scope.fanoutPath})
-      if (expr.type == 'interval' && expr.interval?.form == 'scaled') diag(col.exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
+      let expr = analyzeExpr(ctx, col.exprNode, {query: scope.query, table, alias, otherTables: scope.otherTables, fanoutPath: scope.fanoutPath})
+      if (expr.type == 'interval' && expr.interval?.form == 'scaled') diag(ctx, col.exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
       query.fields.push({
         name: outName,
         sql: expr.sql,
@@ -241,7 +255,7 @@ function expandColumns(table: Table | null, alias: string, query: Query, scope: 
 }
 
 // Main query analysis - analyzes and returns a Query with computed SQL
-export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query | void {
+export function analyzeQuery(ctx: AnalysisContext, queryNode: SyntaxNode, outerCtes?: Table[]): Query | void {
   let query: Query = {sql: '', fields: [], joins: [], filters: [], groupBy: [], orderBy: []}
   let ctes = new Map<string, CteTable>()
   let scope: Scope = {query, alias: '', fanoutPath: [], otherTables: outerCtes || []}
@@ -252,7 +266,7 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
   let withClauses = queryNode.getChild('WithClause')?.getChildren('CteDef') || []
   for (let cteDef of withClauses) {
     let name = txt(cteDef.getChild('Alias'))
-    let query = analyzeQuery(cteDef.getChild('QueryStatement')!, scope.otherTables)
+    let query = analyzeQuery(ctx, cteDef.getChild('QueryStatement')!, scope.otherTables)
     if (!query) return
     let columns = query.fields.map(f => ({name: f.name, type: f.type, metadata: f.metadata}) as Column)
     let cte: CteTable = {name, type: 'cte', tablePath: name, columns, joins: [], query}
@@ -267,21 +281,21 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
   for (let sourceNode of sources) {
     let isJoin = sourceNode.name == 'JoinClause'
     let tablePrimary = sourceNode.getChild('TablePrimary')
-    if (!tablePrimary) return diag(sourceNode, `Invalid ${isJoin ? 'JOIN' : 'FROM'} source`)
+    if (!tablePrimary) return diag(ctx, sourceNode, `Invalid ${isJoin ? 'JOIN' : 'FROM'} source`)
     let alias = txt(tablePrimary.getChild('Alias'))
     let table: Table | undefined
 
     // This might be referring to a table by name
     let refNode = tablePrimary.getChild('Ref') || undefined
     if (refNode) {
-      table = lookupTable(refNode, scope)
+      table = lookupTable(ctx, refNode, scope)
       if (!table) return
       alias ||= txt(refNode.getChildren('Identifier').at(-1))
     }
 
     // or it could be a subquery
     if (tablePrimary.getChild('SubqueryExpression')) {
-      let subquery = analyzeQuery(tablePrimary.getChild('SubqueryExpression')!.getChild('QueryStatement')!, scope.otherTables)
+      let subquery = analyzeQuery(ctx, tablePrimary.getChild('SubqueryExpression')!.getChild('QueryStatement')!, scope.otherTables)
       if (!subquery) return
       let columns = subquery.fields.map(f => ({name: f.name, type: f.type, metadata: f.metadata}) as Column)
       table = {name: 'subquery', type: 'subquery', tablePath: alias, columns, joins: [], query: subquery}
@@ -293,17 +307,17 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
     if (firstKw == 'left' || firstKw == 'right' || firstKw == 'full' || firstKw == 'cross') joinType = firstKw
 
     // Now that we have all the bits, construct the join for it.
-    if (query.joins.find(j => j.alias == alias)) return diag(tablePrimary, `Query already has table called "${alias}"`)
+    if (query.joins.find(j => j.alias == alias)) return diag(ctx, tablePrimary, `Query already has table called "${alias}"`)
     let onExpr = sourceNode.getChild('Expression') || undefined
     let qj: QueryJoin = {alias, source: isJoin ? 'ad-hoc' : 'from', table, joinType, fanoutPath: [], onExpr}
     query.joins.push(qj)
-    NODE_ENTITY_MAP.set(tablePrimary, {entityType: 'table', table})
+    internalizeContext(ctx).nodeEntityMap.set(tablePrimary, {entityType: 'table', table})
 
     // If this is a JOIN, analyze the ON expr
     // It's important we do this _after_ adding the join to the query, since analyzing the expression looks at the query
-    if (joinType == 'cross' && onExpr) return diag(sourceNode, 'CROSS JOIN cannot have an ON clause')
-    if (isJoin && !onExpr && joinType != 'cross') return diag(sourceNode, `${joinType!.toUpperCase()} JOIN requires an ON clause`)
-    qj.onClause = onExpr && analyzeExpr(onExpr, {query, alias: '', otherTables: scope.otherTables}).sql
+    if (joinType == 'cross' && onExpr) return diag(ctx, sourceNode, 'CROSS JOIN cannot have an ON clause')
+    if (isJoin && !onExpr && joinType != 'cross') return diag(ctx, sourceNode, `${joinType!.toUpperCase()} JOIN requires an ON clause`)
+    qj.onClause = onExpr && analyzeExpr(ctx, onExpr, {query, alias: '', otherTables: scope.otherTables}).sql
   }
 
   // SELECT clause
@@ -314,18 +328,18 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
     if (s.getChild('Wildcard')) {
       let pathNodes = s.getChild('Wildcard')!.getChildren('Identifier')
       if (pathNodes.length == 0) {
-        expandColumns(null, '', query, scope)
+        expandColumns(ctx, null, '', query, scope)
         continue
       }
-      let targetScope = followJoins(pathNodes, scope)
+      let targetScope = followJoins(ctx, pathNodes, scope)
       if (!targetScope) continue
       if (!targetScope.table) continue
-      expandColumns(targetScope.table, targetScope.alias, query, targetScope)
+      expandColumns(ctx, targetScope.table, targetScope.alias, query, targetScope)
     } else {
       let exprNode = s.getChild('Expression')!
       let aliasNode = s.getChild('Alias')
-      let expr = analyzeExpr(exprNode, scope)
-      if (expr.type == 'interval' && expr.interval?.form == 'scaled') diag(exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
+      let expr = analyzeExpr(ctx, exprNode, scope)
+      if (expr.type == 'interval' && expr.interval?.form == 'scaled') diag(ctx, exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
       let name = aliasNode ? txt(aliasNode) : inferName(exprNode, scope)
       isAgg ||= !!expr.isAgg
       query.fields.push({
@@ -345,7 +359,7 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
   let havingNode = queryNode.getChild('HavingClause')?.getChild('Expression')
   for (let node of [whereNode, havingNode]) {
     if (!node) continue
-    for (let expr of unpackAnds(node, scope)) {
+    for (let expr of unpackAnds(ctx, node, scope)) {
       query.filters.push({sql: expr.sql, isAgg: expr.isAgg})
       fanoutExprs.push({node, expr})
     }
@@ -360,13 +374,13 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
     // Positional GROUP BY (e.g. `group by 2, 1`) references the current SELECT list.
     if (exprNode.name == 'Number' && !alias) {
       let f = query.fields[Number(txt(exprNode)) - 1]
-      if (!f) diag(g, 'No field at index ' + txt(exprNode))
+      if (!f) diag(ctx, g, 'No field at index ' + txt(exprNode))
       query.groupBy.push(f?.name)
     } else {
       // Otherwise, we can assume this is an expression (possibly with an alias)
       // If that expression is already in the selected fields, it's just a reference.
-      let expr = analyzeExpr(exprNode, scope)
-      if (expr.isAgg) diag(g, 'Cannot group by aggregate expressions')
+      let expr = analyzeExpr(ctx, exprNode, scope)
+      if (expr.isAgg) diag(ctx, g, 'Cannot group by aggregate expressions')
       let name = g.getChild('Alias') ? txt(g.getChild('Alias')) : inferName(exprNode, scope)
       query.groupBy.push(name)
 
@@ -392,19 +406,19 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
     let desc = txt(o.getChild('Kw')).toLowerCase() == 'desc'
     let idx = Number(fieldRef) || query.fields.findIndex(f => f.name == fieldRef) + 1
     if (idx > 0) orderBy.push({idx, desc})
-    else if (fieldRef && isNaN(Number(fieldRef))) diag(o, `Unknown field in ORDER BY: ${fieldRef}`)
+    else if (fieldRef && isNaN(Number(fieldRef))) diag(ctx, o, `Unknown field in ORDER BY: ${fieldRef}`)
   }
 
   // LIMIT
   let limitNodes = queryNode.getChild('LimitClause')?.getChildren('Number') || []
   let limit = limitNodes[0] ? Number(txt(limitNodes[0])) : undefined
-  if (limitNodes[1]) diag(limitNodes[1], 'OFFSET is not supported yet')
+  if (limitNodes[1]) diag(ctx, limitNodes[1], 'OFFSET is not supported yet')
 
   // Implicit `select *` if nothing selected (only when we have a base table)
   let baseJoin = query.joins.find(j => j.source == 'from')
   if (query.fields.length == 0 && baseJoin?.table) {
     let hasAdHoc = query.joins.some(j => j.source == 'ad-hoc')
-    expandColumns(hasAdHoc ? null : baseJoin.table, baseJoin.alias, query, scope)
+    expandColumns(ctx, hasAdHoc ? null : baseJoin.table, baseJoin.alias, query, scope)
   }
 
   // Default ORDER BY for aggregate queries
@@ -419,22 +433,22 @@ export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query 
   query.orderBy = orderBy
   query.limit = limit
   if (isAgg) {
-    fanoutExprs.forEach(({node, expr}) => analyzeAggregateQueryExpr(node, expr))
-    analyzeAggregateQueryFanout(fanoutExprs)
+    fanoutExprs.forEach(({node, expr}) => analyzeAggregateQueryExpr(ctx, node, expr))
+    analyzeAggregateQueryFanout(ctx, fanoutExprs)
   }
-  query.sql = buildSql(query, ctes)
+  query.sql = buildSql(query, ctes, ctx.options)
   return query
 }
 
 // Assemble query parts into final SQL
 // Format a table path for the current dialect
-function formatTablePath(path: string): string {
-  if (config.dialect === 'bigquery') return `\`${path}\``
-  if (config.dialect === 'snowflake') return path.toUpperCase()
+function formatTablePath(path: string, options: AnalysisOptions): string {
+  if (options.dialect === 'bigquery') return `\`${path}\``
+  if (options.dialect === 'snowflake') return path.toUpperCase()
   return path
 }
 
-function buildSql(query: Query, cteMap: Map<string, CteTable>): string {
+function buildSql(query: Query, cteMap: Map<string, CteTable>, options: AnalysisOptions): string {
   let ctes: string[] = [...cteMap.values()].map(c => `${c.name} as ( ${c.query.sql} )`)
   let selectParts = query.fields.map(f => `${f.sql} as ${f.name}`)
   let baseJoin = query.joins.find(j => j.source == 'from')
@@ -450,7 +464,7 @@ function buildSql(query: Query, cteMap: Map<string, CteTable>): string {
       return table.name
     }
     if (table.type === 'subquery') return `( ${table.query.sql} )`
-    return formatTablePath(table.tablePath)
+    return formatTablePath(table.tablePath, options)
   }
 
   let fromTable = renderTableRef(baseJoin.table)
@@ -484,8 +498,8 @@ function buildSql(query: Query, cteMap: Map<string, CteTable>): string {
 }
 
 // Analyze an expression node and return SQL + type info
-export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
-  if (node.type.isError) return diag(node, 'Invalid expression', {sql: 'NULL', type: 'error'})
+export function analyzeExpr(ctx: AnalysisContext, node: SyntaxNode, scope: Scope): Expr {
+  if (node.type.isError) return diag(ctx, node, 'Invalid expression', {sql: 'NULL', type: 'error'})
 
   switch (node.name) {
     case 'Number':
@@ -513,7 +527,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       }
 
       // Follow any dot path (e.g., `users.orders` in `users.orders.amount`), then find the field
-      let targetScope = followJoins(pathNodes, scope)
+      let targetScope = followJoins(ctx, pathNodes, scope)
       if (!targetScope) return {sql: 'NULL', type: 'error'}
 
       // Build the list of tables to search: if followJoins landed on a specific table, just that one.
@@ -525,30 +539,30 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       // Expect just one of the possibleJoins to have the named column. Otherwise, it's an error.
       let matches = possibleJoins.filter(j => j.table.columns.some(c => c.name == fieldName))
       if (matches.length > 1) {
-        return diag(fieldNode, `Ambiguous field "${fieldName}"`, {sql: 'NULL', type: 'error'})
+        return diag(ctx, fieldNode, `Ambiguous field "${fieldName}"`, {sql: 'NULL', type: 'error'})
       }
 
       if (matches.length == 0) {
         if (possibleJoins.some(j => j.table.joins.some(jj => jj.alias == fieldName))) {
-          return diag(fieldNode, `"${fieldName}" is a join, not a column`, {sql: 'NULL', type: 'error'})
+          return diag(ctx, fieldNode, `"${fieldName}" is a join, not a column`, {sql: 'NULL', type: 'error'})
         }
         let on = possibleJoins.length == 1 ? ` on ${possibleJoins[0].table.name}` : ''
-        return diag(fieldNode, `Unknown field "${fieldName}"${on}`, {sql: 'NULL', type: 'error'})
+        return diag(ctx, fieldNode, `Unknown field "${fieldName}"${on}`, {sql: 'NULL', type: 'error'})
       }
 
       let {table, alias} = matches[0]
       let col = table.columns.find(c => c.name == fieldName)!
-      NODE_ENTITY_MAP.set(fieldNode, {entityType: 'field', field: col, table})
+      internalizeContext(ctx).nodeEntityMap.set(fieldNode, {entityType: 'field', field: col, table})
       addReference('column', fieldNode, col.symbolId)
 
       // Simple case: this is just a regular column on a table
       if (!col.exprNode) return {sql: `${alias}.${col.name}`, type: col.type, fanout: normalizeExprFanout({path: matches[0].fanoutPath})}
 
       // Computed column: analyze its expression in the matched table's scope
-      if (analysisStack.has(col)) return diag(col.exprNode, 'Cycles are not allowed between computed columns', {sql: 'NULL', type: 'error'})
-      analysisStack.add(col)
-      let expr = analyzeExpr(col.exprNode, {query: scope.query, table, alias, otherTables: scope.otherTables, fanoutPath: matches[0].fanoutPath})
-      analysisStack.delete(col)
+      if (ctx.analysisStack.has(col)) return diag(ctx, col.exprNode, 'Cycles are not allowed between computed columns', {sql: 'NULL', type: 'error'})
+      ctx.analysisStack.add(col)
+      let expr = analyzeExpr(ctx, col.exprNode, {query: scope.query, table, alias, otherTables: scope.otherTables, fanoutPath: matches[0].fanoutPath})
+      ctx.analysisStack.delete(col)
       return {
         sql: `(${expr.sql})`,
         type: expr.type,
@@ -558,31 +572,31 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
     }
 
     case 'FunctionCall':
-      return analyzeFunction(node, scope, analyzeExpr)
+      return analyzeFunction(ctx, node, scope, analyzeExpr)
 
     case 'WindowExpression': {
       let baseNode = node.getChild('FunctionCall') || node.getChild('Count')
-      if (!baseNode) return diag(node, 'Window expressions require a function call', {sql: 'NULL', type: 'error'})
+      if (!baseNode) return diag(ctx, node, 'Window expressions require a function call', {sql: 'NULL', type: 'error'})
       let isPercentile = isPercentileFunctionCall(baseNode)
       if (isPercentile && !isPercentileWindowSpecSupported(node.getChild('OverClause')!)) {
-        return diag(node.getChild('OverClause')!, 'pXX window form currently supports PARTITION BY only', {sql: 'NULL', type: 'error'})
+        return diag(ctx, node.getChild('OverClause')!, 'pXX window form currently supports PARTITION BY only', {sql: 'NULL', type: 'error'})
       }
-      let base = baseNode.name == 'FunctionCall' ? analyzeFunction(baseNode, scope, analyzeExpr, {isWindow: true}) : analyzeExpr(baseNode, scope)
+      let base = baseNode.name == 'FunctionCall' ? analyzeFunction(ctx, baseNode, scope, analyzeExpr, {isWindow: true}) : analyzeExpr(ctx, baseNode, scope)
       if (base.type == 'error') return base
-      if (!base.canWindow) return diag(baseNode, 'Only aggregate or window functions can use OVER', {sql: 'NULL', type: 'error'})
-      let over = renderOverClause(node.getChild('OverClause')!, scope)
+      if (!base.canWindow) return diag(ctx, baseNode, 'Only aggregate or window functions can use OVER', {sql: 'NULL', type: 'error'})
+      let over = renderOverClause(ctx, node.getChild('OverClause')!, scope)
       return {sql: `${base.sql} OVER (${over})`, type: base.type, isAgg: false}
     }
 
     case 'Parenthetical': {
-      let inner = analyzeExpr(node.getChild('Expression')!, scope)
+      let inner = analyzeExpr(ctx, node.getChild('Expression')!, scope)
       return {...inner, sql: `(${inner.sql})`}
     }
 
     case 'Count': {
       let inner = node.getChild('Expression')
       if (inner) {
-        let e = analyzeExpr(inner, scope)
+        let e = analyzeExpr(ctx, inner, scope)
         return {
           sql: `count(distinct ${e.sql})`,
           type: 'number',
@@ -609,41 +623,41 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
     case 'ComparisonExpression':
     case 'AddExpression':
     case 'MultiplyExpression': {
-      let left = analyzeExpr(node.firstChild!, scope)
-      let right = analyzeExpr(node.lastChild!, scope)
+      let left = analyzeExpr(ctx, node.firstChild!, scope)
+      let right = analyzeExpr(ctx, node.lastChild!, scope)
       let op = txt(node.firstChild?.nextSibling).toLowerCase()
 
       // Type coercion for dates
       if ((left.type == 'date' || left.type == 'timestamp') && right.type == 'string') {
-        right = coerceToTemporal(right, left.type, node.lastChild!)
+        right = coerceToTemporal(ctx, right, left.type, node.lastChild!)
       }
       if ((right.type == 'date' || right.type == 'timestamp') && left.type == 'string') {
-        left = coerceToTemporal(left, right.type, node.firstChild!)
+        left = coerceToTemporal(ctx, left, right.type, node.firstChild!)
       }
 
       // Date arithmetic
       if (op == '+' || op == '-') {
         if (left.type == 'date' || left.type == 'timestamp' || left.type == 'interval' || right.type == 'interval') {
-          return analyzeDateArithmetic(op, left, right, node)
+          return analyzeDateArithmetic(ctx, op, left, right, node)
         }
       }
 
       // Type checking for operators
       if (op == '*') {
-        let multiplied = analyzeIntervalMultiplication(left, right, node)
+        let multiplied = analyzeIntervalMultiplication(ctx, left, right, node)
         if (multiplied) return multiplied
       }
       if (op == '*' || op == '/' || op == '%') {
-        checkTypes(left, ['number'], node.firstChild!)
-        checkTypes(right, ['number'], node.lastChild!)
+        checkTypes(ctx, left, ['number'], node.firstChild!)
+        checkTypes(ctx, right, ['number'], node.lastChild!)
       }
       if (op == 'like' || op == 'ilike') {
-        checkTypes(left, ['string'], node.firstChild!)
-        checkTypes(right, ['string'], node.lastChild!)
+        checkTypes(ctx, left, ['string'], node.firstChild!)
+        checkTypes(ctx, right, ['string'], node.lastChild!)
       }
       if (op == '||') {
-        checkTypes(left, ['string'], node.firstChild!)
-        checkTypes(right, ['string'], node.lastChild!)
+        checkTypes(ctx, left, ['string'], node.firstChild!)
+        checkTypes(ctx, right, ['string'], node.lastChild!)
       }
 
       let resultType = left.type
@@ -653,7 +667,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
 
       // ILIKE handling for BigQuery
       let sql: string
-      if (op == 'ilike' && config.dialect == 'bigquery') {
+      if (op == 'ilike' && ctx.options.dialect == 'bigquery') {
         sql = `LOWER(${left.sql}) LIKE LOWER(${right.sql})`
       } else if (op == 'and' || op == 'or') {
         sql = `(${left.sql} ${op.toUpperCase()} ${right.sql})`
@@ -668,16 +682,16 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
 
     case 'UnaryExpression': {
       let op = txt(node.firstChild).toLowerCase()
-      let child = analyzeExpr(node.lastChild!, scope)
+      let child = analyzeExpr(ctx, node.lastChild!, scope)
       if (op == 'not') return {...child, sql: `NOT (${child.sql})`, type: 'boolean'}
       if (op == '-') return {...child, sql: `-(${child.sql})`}
       if (op == '+') return {...child, sql: `(${child.sql})`}
-      return diag(node, `Unknown unary operator: ${op}`, {sql: 'NULL', type: 'error'})
+      return diag(ctx, node, `Unknown unary operator: ${op}`, {sql: 'NULL', type: 'error'})
     }
 
     case 'NullTestExpression': {
       let isNot = !!node.getChildren('Kw').find(n => txt(n).toLowerCase() == 'not')
-      let e = analyzeExpr(node.firstChild!, scope)
+      let e = analyzeExpr(ctx, node.firstChild!, scope)
       return {...e, sql: `${e.sql} IS ${isNot ? 'NOT ' : ''}NULL`, type: 'boolean'}
     }
 
@@ -687,7 +701,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       let fanoutExprs: Expr[] = []
       let caseValue = node.getChild('Expression')
       if (caseValue) {
-        let e = analyzeExpr(caseValue, scope)
+        let e = analyzeExpr(ctx, caseValue, scope)
         parts.push(e.sql)
         isAgg ||= !!e.isAgg
         fanoutExprs.push(e)
@@ -696,8 +710,8 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       let resultType: FieldType = 'string'
       for (let w of node.getChildren('WhenClause')) {
         let exprs = w.getChildren('Expression')
-        let when = analyzeExpr(exprs[0], scope)
-        let then = analyzeExpr(exprs[1], scope)
+        let when = analyzeExpr(ctx, exprs[0], scope)
+        let then = analyzeExpr(ctx, exprs[1], scope)
         resultType = then.type
         isAgg ||= !!when.isAgg || !!then.isAgg
         fanoutExprs.push(when, then)
@@ -706,7 +720,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
 
       let elseClause = node.getChild('ElseClause')
       if (elseClause) {
-        let elseExpr = analyzeExpr(elseClause.getChild('Expression')!, scope)
+        let elseExpr = analyzeExpr(ctx, elseClause.getChild('Expression')!, scope)
         parts.push(`ELSE ${elseExpr.sql}`)
         isAgg ||= !!elseExpr.isAgg
         fanoutExprs.push(elseExpr)
@@ -717,23 +731,23 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
 
     case 'InExpression': {
       let not = txt(node.getChild('Kw')).toLowerCase() == 'not'
-      let e = analyzeExpr(node.firstChild!, scope)
+      let e = analyzeExpr(ctx, node.firstChild!, scope)
       let valueList = node.getChild('InValueList')
       let subqueryNode = node.getChild('QueryStatement')
       if (subqueryNode) {
-        let subquery = analyzeQuery(subqueryNode, scope.otherTables)
+        let subquery = analyzeQuery(ctx, subqueryNode, scope.otherTables)
         if (!subquery) return {sql: 'NULL', type: 'error'}
-        if (subquery.fields.length != 1) return diag(subqueryNode, 'Subquery in IN must return exactly one column', {sql: 'NULL', type: 'error'})
+        if (subquery.fields.length != 1) return diag(ctx, subqueryNode, 'Subquery in IN must return exactly one column', {sql: 'NULL', type: 'error'})
         return {...e, sql: `${e.sql} ${not ? 'NOT IN' : 'IN'} (${subquery.sql})`, type: 'boolean'}
       }
       if (!valueList) {
-        return diag(node, 'IN expression must provide either values or a subquery', {sql: 'NULL', type: 'error'})
+        return diag(ctx, node, 'IN expression must provide either values or a subquery', {sql: 'NULL', type: 'error'})
       }
       let values = valueList.getChildren('Expression').map(v => {
-        let val = analyzeExpr(v, scope)
+        let val = analyzeExpr(ctx, v, scope)
         // Coerce string literals to temporal types if needed
         if ((e.type == 'date' || e.type == 'timestamp') && val.type == 'string') {
-          val = coerceToTemporal(val, e.type, v)
+          val = coerceToTemporal(ctx, val, e.type, v)
         }
         return val.sql
       })
@@ -746,11 +760,11 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
         .map(n => txt(n).toLowerCase())
         .find(k => k == 'not')
       let [eNode, lowNode, highNode] = node.getChildren('Expression')
-      let [e, low, high] = [eNode, lowNode, highNode].map(n => analyzeExpr(n, scope))
+      let [e, low, high] = [eNode, lowNode, highNode].map(n => analyzeExpr(ctx, n, scope))
 
       if (e.type == 'date' || e.type == 'timestamp') {
-        low = coerceToTemporal(low, e.type, lowNode)
-        high = coerceToTemporal(high, e.type, highNode)
+        low = coerceToTemporal(ctx, low, e.type, lowNode)
+        high = coerceToTemporal(ctx, high, e.type, highNode)
       }
 
       let sql = `${e.sql} ${not ? 'NOT BETWEEN' : 'BETWEEN'} ${low.sql} AND ${high.sql}`
@@ -758,27 +772,27 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
     }
 
     case 'SubqueryExpression': {
-      let subquery = analyzeQuery(node.getChild('QueryStatement')!, scope.otherTables)
+      let subquery = analyzeQuery(ctx, node.getChild('QueryStatement')!, scope.otherTables)
       if (!subquery) return {sql: 'NULL', type: 'error'}
-      if (subquery.fields.length != 1) return diag(node, 'Subquery expression must return exactly one column', {sql: 'NULL', type: 'error'})
+      if (subquery.fields.length != 1) return diag(ctx, node, 'Subquery expression must return exactly one column', {sql: 'NULL', type: 'error'})
       return {sql: `(${subquery.sql})`, type: subquery.fields[0].type}
     }
 
     case 'CastExpression':
     case 'TypeCastExpression': {
       let inner = node.getChild('Expression') || node.firstChild!
-      let e = analyzeExpr(inner, scope)
+      let e = analyzeExpr(ctx, inner, scope)
       let typeNode = node.getChild('CastType')!
       let targetType = txt(typeNode).toUpperCase()
       let resultType = convertDataType(targetType)
-      if (!resultType) return diag(typeNode, `Unsupported cast type: ${targetType.toLowerCase()}`, {sql: 'NULL', type: 'error'})
+      if (!resultType) return diag(ctx, typeNode, `Unsupported cast type: ${targetType.toLowerCase()}`, {sql: 'NULL', type: 'error'})
       return {...e, sql: `CAST(${e.sql} AS ${targetType})`, type: resultType}
     }
 
     case 'ExtractExpression': {
       let extractInner = node.getChild('Expression')!
-      let e = analyzeExpr(extractInner, scope)
-      checkTypes(e, ['date', 'timestamp'], extractInner)
+      let e = analyzeExpr(ctx, extractInner, scope)
+      checkTypes(ctx, e, ['date', 'timestamp'], extractInner)
       let unit = txt(node.getChild('ExtractUnit')!)
         .replace(/^['"]|['"]$/g, '')
         .toLowerCase()
@@ -789,7 +803,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       let stringNode = node.getChild('String')
       if (stringNode) {
         let parsed = parseIntervalLiteral(txt(stringNode).slice(1, -1))
-        if (!parsed) return diag(stringNode, 'Could not parse interval', {sql: 'NULL', type: 'error'})
+        if (!parsed) return diag(ctx, stringNode, 'Could not parse interval', {sql: 'NULL', type: 'error'})
         return {
           sql: `interval ${parsed.quantity} ${parsed.unit}`,
           type: 'interval',
@@ -797,11 +811,11 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
         }
       }
       let quantityNode = node.getChild('Number') || node.getChild('Ref')
-      if (!quantityNode) return diag(node, 'Interval requires a quantity before the unit', {sql: 'NULL', type: 'error'})
-      let quantity = analyzeExpr(quantityNode, scope)
-      checkTypes(quantity, ['number'], quantityNode)
+      if (!quantityNode) return diag(ctx, node, 'Interval requires a quantity before the unit', {sql: 'NULL', type: 'error'})
+      let quantity = analyzeExpr(ctx, quantityNode, scope)
+      checkTypes(ctx, quantity, ['number'], quantityNode)
       let unit = parseIntervalUnit(txt(node.getChild('IntervalUnit')!).toLowerCase())
-      if (!unit) return diag(node, 'Invalid interval unit', {sql: 'NULL', type: 'error'})
+      if (!unit) return diag(ctx, node, 'Invalid interval unit', {sql: 'NULL', type: 'error'})
       return {...quantity, sql: `INTERVAL ${quantity.sql} ${unit}`, type: 'interval', interval: {quantitySql: quantity.sql, unit, form: quantityNode.name == 'Number' ? 'constant' : 'dynamic'}}
     }
 
@@ -810,26 +824,27 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       let isDate = node.name == 'DateExpression'
       let lit = txt(node.getChild('String')!).slice(1, -1)
       let parsed = parseTemporalLiteral(lit, isDate ? 'date' : 'timestamp')
-      if (!parsed) return diag(node, `Invalid ${isDate ? 'date' : 'timestamp'}`, {sql: 'NULL', type: 'error'})
+      if (!parsed) return diag(ctx, node, `Invalid ${isDate ? 'date' : 'timestamp'}`, {sql: 'NULL', type: 'error'})
       return {sql: `${isDate ? 'DATE' : 'TIMESTAMP'} '${parsed.literal}'`, type: isDate ? 'date' : 'timestamp'}
     }
 
     default:
-      return diag(node, `Unsupported expression: ${node.name}`, {sql: 'NULL', type: 'error'})
+      return diag(ctx, node, `Unsupported expression: ${node.name}`, {sql: 'NULL', type: 'error'})
   }
 }
 
-function analyzeDateArithmetic(op: '+' | '-', left: Expr, right: Expr, node: SyntaxNode): Expr {
+function analyzeDateArithmetic(ctx: AnalysisContext, op: '+' | '-', left: Expr, right: Expr, node: SyntaxNode): Expr {
   let merged = mergeExprAnalysis([left, right], '', 'number', left.isAgg || right.isAgg)
+  let dialect = ctx.options.dialect
 
   // date - date = interval
   if ((left.type == 'date' || left.type == 'timestamp') && (right.type == 'date' || right.type == 'timestamp')) {
-    if (op != '-') return diag(node, 'Can only subtract dates', {sql: 'NULL', type: 'error'})
+    if (op != '-') return diag(ctx, node, 'Can only subtract dates', {sql: 'NULL', type: 'error'})
     let unit = left.type == 'timestamp' ? 'SECOND' : 'DAY'
-    if (config.dialect == 'bigquery') {
+    if (dialect == 'bigquery') {
       return {...merged, sql: `TIMESTAMP_DIFF(${left.sql}, ${right.sql}, ${unit})`, type: 'number'}
     }
-    if (config.dialect == 'snowflake') {
+    if (dialect == 'snowflake') {
       return {...merged, sql: `TIMESTAMPDIFF(${unit}, ${right.sql}, ${left.sql})`, type: 'number'}
     }
     return {...merged, sql: `DATE_DIFF('${unit.toLowerCase()}', ${right.sql}, ${left.sql})`, type: 'number'}
@@ -837,49 +852,49 @@ function analyzeDateArithmetic(op: '+' | '-', left: Expr, right: Expr, node: Syn
 
   // date +/- interval
   if ((left.type == 'date' || left.type == 'timestamp') && right.type == 'interval') {
-    if (!right.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
-    return {...merged, sql: renderTemporalArithmetic(config.dialect, left.sql, left.type, op, right.interval), type: left.type}
+    if (!right.interval) return diag(ctx, node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
+    return {...merged, sql: renderTemporalArithmetic(dialect, left.sql, left.type, op, right.interval), type: left.type}
   }
 
   // interval + date (normalize to date + interval)
   if (left.type == 'interval' && (right.type == 'date' || right.type == 'timestamp')) {
-    if (op == '-') return diag(node, 'Cannot subtract date from interval', {sql: 'NULL', type: 'error'})
-    if (!left.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
-    return {...merged, sql: renderTemporalArithmetic(config.dialect, right.sql, right.type, '+', left.interval), type: right.type}
+    if (op == '-') return diag(ctx, node, 'Cannot subtract date from interval', {sql: 'NULL', type: 'error'})
+    if (!left.interval) return diag(ctx, node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
+    return {...merged, sql: renderTemporalArithmetic(dialect, right.sql, right.type, '+', left.interval), type: right.type}
   }
 
-  return diag(node, 'Invalid date arithmetic', {sql: 'NULL', type: 'error'})
+  return diag(ctx, node, 'Invalid date arithmetic', {sql: 'NULL', type: 'error'})
 }
 
-function analyzeIntervalMultiplication(left: Expr, right: Expr, node: SyntaxNode): Expr | null {
+function analyzeIntervalMultiplication(ctx: AnalysisContext, left: Expr, right: Expr, node: SyntaxNode): Expr | null {
   if (left.type == 'number' && right.type == 'interval') {
-    return scaleInterval(left, right, node.lastChild!)
+    return scaleInterval(ctx, left, right, node.lastChild!)
   }
   if (left.type == 'interval' && right.type == 'number') {
-    return scaleInterval(right, left, node.firstChild!)
+    return scaleInterval(ctx, right, left, node.firstChild!)
   }
   return null
 }
 
-function scaleInterval(multiplier: Expr, intervalExpr: Expr, node: SyntaxNode): Expr {
-  if (!intervalExpr.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
-  if (intervalExpr.interval.form != 'constant') return diag(node, 'Only literal intervals can be multiplied', {sql: 'NULL', type: 'error'})
+function scaleInterval(ctx: AnalysisContext, multiplier: Expr, intervalExpr: Expr, node: SyntaxNode): Expr {
+  if (!intervalExpr.interval) return diag(ctx, node, 'Invalid interval expression', {sql: 'NULL', type: 'error'})
+  if (intervalExpr.interval.form != 'constant') return diag(ctx, node, 'Only literal intervals can be multiplied', {sql: 'NULL', type: 'error'})
   let quantitySql = intervalExpr.interval.quantitySql == '1' ? multiplier.sql : `${multiplier.sql}*${intervalExpr.interval.quantitySql}`
   return {
-    sql: renderStandaloneInterval(config.dialect, {quantitySql, unit: intervalExpr.interval.unit, form: 'scaled'}),
+    sql: renderStandaloneInterval(ctx.options.dialect, {quantitySql, unit: intervalExpr.interval.unit, form: 'scaled'}),
     type: 'interval',
     isAgg: multiplier.isAgg || intervalExpr.isAgg,
     interval: {quantitySql, unit: intervalExpr.interval.unit, form: 'scaled'},
   }
 }
 
-function coerceToTemporal(expr: Expr, targetType: 'date' | 'timestamp', node: SyntaxNode): Expr {
+function coerceToTemporal(ctx: AnalysisContext, expr: Expr, targetType: 'date' | 'timestamp', node: SyntaxNode): Expr {
   // Extract the string literal value (remove quotes)
   let match = expr.sql.match(/^'(.+)'$/)
   if (!match) return expr
   let parsed = parseTemporalLiteral(match[1], targetType)
   if (!parsed) {
-    diag(node, `Cannot parse as ${targetType}: ${expr.sql}`)
+    diag(ctx, node, `Cannot parse as ${targetType}: ${expr.sql}`)
     return expr
   }
   return {...expr, sql: `${targetType.toUpperCase()} '${parsed.literal}'`, type: targetType}
@@ -899,21 +914,21 @@ function isPercentileWindowSpecSupported(overClause: SyntaxNode): boolean {
   return true
 }
 
-function renderOverClause(overClause: SyntaxNode, scope: Scope): string {
+function renderOverClause(ctx: AnalysisContext, overClause: SyntaxNode, scope: Scope): string {
   let spec = overClause.getChild('WindowSpec')
   if (!spec) return ''
   let parts: string[] = []
 
   let partition = spec.getChild('WindowPartitionClause')
   if (partition) {
-    let exprs = partition.getChildren('Expression').map(e => analyzeExpr(e, scope).sql)
+    let exprs = partition.getChildren('Expression').map(e => analyzeExpr(ctx, e, scope).sql)
     parts.push(`PARTITION BY ${exprs.join(', ')}`)
   }
 
   let orderBy = spec.getChild('WindowOrderByClause')
   if (orderBy) {
     let items = orderBy.getChildren('WindowOrderItem').map(item => {
-      let expr = analyzeExpr(item.getChild('Expression')!, scope).sql
+      let expr = analyzeExpr(ctx, item.getChild('Expression')!, scope).sql
       let desc = txt(item.getChild('Kw')).toLowerCase() == 'desc'
       return `${expr} ${desc ? 'DESC' : 'ASC'}`
     })
@@ -921,34 +936,34 @@ function renderOverClause(overClause: SyntaxNode, scope: Scope): string {
   }
 
   let frame = spec.getChild('WindowFrameClause')
-  if (frame) parts.push(renderWindowFrame(frame, scope))
+  if (frame) parts.push(renderWindowFrame(ctx, frame, scope))
 
   return parts.join(' ')
 }
 
-function renderWindowFrame(frame: SyntaxNode, scope: Scope): string {
+function renderWindowFrame(ctx: AnalysisContext, frame: SyntaxNode, scope: Scope): string {
   let mode = txt(frame.getChildren('Kw')[0]).toUpperCase()
   let between = frame.getChild('WindowFrameBetween')
   if (between) {
-    let bounds = between.getChildren('WindowFrameBound').map(b => renderWindowBound(b, scope))
+    let bounds = between.getChildren('WindowFrameBound').map(b => renderWindowBound(ctx, b, scope))
     return `${mode} BETWEEN ${bounds[0]} AND ${bounds[1]}`
   }
   let start = frame.getChild('WindowFrameStart')!.getChild('WindowFrameBound')!
-  return `${mode} ${renderWindowBound(start, scope)}`
+  return `${mode} ${renderWindowBound(ctx, start, scope)}`
 }
 
-function renderWindowBound(bound: SyntaxNode, scope: Scope): string {
+function renderWindowBound(ctx: AnalysisContext, bound: SyntaxNode, scope: Scope): string {
   let kws = bound.getChildren('Kw').map(k => txt(k).toLowerCase())
   if (kws.includes('unbounded')) {
     return `UNBOUNDED ${kws.includes('following') ? 'FOLLOWING' : 'PRECEDING'}`
   }
   if (kws.includes('current')) return 'CURRENT ROW'
-  let expr = analyzeExpr(bound.getChild('Expression')!, scope).sql
+  let expr = analyzeExpr(ctx, bound.getChild('Expression')!, scope).sql
   return `${expr} ${kws.includes('following') ? 'FOLLOWING' : 'PRECEDING'}`
 }
 
 // Traverse a join path (like `tableA.tableB.`), returning a new scope pointing to the target table. Adds implied joins to the query as it goes
-function followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
+function followJoins(ctx: AnalysisContext, pathNodes: SyntaxNode[], scope: Scope): Scope | null {
   let part = pathNodes[0]
   let name = txt(part)
 
@@ -958,11 +973,11 @@ function followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
   if (scope.joinTarget) {
     let pointsAtSource = !!scope.table && name == scope.alias
     let pointsAtTarget = name == scope.joinTarget.alias || name == scope.joinTarget.name
-    if (!pointsAtSource && !pointsAtTarget) return diag(pathNodes[0], 'Joins must point at either the source or target table', null)
+    if (!pointsAtSource && !pointsAtTarget) return diag(ctx, pathNodes[0], 'Joins must point at either the source or target table', null)
 
     let table = pointsAtTarget ? scope.joinTarget.table : scope.table!
     let alias = pointsAtTarget ? scope.joinTarget.alias : scope.alias
-    NODE_ENTITY_MAP.set(pathNodes[0], {entityType: 'table', table})
+    internalizeContext(ctx).nodeEntityMap.set(pathNodes[0], {entityType: 'table', table})
     addReference('table', pathNodes[0], table.symbolId)
     return {query: scope.query, table, alias, fanoutPath: scope.fanoutPath, otherTables: scope.otherTables}
   }
@@ -974,15 +989,15 @@ function followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
     // This could be a ref to an existing FROM/JOIN alias
     let existing = scope.query!.joins.find(j => j.alias == name)
     if (existing) {
-      NODE_ENTITY_MAP.set(part, {entityType: 'table', table: existing.table})
+      internalizeContext(ctx).nodeEntityMap.set(part, {entityType: 'table', table: existing.table})
       addReference('table', part, existing.table?.symbolId)
       scope = {...scope, table: existing.table!, alias: existing.alias, fanoutPath: existing.fanoutPath}
       pathNodes.shift() // remove, since we're updating scope
     } else {
       // otherwise, this might be referring to a join _on_ one of those FROM/JOIN tables
       let matches = scope.query!.joins.filter(j => j.table!.joins.some(jj => jj.alias == name))
-      if (matches.length > 1) return diag(part, `"${name}" matches multiple possible joins in this query`, null)
-      if (matches.length == 0) return diag(part, `Could not find "${name}" on query`, null)
+      if (matches.length > 1) return diag(ctx, part, `"${name}" matches multiple possible joins in this query`, null)
+      if (matches.length == 0) return diag(ctx, part, `Could not find "${name}" on query`, null)
       scope = {...scope, table: matches[0].table!, alias: matches[0].alias, fanoutPath: matches[0].fanoutPath}
     }
   }
@@ -996,9 +1011,9 @@ function followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
     let table = scope.table!
     let alias = scope.alias
     let next = table.joins.find(j => j.alias == name)
-    if (!next) return diag(part, `Unknown join "${name}" on ${table.name}`, null)
+    if (!next) return diag(ctx, part, `Unknown join "${name}" on ${table.name}`, null)
 
-    next.table = lookupTable(next.targetNode!)
+    next.table = lookupTable(ctx, next.targetNode!)
     if (!next.table) return null
 
     // Construct a new implied join and attache it to the query
@@ -1007,11 +1022,11 @@ function followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
     let fanoutPath = next.cardinality == 'many' ? extendFanoutPath(scope.fanoutPath, name) : extendFanoutPath(scope.fanoutPath)
     if (scope.query && !scope.query.joins.find(j => j.alias == newAlias)) {
       let joinTarget = {name: next.alias, table: next.table, alias: newAlias}
-      let onClause = analyzeExpr(next.onExpr!, {table, alias, fanoutPath: scope.fanoutPath, joinTarget}).sql
+      let onClause = analyzeExpr(ctx, next.onExpr!, {table, alias, fanoutPath: scope.fanoutPath, joinTarget}).sql
       scope.query.joins.push({alias: newAlias, targetTable: next.targetTable, table: next.table, source: 'implicit', cardinality: next.cardinality, fanoutPath, joinType: 'left', onClause})
     }
 
-    NODE_ENTITY_MAP.set(part, {entityType: 'table', table: next.table})
+    internalizeContext(ctx).nodeEntityMap.set(part, {entityType: 'table', table: next.table})
     addReference('table', part, next.table.symbolId)
     scope = {...scope, table: next.table, alias: newAlias, fanoutPath}
   }
@@ -1033,17 +1048,17 @@ function mergeExprAnalysis(exprs: Expr[], sql: string, type: FieldType, isAgg?: 
   }
 }
 
-function analyzeComputedFieldExpr(node: SyntaxNode, expr: Expr) {
-  if (expr.fanout?.conflict) diag(node, 'Join graph creates a chasm trap')
-  if (!expr.isAgg && !isBaseFanoutPath(expr.fanout?.path)) diag(node, fanoutMessage(expr.fanout?.path, 'aggregate it first'))
+function analyzeComputedFieldExpr(ctx: AnalysisContext, node: SyntaxNode, expr: Expr) {
+  if (expr.fanout?.conflict) diag(ctx, node, 'Join graph creates a chasm trap')
+  if (!expr.isAgg && !isBaseFanoutPath(expr.fanout?.path)) diag(ctx, node, fanoutMessage(expr.fanout?.path, 'aggregate it first'))
   let paths = uniqueFanoutPaths(expr.fanout?.sensitivePaths || [])
   if (paths.length > 1) {
-    diag(node, multiGrainMessage(paths))
+    diag(ctx, node, multiGrainMessage(paths))
   }
 }
 
-function analyzeAggregateQueryExpr(node: SyntaxNode, expr: Expr) {
-  if (expr.fanout?.conflict) diag(node, 'Join graph creates a chasm trap')
+function analyzeAggregateQueryExpr(ctx: AnalysisContext, node: SyntaxNode, expr: Expr) {
+  if (expr.fanout?.conflict) diag(ctx, node, 'Join graph creates a chasm trap')
 }
 
 // Aggregate-query fanout diagnostics have to look at the query as a whole: first ensure
@@ -1051,7 +1066,7 @@ function analyzeAggregateQueryExpr(node: SyntaxNode, expr: Expr) {
 // aggregate grains into the more specific cases we can explain clearly (chasm trap, a base
 // aggregate fanned out by one join, an ancestor aggregate fanned out by a descendant join,
 // or the generic join-graph fanout fallback).
-function analyzeAggregateQueryFanout(exprs: {node: SyntaxNode; expr: Expr}[]) {
+function analyzeAggregateQueryFanout(ctx: AnalysisContext, exprs: {node: SyntaxNode; expr: Expr}[]) {
   let aggExprs = exprs.filter(entry => entry.expr.isAgg)
   let paths = uniqueFanoutPaths(aggExprs.flatMap(entry => entry.expr.fanout?.sensitivePaths || []))
   if (paths.length == 0) return
@@ -1072,13 +1087,13 @@ function analyzeAggregateQueryFanout(exprs: {node: SyntaxNode; expr: Expr}[]) {
       for (let aggEntry of aggExprs) {
         let entryPaths = uniqueFanoutPaths(aggEntry.expr.fanout?.sensitivePaths || [])
         if (!entryPaths.some(path => isBaseFanoutPath(path))) continue
-        diag(aggEntry.node, aggregateFanoutMessage(txt(aggEntry.node), entry.expr.fanout?.path))
+        diag(ctx, aggEntry.node, aggregateFanoutMessage(txt(aggEntry.node), entry.expr.fanout?.path))
       }
       continue
     }
 
     let targetPath = paths.length == 1 && isPrefix(entry.expr.fanout!.path!, paths[0]) ? paths[0] : entry.expr.fanout?.path
-    diag(entry.node, fanoutMessage(targetPath, 'aggregate queries cannot group by it directly'))
+    diag(ctx, entry.node, fanoutMessage(targetPath, 'aggregate queries cannot group by it directly'))
   }
 
   if (paths.length <= 1) return
@@ -1091,7 +1106,7 @@ function analyzeAggregateQueryFanout(exprs: {node: SyntaxNode; expr: Expr}[]) {
     for (let entry of aggExprs) {
       let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
       if (entryPaths.length == 0) continue
-      diag(entry.node, message)
+      diag(ctx, entry.node, message)
     }
     return
   }
@@ -1101,7 +1116,7 @@ function analyzeAggregateQueryFanout(exprs: {node: SyntaxNode; expr: Expr}[]) {
     for (let entry of aggExprs) {
       let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
       if (!entryPaths.some(path => isBaseFanoutPath(path))) continue
-      diag(entry.node, aggregateFanoutMessage(txt(entry.node), joinedPaths[0]))
+      diag(ctx, entry.node, aggregateFanoutMessage(txt(entry.node), joinedPaths[0]))
     }
     return
   }
@@ -1127,7 +1142,7 @@ function analyzeAggregateQueryFanout(exprs: {node: SyntaxNode; expr: Expr}[]) {
       for (let entry of aggExprs) {
         let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
         if (!entryPaths.some(path => fanoutPathKey(path) == ancestorKey) || entryPaths.some(path => fanoutPathKey(path) == descendantKey)) continue
-        diag(entry.node, aggregateFanoutMessage(txt(entry.node), descendant))
+        diag(ctx, entry.node, aggregateFanoutMessage(txt(entry.node), descendant))
       }
       return
     }
@@ -1138,12 +1153,12 @@ function analyzeAggregateQueryFanout(exprs: {node: SyntaxNode; expr: Expr}[]) {
   for (let entry of aggExprs) {
     let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
     if (entryPaths.length == 0) continue
-    diag(entry.node, message)
+    diag(ctx, entry.node, message)
   }
 }
 
 // Find a table by Ref node, failing if it doesn't exist
-function lookupTable(node: SyntaxNode, scope?: Scope): Table | undefined {
+function lookupTable(ctx: AnalysisContext, node: SyntaxNode, scope?: Scope): Table | undefined {
   let name = txt(node)
   let table: Table | undefined
 
@@ -1151,15 +1166,15 @@ function lookupTable(node: SyntaxNode, scope?: Scope): Table | undefined {
     if (scopeTable.name == name) table = scopeTable
   }
   let currentUri = getFile(node).path
-  for (let file of Object.values(FILE_MAP)) {
+  for (let file of Object.values(ctx.files)) {
     if (table) break
     if (file.path.endsWith('.gsql') || file.path == currentUri) {
       let match = file.tables.find(t => t.name == name)
       if (match) table = match
     }
   }
-  if (!table) return diag(node, `Unknown table "${name}"`)
-  analyzeView(table)
+  if (!table) return diag(ctx, node, `Unknown table "${name}"`)
+  analyzeView(ctx, table)
   if (table.type == 'view' && !table.query) return
   addReference('table', node, table.symbolId)
   return table
@@ -1176,46 +1191,34 @@ function inferName(exprNode: SyntaxNode, scope: Scope): string {
 }
 
 // TODO: do we still need this?
-function unpackAnds(node: SyntaxNode, scope: Scope): Expr[] {
+function unpackAnds(ctx: AnalysisContext, node: SyntaxNode, scope: Scope): Expr[] {
   if (node.name == 'BinaryExpression') {
     let op = txt(node.firstChild?.nextSibling).toLowerCase()
     if (op == 'and') {
-      return [...unpackAnds(node.firstChild!, scope), ...unpackAnds(node.lastChild!, scope)]
+      return [...unpackAnds(ctx, node.firstChild!, scope), ...unpackAnds(ctx, node.lastChild!, scope)]
     }
   }
-  return [analyzeExpr(node, scope)]
+  return [analyzeExpr(ctx, node, scope)]
 }
 
-export function clearWorkspace() {
-  Object.keys(FILE_MAP).forEach(k => delete FILE_MAP[k])
-  diagnostics = []
-}
-
-export function clearDiagnostics() {
-  diagnostics = []
-}
-export function getNodeEntity(node: SyntaxNode) {
-  return NODE_ENTITY_MAP.get(node)
-}
-
-export function recordSyntaxErrors(fi: FileInfo) {
+export function recordSyntaxErrors(ctx: AnalysisContext, fi: FileInfo) {
   fi.tree!.topNode.cursor().iterate(n => {
-    if (n.type.isError) diag(n.node, 'Syntax error')
+    if (n.type.isError) diag(ctx, n.node, 'Syntax error')
   })
 }
 
-export function diag<T>(node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T {
+export function diag<T>(ctx: AnalysisContext, node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T {
   let file = getFile(node)
   let from = getPosition(node.from, file)
   let to = getPosition(node.to, file)
-  diagnostics.push({severity: 'error', message, file: toRelativePath(file.path), from, to, frame: buildFrame(from, to)})
+  ctx.diagnostics.push({severity: 'error', message, file: toRelativePath(file.path), from, to, frame: buildFrame(from, to)})
   return defaultReturn as T
 }
 
-export function checkTypes(expr: Expr, expected: FieldType[], node: SyntaxNode) {
+export function checkTypes(ctx: AnalysisContext, expr: Expr, expected: FieldType[], node: SyntaxNode) {
   if (expr.type == 'error' || expr.type == 'null') return
   if (expected.includes(expr.type)) return
-  diag(node, `Expected ${expected.join(' or ')}, got ${expr.type}`)
+  diag(ctx, node, `Expected ${expected.join(' or ')}, got ${expr.type}`)
 }
 
 // Convert raw database types into simplified types. Malloy did this, I'm on the fence if we need it.

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -2,35 +2,89 @@ import {glob} from 'glob'
 import {readFile} from 'node:fs/promises'
 import path from 'node:path'
 
-import {FILE_MAP, analyzeQuery, findTables, clearWorkspace, diagnostics, clearDiagnostics, getNodeEntity, recordSyntaxErrors, analyzeTableFully, applyExtends} from './analyze.ts'
+import {analyzeQuery, analyzeTableFully, applyExtends, createAnalysisContext, findTables, recordSyntaxErrors} from './analyze.ts'
 import {config, loadConfig} from './config.ts'
 import {parseMarkdown} from './markdown.ts'
 import {fillInParams} from './params.ts'
 import {parser} from './parser.js'
-import {type GrapheneError, type Location, type Query} from './types.ts'
-import {getOffset, getSourceOffset} from './util.ts'
+import {type AnalysisFileInput, type AnalysisInput, type AnalysisOptions, type AnalysisResult, type FileInfo, type Location, type Query, type Table} from './types.ts'
+import {getSourceOffset} from './util.ts'
 
-export {clearWorkspace}
 export {config, loadConfig}
-export type {Query, Table, GrapheneError} from './types.ts'
-export function getTable(name: string) {
-  return Object.values(FILE_MAP)
-    .flatMap(f => f.tables)
-    .find(t => t.name == name)
-}
-export function getFile(name: string) {
-  return FILE_MAP[name]
-}
-export function getFiles() {
-  return Object.values(FILE_MAP)
-}
-export function getDiagnostics(): GrapheneError[] {
-  return diagnostics
+export type {AnalysisFileInput, AnalysisInput, AnalysisOptions, AnalysisResult, Query, Table, GrapheneError} from './types.ts'
+
+// `analyzeProject(...)` is the real pure API now. These module-level values only exist
+// to preserve the older stateful `core.ts` interface used by the CLI/tests/IDE helpers:
+// callers mutate a workspace snapshot with `updateFile/loadWorkspace`, then `analyze()`
+// materializes a fresh pure result and stores it here for the legacy getter functions.
+let legacyWorkspace: Record<string, FileInfo> = {}
+let legacyResult: AnalysisResult = {files: {}, diagnostics: [], queries: []}
+
+function toAnalysisOptions(options: Partial<AnalysisOptions> = config): AnalysisOptions {
+  return {dialect: options.dialect || 'duckdb', defaultNamespace: options.defaultNamespace}
 }
 
-// Loads and parses all gsql files within a directory
+function createFileInfo(input: AnalysisFileInput): FileInfo {
+  return {
+    path: input.path,
+    contents: input.contents,
+    tree: null,
+    tables: [],
+    queries: [],
+    navigation: {symbols: [], references: []},
+  }
+}
+
+function isMarkdownFile(file: AnalysisFileInput) {
+  if (file.contentType) return file.contentType == 'md'
+  return file.path.endsWith('.md')
+}
+
+// Pure analysis API. Callers provide files and options explicitly and receive the full analyzed result.
+export function analyzeProject(input: AnalysisInput): AnalysisResult {
+  let files = Object.fromEntries(input.files.map(file => [file.path, createFileInfo(file)]))
+  let ctx = createAnalysisContext(files, input.options)
+
+  for (let inputFile of input.files) {
+    let fi = files[inputFile.path]
+    fi.navigation = {symbols: [], references: []}
+    fi.tree = isMarkdownFile(inputFile) ? parseMarkdown(fi) : parser.parse(fi.contents)
+    fi.tree.fileInfo = fi
+    recordSyntaxErrors(ctx, fi)
+    findTables(ctx, fi)
+  }
+
+  Object.values(files).forEach(fi => applyExtends(ctx, fi))
+  if (input.targetPath && files[input.targetPath]) {
+    let fi = files[input.targetPath]
+    fi.tables.forEach(table => analyzeTableFully(ctx, table))
+    let nodes = fi.tree!.topNode.getChildren('QueryStatement') || []
+    fi.queries = nodes.map(node => analyzeQuery(ctx, node)).filter((query): query is Query => !!query)
+  } else {
+    Object.values(files)
+      .flatMap(f => f.tables)
+      .forEach(table => analyzeTableFully(ctx, table))
+    Object.values(files).forEach(fi => {
+      let nodes = fi.tree!.topNode.getChildren('QueryStatement') || []
+      fi.queries = nodes.map(node => analyzeQuery(ctx, node)).filter((query): query is Query => !!query)
+    })
+  }
+
+  return {
+    files,
+    diagnostics: ctx.diagnostics,
+    queries: input.targetPath ? files[input.targetPath]?.queries || [] : [],
+  }
+}
+
+export function clearWorkspace() {
+  legacyWorkspace = {}
+  legacyResult = {files: {}, diagnostics: [], queries: []}
+}
+
+// Loads all gsql files within a directory into the legacy workspace state.
 export async function loadWorkspace(dir: string, includeMd: boolean) {
-  let ignore = ['node_modules/**', '**/.*/**', ...config.ignoredFiles]
+  let ignore = ['node_modules/**', '**/.*/**', ...(config.ignoredFiles || [])]
   let files = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore, follow: false})
   for await (let file of files) {
     try {
@@ -42,51 +96,45 @@ export async function loadWorkspace(dir: string, includeMd: boolean) {
   }
 }
 
-export function updateFile(contents: string, path: string) {
-  FILE_MAP[path] ||= {path, contents, tree: null, tables: [], queries: [], navigation: {symbols: [], references: []}}
-  FILE_MAP[path].contents = contents
-  FILE_MAP[path].tree = null
-  FILE_MAP[path].navigation = {symbols: [], references: []}
-  return FILE_MAP[path]
+export function updateFile(contents: string, path: string, contentType?: 'gsql' | 'md') {
+  legacyWorkspace[path] ||= createFileInfo({path, contents, contentType})
+  Object.assign(legacyWorkspace[path], {
+    contents,
+    tree: null,
+    tables: [],
+    queries: [],
+    navigation: {symbols: [], references: []},
+  })
+  delete legacyWorkspace[path].virtualContents
+  delete legacyWorkspace[path].virtualToMarkdownOffset
+  return legacyWorkspace[path]
 }
 
 export function deleteFile(path: string) {
-  delete FILE_MAP[path]
+  delete legacyWorkspace[path]
+  if (legacyResult.files[path]) {
+    let files = {...legacyResult.files}
+    delete files[path]
+    legacyResult = {...legacyResult, files}
+  }
 }
 
-// Analyze all files in the workspace. If content is provided, it's added as a virtual 'input' file and its queries are returned.
+// Legacy compatibility wrapper. If content is provided, it is analyzed as a temporary "input" file.
 export function analyze(contents?: string, contentType?: 'gsql' | 'md'): Query[] {
-  clearDiagnostics()
+  let files = Object.values(legacyWorkspace).map(fi => ({path: fi.path, contents: fi.contents, contentType: fi.path.endsWith('.md') ? 'md' : 'gsql'}) as AnalysisFileInput)
+  let targetPath: string | undefined
 
-  delete FILE_MAP['input']
-  if (contents) updateFile(contents, 'input')
-
-  Object.values(FILE_MAP).forEach(fi => {
-    let isMd = fi.path.endsWith('.md') || (fi.path == 'input' && contentType == 'md')
-    fi.navigation = {symbols: [], references: []}
-    fi.tree ||= isMd ? parseMarkdown(fi) : parser.parse(fi.contents)
-    fi.tree!.fileInfo = fi
-    recordSyntaxErrors(fi)
-    findTables(fi)
-  })
-  Object.values(FILE_MAP).forEach(applyExtends)
-
-  if (contents) {
-    let fi = FILE_MAP['input']
-    fi.tables.forEach(analyzeTableFully)
-    let nodes = fi.tree!.topNode.getChildren('QueryStatement') || []
-    fi.queries = nodes.map(n => analyzeQuery(n)).filter((q): q is Query => !!q)
-    return fi.queries
+  if (contents != null) {
+    targetPath = 'input'
+    files.push({path: 'input', contents, contentType})
   }
 
-  Object.values(FILE_MAP)
-    .flatMap(f => f.tables)
-    .forEach(analyzeTableFully)
-  Object.values(FILE_MAP).forEach(fi => {
-    let nodes = fi.tree!.topNode.getChildren('QueryStatement') || []
-    fi.queries = nodes.map(n => analyzeQuery(n)).filter((q): q is Query => !!q)
-  })
-  return []
+  legacyResult = analyzeProject({files, targetPath, options: toAnalysisOptions()})
+  for (let [path, fi] of Object.entries(legacyResult.files)) {
+    if (path == 'input') continue
+    legacyWorkspace[path] = fi
+  }
+  return legacyResult.queries
 }
 
 export function toSql(query: Query, params: Record<string, any> = {}): string {
@@ -95,59 +143,107 @@ export function toSql(query: Query, params: Record<string, any> = {}): string {
   return query.sql
 }
 
-export function getHover(path: string, line: number, col: number): string {
-  let fi = FILE_MAP[path]
-  let offset = getOffset(line, col, fi)
-
-  if (!fi.tree) return ''
-
-  let node = fi.tree!.resolve(offset)
-  let entity = getNodeEntity(node)
-  while (!entity && node.parent) {
-    node = node.parent
-    entity = getNodeEntity(node)
-  }
-
-  if (!entity) return ''
-  if (entity.entityType == 'field') {
-    let desc = entity.field.metadata?.description ? `\n\n${entity.field.metadata.description}` : ''
-    return `#### ${entity.table.name}.${entity.field.name}${desc}`
-  }
-
-  if (entity.entityType == 'table') {
-    let desc = entity.table.metadata?.description ? `\n\n${entity.table.metadata.description}` : ''
-    return `#### ${entity.table.name}${desc}`
-  }
-  return ''
+function currentFiles(result?: AnalysisResult) {
+  if (result) return result.files
+  return {...legacyWorkspace, ...legacyResult.files}
 }
 
-export function getDefinition(path: string, line: number, col: number): Location | null {
-  let symbol = getNavigationTarget(path, line, col)
-  return symbol?.location || null
+export function getDiagnostics() {
+  return legacyResult.diagnostics
 }
 
-export function getReferences(path: string, line: number, col: number, includeDeclaration = false): Location[] {
-  let symbol = getNavigationTarget(path, line, col)
-  if (!symbol) return []
-
-  let references = Object.values(FILE_MAP).flatMap(file => file.navigation.references.filter(ref => ref.targetId == symbol.id).map(ref => ref.location))
-  if (includeDeclaration) return [symbol.location, ...references]
-  return references
+export function getTable(name: string): Table | undefined
+export function getTable(result: AnalysisResult, name: string): Table | undefined
+export function getTable(arg1: string | AnalysisResult, arg2?: string) {
+  let [result, name] = typeof arg1 == 'string' ? [undefined, arg1] : [arg1, arg2!]
+  return Object.values(currentFiles(result))
+    .flatMap(file => file.tables)
+    .find(table => table.name == name)
 }
 
-function getNavigationTarget(path: string, line: number, col: number) {
-  let fi = FILE_MAP[path]
+export function getFile(name: string): FileInfo | undefined
+export function getFile(result: AnalysisResult, name: string): FileInfo | undefined
+export function getFile(arg1: string | AnalysisResult, arg2?: string) {
+  let [result, name] = typeof arg1 == 'string' ? [undefined, arg1] : [arg1, arg2!]
+  return currentFiles(result)[name]
+}
+
+export function getFiles(): FileInfo[]
+export function getFiles(result: AnalysisResult): FileInfo[]
+export function getFiles(result?: AnalysisResult) {
+  return Object.values(currentFiles(result))
+}
+
+function findColumn(result: AnalysisResult, symbolId: string) {
+  for (let file of Object.values(result.files)) {
+    for (let table of file.tables) {
+      let column = table.columns.find(col => col.symbolId == symbolId)
+      if (column) return {table, column}
+    }
+  }
+  return null
+}
+
+function findTableBySymbol(result: AnalysisResult, symbolId: string) {
+  return Object.values(result.files)
+    .flatMap(file => file.tables)
+    .find(table => table.symbolId == symbolId)
+}
+
+function getNavigationTarget(result: AnalysisResult, path: string, line: number, col: number) {
+  let fi = result.files[path]
   if (!fi) return null
 
   let offset = getSourceOffset(line, col, fi)
   let reference = fi.navigation.references.find(ref => containsOffset(ref.location, offset))
   if (reference) {
-    return Object.values(FILE_MAP)
+    return Object.values(result.files)
       .flatMap(file => file.navigation.symbols)
       .find(symbol => symbol.id == reference.targetId)
   }
 
   return fi.navigation.symbols.find(symbol => containsOffset(symbol.location, offset)) || null
+}
+
+export function getHover(path: string, line: number, col: number): string
+export function getHover(result: AnalysisResult, path: string, line: number, col: number): string
+export function getHover(arg1: string | AnalysisResult, arg2: string | number, arg3?: number, arg4?: number) {
+  let [result, path, line, col] = typeof arg1 == 'string' ? [legacyResult, arg1, arg2 as number, arg3 as number] : [arg1, arg2 as string, arg3 as number, arg4 as number]
+  let symbol = getNavigationTarget(result, path, line, col)
+  if (!symbol) return ''
+
+  if (symbol.kind == 'column') {
+    let entity = findColumn(result, symbol.id)
+    if (!entity) return ''
+    let desc = entity.column.metadata?.description ? `\n\n${entity.column.metadata.description}` : ''
+    return `#### ${entity.table.name}.${entity.column.name}${desc}`
+  }
+
+  let table = findTableBySymbol(result, symbol.id)
+  if (!table) return ''
+  let desc = table.metadata?.description ? `\n\n${table.metadata.description}` : ''
+  return `#### ${table.name}${desc}`
+}
+
+export function getDefinition(path: string, line: number, col: number): Location | null
+export function getDefinition(result: AnalysisResult, path: string, line: number, col: number): Location | null
+export function getDefinition(arg1: string | AnalysisResult, arg2: string | number, arg3?: number, arg4?: number) {
+  let [result, path, line, col] = typeof arg1 == 'string' ? [legacyResult, arg1, arg2 as number, arg3 as number] : [arg1, arg2 as string, arg3 as number, arg4 as number]
+  let symbol = getNavigationTarget(result, path, line, col)
+  return symbol?.location || null
+}
+
+export function getReferences(path: string, line: number, col: number, includeDeclaration?: boolean): Location[]
+export function getReferences(result: AnalysisResult, path: string, line: number, col: number, includeDeclaration?: boolean): Location[]
+export function getReferences(arg1: string | AnalysisResult, arg2: string | number, arg3?: number, arg4?: number | boolean, arg5?: boolean) {
+  let [result, path, line, col, includeDeclaration] =
+    typeof arg1 == 'string' ? [legacyResult, arg1, arg2 as number, arg3 as number, (arg4 as boolean) || false] : [arg1, arg2 as string, arg3 as number, arg4 as number, arg5 || false]
+  let symbol = getNavigationTarget(result, path, line, col)
+  if (!symbol) return []
+
+  let references = Object.values(result.files).flatMap(file => file.navigation.references.filter(ref => ref.targetId == symbol.id).map(ref => ref.location))
+  if (includeDeclaration) return [symbol.location, ...references]
+  return references
 }
 
 function containsOffset(location: Location, offset: number) {

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -7,18 +7,18 @@ import {config, loadConfig} from './config.ts'
 import {parseMarkdown} from './markdown.ts'
 import {fillInParams} from './params.ts'
 import {parser} from './parser.js'
-import {type AnalysisFileInput, type AnalysisInput, type AnalysisOptions, type AnalysisResult, type FileInfo, type Location, type Query, type Table} from './types.ts'
+import {type AnalysisFileInput, type AnalysisInput, type AnalysisOptions, type WorkspaceAnalysis, type FileInfo, type Location, type Query, type Table} from './types.ts'
 import {getSourceOffset} from './util.ts'
 
 export {config, loadConfig}
-export type {AnalysisFileInput, AnalysisInput, AnalysisOptions, AnalysisResult, Query, Table, GrapheneError} from './types.ts'
+export type {AnalysisFileInput, AnalysisInput, AnalysisOptions, WorkspaceAnalysis as AnalysisResult, Query, Table, GrapheneError} from './types.ts'
 
 // `analyzeProject(...)` is the real pure API now. These module-level values only exist
 // to preserve the older stateful `core.ts` interface used by the CLI/tests/IDE helpers:
 // callers mutate a workspace snapshot with `updateFile/loadWorkspace`, then `analyze()`
 // materializes a fresh pure result and stores it here for the legacy getter functions.
 let legacyWorkspace: Record<string, FileInfo> = {}
-let legacyResult: AnalysisResult = {files: {}, diagnostics: [], queries: []}
+let legacyResult: WorkspaceAnalysis = {files: {}, diagnostics: [], queries: []}
 
 function toAnalysisOptions(options: Partial<AnalysisOptions> = config): AnalysisOptions {
   return {dialect: options.dialect || 'duckdb', defaultNamespace: options.defaultNamespace}
@@ -41,7 +41,7 @@ function isMarkdownFile(file: AnalysisFileInput) {
 }
 
 // Pure analysis API. Callers provide files and options explicitly and receive the full analyzed result.
-export function analyzeProject(input: AnalysisInput): AnalysisResult {
+export function analyzeProject(input: AnalysisInput): WorkspaceAnalysis {
   let files = Object.fromEntries(input.files.map(file => [file.path, createFileInfo(file)]))
   let ctx = createAnalysisContext(files, input.options)
 
@@ -143,7 +143,7 @@ export function toSql(query: Query, params: Record<string, any> = {}): string {
   return query.sql
 }
 
-function currentFiles(result?: AnalysisResult) {
+function currentFiles(result?: WorkspaceAnalysis) {
   if (result) return result.files
   return {...legacyWorkspace, ...legacyResult.files}
 }
@@ -153,8 +153,8 @@ export function getDiagnostics() {
 }
 
 export function getTable(name: string): Table | undefined
-export function getTable(result: AnalysisResult, name: string): Table | undefined
-export function getTable(arg1: string | AnalysisResult, arg2?: string) {
+export function getTable(result: WorkspaceAnalysis, name: string): Table | undefined
+export function getTable(arg1: string | WorkspaceAnalysis, arg2?: string) {
   let [result, name] = typeof arg1 == 'string' ? [undefined, arg1] : [arg1, arg2!]
   return Object.values(currentFiles(result))
     .flatMap(file => file.tables)
@@ -162,19 +162,19 @@ export function getTable(arg1: string | AnalysisResult, arg2?: string) {
 }
 
 export function getFile(name: string): FileInfo | undefined
-export function getFile(result: AnalysisResult, name: string): FileInfo | undefined
-export function getFile(arg1: string | AnalysisResult, arg2?: string) {
+export function getFile(result: WorkspaceAnalysis, name: string): FileInfo | undefined
+export function getFile(arg1: string | WorkspaceAnalysis, arg2?: string) {
   let [result, name] = typeof arg1 == 'string' ? [undefined, arg1] : [arg1, arg2!]
   return currentFiles(result)[name]
 }
 
 export function getFiles(): FileInfo[]
-export function getFiles(result: AnalysisResult): FileInfo[]
-export function getFiles(result?: AnalysisResult) {
+export function getFiles(result: WorkspaceAnalysis): FileInfo[]
+export function getFiles(result?: WorkspaceAnalysis) {
   return Object.values(currentFiles(result))
 }
 
-function findColumn(result: AnalysisResult, symbolId: string) {
+function findColumn(result: WorkspaceAnalysis, symbolId: string) {
   for (let file of Object.values(result.files)) {
     for (let table of file.tables) {
       let column = table.columns.find(col => col.symbolId == symbolId)
@@ -184,13 +184,13 @@ function findColumn(result: AnalysisResult, symbolId: string) {
   return null
 }
 
-function findTableBySymbol(result: AnalysisResult, symbolId: string) {
+function findTableBySymbol(result: WorkspaceAnalysis, symbolId: string) {
   return Object.values(result.files)
     .flatMap(file => file.tables)
     .find(table => table.symbolId == symbolId)
 }
 
-function getNavigationTarget(result: AnalysisResult, path: string, line: number, col: number) {
+function getNavigationTarget(result: WorkspaceAnalysis, path: string, line: number, col: number) {
   let fi = result.files[path]
   if (!fi) return null
 
@@ -206,8 +206,8 @@ function getNavigationTarget(result: AnalysisResult, path: string, line: number,
 }
 
 export function getHover(path: string, line: number, col: number): string
-export function getHover(result: AnalysisResult, path: string, line: number, col: number): string
-export function getHover(arg1: string | AnalysisResult, arg2: string | number, arg3?: number, arg4?: number) {
+export function getHover(result: WorkspaceAnalysis, path: string, line: number, col: number): string
+export function getHover(arg1: string | WorkspaceAnalysis, arg2: string | number, arg3?: number, arg4?: number) {
   let [result, path, line, col] = typeof arg1 == 'string' ? [legacyResult, arg1, arg2 as number, arg3 as number] : [arg1, arg2 as string, arg3 as number, arg4 as number]
   let symbol = getNavigationTarget(result, path, line, col)
   if (!symbol) return ''
@@ -226,16 +226,16 @@ export function getHover(arg1: string | AnalysisResult, arg2: string | number, a
 }
 
 export function getDefinition(path: string, line: number, col: number): Location | null
-export function getDefinition(result: AnalysisResult, path: string, line: number, col: number): Location | null
-export function getDefinition(arg1: string | AnalysisResult, arg2: string | number, arg3?: number, arg4?: number) {
+export function getDefinition(result: WorkspaceAnalysis, path: string, line: number, col: number): Location | null
+export function getDefinition(arg1: string | WorkspaceAnalysis, arg2: string | number, arg3?: number, arg4?: number) {
   let [result, path, line, col] = typeof arg1 == 'string' ? [legacyResult, arg1, arg2 as number, arg3 as number] : [arg1, arg2 as string, arg3 as number, arg4 as number]
   let symbol = getNavigationTarget(result, path, line, col)
   return symbol?.location || null
 }
 
 export function getReferences(path: string, line: number, col: number, includeDeclaration?: boolean): Location[]
-export function getReferences(result: AnalysisResult, path: string, line: number, col: number, includeDeclaration?: boolean): Location[]
-export function getReferences(arg1: string | AnalysisResult, arg2: string | number, arg3?: number, arg4?: number | boolean, arg5?: boolean) {
+export function getReferences(result: WorkspaceAnalysis, path: string, line: number, col: number, includeDeclaration?: boolean): Location[]
+export function getReferences(arg1: string | WorkspaceAnalysis, arg2: string | number, arg3?: number, arg4?: number | boolean, arg5?: boolean) {
   let [result, path, line, col, includeDeclaration] =
     typeof arg1 == 'string' ? [legacyResult, arg1, arg2 as number, arg3 as number, (arg4 as boolean) || false] : [arg1, arg2 as string, arg3 as number, arg4 as number, arg5 || false]
   let symbol = getNavigationTarget(result, path, line, col)

--- a/lang/features.test.ts
+++ b/lang/features.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'vitest'
 
 /// <reference types="vitest/globals" />
-import {analyze, getDefinition, getHover, getReferences, clearWorkspace, updateFile} from './core.ts'
+import {analyze, analyzeProject, getDefinition, getFile, getHover, getReferences, clearWorkspace, updateFile} from './core.ts'
 
 function simple(location: ReturnType<typeof getDefinition>) {
   if (!location) return null
@@ -169,5 +169,47 @@ describe('reference navigation', () => {
 from users as u select u.name as display_name`)
 
     expect(getDefinition('input', 1, 33)).toBeNull()
+  })
+})
+
+describe('pure analysis api', () => {
+  it('analyzes a workspace without relying on legacy globals', () => {
+    let result = analyzeProject({
+      options: {dialect: 'duckdb'},
+      targetPath: 'query.gsql',
+      files: [
+        {path: 'schema.gsql', contents: 'table users (id int, name text)'},
+        {path: 'query.gsql', contents: 'from users select name'},
+      ],
+    })
+
+    expect(result.diagnostics).toEqual([])
+    expect(result.queries).toHaveLength(1)
+    expect(result.files['schema.gsql']?.tables[0]?.name).toBe('users')
+  })
+
+  it('supports navigation helpers against an explicit result', () => {
+    let result = analyzeProject({
+      options: {dialect: 'duckdb'},
+      targetPath: 'input',
+      files: [{path: 'input', contents: 'table users (id int, name text)\nfrom users select name'}],
+    })
+
+    expect(getDefinition(result, 'input', 1, 18)).toEqual({
+      file: 'input',
+      from: expect.objectContaining({line: 0, col: 21}),
+      to: expect.objectContaining({line: 0, col: 25}),
+    })
+    expect(getHover(result, 'input', 1, 18)).toBe('#### users.name')
+  })
+
+  it('lets callers read files from an explicit pure result', () => {
+    let result = analyzeProject({
+      options: {dialect: 'duckdb'},
+      files: [{path: 'input', contents: 'table users (id int)'}],
+      targetPath: 'input',
+    })
+
+    expect(getFile(result, 'input')?.contents).toContain('table users')
   })
 })

--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -4,11 +4,10 @@ import type {FunctionDef, ArgDef} from './functionTypes.ts'
 
 import {diag, checkTypes} from './analyze.ts'
 import {bigQueryFunctions} from './bigQueryFunctions.ts'
-import {config} from './config.ts'
 import {duckDbFunctions} from './duckDbFunctions.ts'
 import {extendFanoutPath, mergeFanoutPaths, mergeSensitiveFanouts, normalizeExprFanout} from './fanout.ts'
 import {snowflakeFunctions} from './snowflakeFunctions.ts'
-import {type Expr, type FieldType, type Scope} from './types.ts'
+import {type AnalysisContext, type Expr, type FieldType, type Scope} from './types.ts'
 import {txt} from './util.ts'
 
 // The shape that analyzeFunction works with. Converted from FunctionDef at startup.
@@ -93,22 +92,22 @@ function findOverloads(name: string, dialect: string): Overload[] {
 // Function Call Analysis
 // ============================================================================
 
-type AnalyzeExprFn = (node: SyntaxNode, scope: Scope) => Expr
+type AnalyzeExprFn = (ctx: AnalysisContext, node: SyntaxNode, scope: Scope) => Expr
 
-export function analyzeFunction(node: SyntaxNode, scope: Scope, analyzeExpr: AnalyzeExprFn, opts: {isWindow?: boolean} = {}): Expr {
+export function analyzeFunction(ctx: AnalysisContext, node: SyntaxNode, scope: Scope, analyzeExpr: AnalyzeExprFn, opts: {isWindow?: boolean} = {}): Expr {
   let name = txt(node.getChild('Identifier')).toLowerCase()
   let argNodes = node.getChildren('Expression')
 
   // Check for percentile functions (p50, p90, etc.) before overload lookup
   let percentileMatch = /^p(\d+)$/.exec(name)
   if (percentileMatch) {
-    let args = argNodes.map(n => analyzeExpr(n, scope))
-    if (args[0]) checkTypes(args[0], ['number'], argNodes[0])
-    return analyzePercentile(node, args, percentileMatch[1], scope, opts)
+    let args = argNodes.map(n => analyzeExpr(ctx, n, scope))
+    if (args[0]) checkTypes(ctx, args[0], ['number'], argNodes[0])
+    return analyzePercentile(ctx, node, args, percentileMatch[1], scope, opts)
   }
 
   // Find matching overload
-  let overloads = findOverloads(name, config.dialect)
+  let overloads = findOverloads(name, ctx.options.dialect)
   let overload = overloads.find(o => {
     if (o.params.length == argNodes.length) return true
     if (!o.params.some(p => p.isVariadic)) return false
@@ -127,16 +126,16 @@ export function analyzeFunction(node: SyntaxNode, scope: Scope, analyzeExpr: Ana
     if (firstType?.type === 'sql native' && firstType?.rawType === 'kw') {
       return {sql: txt(argNode), type: 'sql native' as FieldType}
     }
-    let arg = analyzeExpr(argNode, scope)
+    let arg = analyzeExpr(ctx, argNode, scope)
     let allowed = overload?.params[paramIdx]?.allowedTypes.map(t => t.type as FieldType)
-    if (allowed) checkTypes(arg, allowed, argNode)
+    if (allowed) checkTypes(ctx, arg, allowed, argNode)
     return arg
   })
 
   if (!overload) {
-    if (overloads.length === 0) return diag(node, `Unknown function: ${name}`, {sql: 'NULL', type: 'error'})
+    if (overloads.length === 0) return diag(ctx, node, `Unknown function: ${name}`, {sql: 'NULL', type: 'error'})
     let expected = [...new Set(overloads.map(o => o.params.length))].sort().join(' or ')
-    return diag(node, `Wrong number of arguments for ${name}: expected ${expected}, got ${argNodes.length}`, {sql: 'NULL', type: 'error'})
+    return diag(ctx, node, `Wrong number of arguments for ${name}: expected ${expected}, got ${argNodes.length}`, {sql: 'NULL', type: 'error'})
   }
 
   let returnType: FieldType = overload.returnType.type as FieldType
@@ -162,15 +161,16 @@ export function analyzeFunction(node: SyntaxNode, scope: Scope, analyzeExpr: Ana
   }
 }
 
-function analyzePercentile(node: SyntaxNode, args: Expr[], digits: string, scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
+function analyzePercentile(ctx: AnalysisContext, node: SyntaxNode, args: Expr[], digits: string, scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
   let frac = Number(`0.${digits}`)
-  if (Number(digits) == 100) return diag(node, 'p100 is not allowed', {sql: 'NULL', type: 'error'})
-  if (Number(digits) == 0) return diag(node, 'p0 is not allowed', {sql: 'NULL', type: 'error'})
-  if (config.dialect == 'bigquery' && frac > 0.99) return diag(node, 'BigQuery only supports up to p99', {sql: 'NULL', type: 'error'})
+  let dialect = ctx.options.dialect
+  if (Number(digits) == 100) return diag(ctx, node, 'p100 is not allowed', {sql: 'NULL', type: 'error'})
+  if (Number(digits) == 0) return diag(ctx, node, 'p0 is not allowed', {sql: 'NULL', type: 'error'})
+  if (dialect == 'bigquery' && frac > 0.99) return diag(ctx, node, 'BigQuery only supports up to p99', {sql: 'NULL', type: 'error'})
 
   let inner = args[0]?.sql || 'NULL'
   let sql: string
-  switch (config.dialect) {
+  switch (dialect) {
     case 'duckdb':
       sql = `quantile_cont(${inner}, ${frac})`
       break
@@ -185,7 +185,7 @@ function analyzePercentile(node: SyntaxNode, args: Expr[], digits: string, scope
       sql = `PERCENTILE_CONT(${frac}) WITHIN GROUP (ORDER BY ${inner})`
       break
     default:
-      return diag(node, `Percentile not supported for ${config.dialect}`, {sql: 'NULL', type: 'error'})
+      return diag(ctx, node, `Percentile not supported for ${dialect}`, {sql: 'NULL', type: 'error'})
   }
   return {
     sql,

--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -7,7 +7,7 @@ import {bigQueryFunctions} from './bigQueryFunctions.ts'
 import {duckDbFunctions} from './duckDbFunctions.ts'
 import {extendFanoutPath, mergeFanoutPaths, mergeSensitiveFanouts, normalizeExprFanout} from './fanout.ts'
 import {snowflakeFunctions} from './snowflakeFunctions.ts'
-import {type AnalysisContext, type Expr, type FieldType, type Scope} from './types.ts'
+import {type Workspace, type Expr, type FieldType, type Scope} from './types.ts'
 import {txt} from './util.ts'
 
 // The shape that analyzeFunction works with. Converted from FunctionDef at startup.
@@ -92,9 +92,9 @@ function findOverloads(name: string, dialect: string): Overload[] {
 // Function Call Analysis
 // ============================================================================
 
-type AnalyzeExprFn = (ctx: AnalysisContext, node: SyntaxNode, scope: Scope) => Expr
+type AnalyzeExprFn = (ctx: Workspace, node: SyntaxNode, scope: Scope) => Expr
 
-export function analyzeFunction(ctx: AnalysisContext, node: SyntaxNode, scope: Scope, analyzeExpr: AnalyzeExprFn, opts: {isWindow?: boolean} = {}): Expr {
+export function analyzeFunction(ctx: Workspace, node: SyntaxNode, scope: Scope, analyzeExpr: AnalyzeExprFn, opts: {isWindow?: boolean} = {}): Expr {
   let name = txt(node.getChild('Identifier')).toLowerCase()
   let argNodes = node.getChildren('Expression')
 
@@ -161,7 +161,7 @@ export function analyzeFunction(ctx: AnalysisContext, node: SyntaxNode, scope: S
   }
 }
 
-function analyzePercentile(ctx: AnalysisContext, node: SyntaxNode, args: Expr[], digits: string, scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
+function analyzePercentile(ctx: Workspace, node: SyntaxNode, args: Expr[], digits: string, scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
   let frac = Number(`0.${digits}`)
   let dialect = ctx.options.dialect
   if (Number(digits) == 100) return diag(ctx, node, 'p100 is not allowed', {sql: 'NULL', type: 'error'})

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -11,6 +11,19 @@ declare module '@lezer/common' {
 
 export type FieldType = 'string' | 'number' | 'boolean' | 'date' | 'timestamp' | 'json' | 'sql native' | 'error' | 'null' | 'interval' | 'array' | 'record'
 
+export interface Workspace {
+  files: Record<string, FileInfo>
+  diagnostics: GrapheneError[]
+  options: AnalysisOptions
+  analysisStack: Set<Column>
+}
+
+export interface WorkspaceAnalysis {
+  files: Record<string, FileInfo>
+  diagnostics: GrapheneError[]
+  queries: Query[]
+}
+
 export interface AnalysisOptions {
   dialect: string
   defaultNamespace?: string
@@ -159,19 +172,6 @@ export interface GrapheneError {
   from?: Position
   to?: Position
   frame?: string
-}
-
-export interface AnalysisContext {
-  files: Record<string, FileInfo>
-  diagnostics: GrapheneError[]
-  options: AnalysisOptions
-  analysisStack: Set<Column>
-}
-
-export interface AnalysisResult {
-  files: Record<string, FileInfo>
-  diagnostics: GrapheneError[]
-  queries: Query[]
 }
 
 export interface Location {

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -11,6 +11,25 @@ declare module '@lezer/common' {
 
 export type FieldType = 'string' | 'number' | 'boolean' | 'date' | 'timestamp' | 'json' | 'sql native' | 'error' | 'null' | 'interval' | 'array' | 'record'
 
+export interface AnalysisOptions {
+  dialect: string
+  defaultNamespace?: string
+}
+
+export interface AnalysisFileInput {
+  path: string
+  contents: string
+  // Only needed for legacy inline `analyze(contents, contentType)` calls, where the
+  // synthetic "input" path has no extension to tell md from gsql.
+  contentType?: 'gsql' | 'md'
+}
+
+export interface AnalysisInput {
+  files: AnalysisFileInput[]
+  options: AnalysisOptions
+  targetPath?: string
+}
+
 // An analyzed expression - contains the SQL string plus metadata for validation
 export interface Expr {
   sql: string // the SQL for this expression, e.g. "users.\"name\"" or "sum(users.\"amount\")"
@@ -140,6 +159,19 @@ export interface GrapheneError {
   from?: Position
   to?: Position
   frame?: string
+}
+
+export interface AnalysisContext {
+  files: Record<string, FileInfo>
+  diagnostics: GrapheneError[]
+  options: AnalysisOptions
+  analysisStack: Set<Column>
+}
+
+export interface AnalysisResult {
+  files: Record<string, FileInfo>
+  diagnostics: GrapheneError[]
+  queries: Query[]
 }
 
 export interface Location {


### PR DESCRIPTION
This PR refactors `analyze.ts` to remove its use of globals as inputs to analysis (`FILE_MAP` for workspace files, global `config` for dialect, `diagnostics` for outputs). It does not change the analysis logic at all, but just threads this context through. In this PR I have kept a global workspace + result (moved to `core.ts`) as a shim, but would aim to move callers over in a follow-up. Definitely open to suggestions on naming (maybe `AnalysisContext` -> `AnalysisWorkspace`?)