### PR TITLE
disable run-examples CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,4 +80,4 @@ jobs:
       - name: Run examples smoke test
         run: pnpm exec vitest run ui/tests/run-examples.test.ts --root .
         env:
-          GRAPHENE_RUN_EXAMPLES_TEST: '1'
+          GRAPHENE_RUN_EXAMPLES_TEST: '0'


### PR DESCRIPTION
The run-examples CI check is failing due to missing GDrive auth (I think?). This PR disables the test for now to unblock