### PR TITLE
refactor out global analysis shims

### DIFF
--- a/cli/check.ts
+++ b/cli/check.ts
@@ -1,7 +1,8 @@
 import {readFileSync} from 'node:fs'
 import path from 'path'
 
-import {analyze, config, getDiagnostics, loadWorkspace, updateFile} from '../lang/core.ts'
+import {analyzeProject, config} from '../lang/core.ts'
+import {listWorkspaceFiles, loadWorkspaceFiles, toAnalysisOptions, updateWorkspaceFile} from '../lang/workspace.ts'
 import {mockFileMap} from './mockFiles.ts'
 import {normalizeFile} from './normalizeFile.ts'
 import {printDiagnostics} from './printer.ts'
@@ -20,19 +21,26 @@ export async function check(options: CheckOptions): Promise<boolean> {
     return false
   }
 
-  await loadWorkspace(config.root, !targetFile)
-  if (targetFile) {
-    if (process.env.NODE_ENV == 'test' && mockFileMap[targetFile]) {
-      updateFile(mockFileMap[targetFile], targetFile)
-    } else {
-      let content = readFileSync(path.resolve(config.root, targetFile), 'utf-8')
-      updateFile(content, targetFile)
+  let files = await loadWorkspaceFiles(config.root, !targetFile)
+  if (process.env.NODE_ENV == 'test') {
+    for (let [mockPath, contents] of Object.entries(mockFileMap)) {
+      if (targetFile && (mockPath == targetFile || mockPath.endsWith('.md'))) continue
+      updateWorkspaceFile(files, contents, mockPath, mockPath.endsWith('.md') ? 'md' : 'gsql')
     }
   }
 
-  analyze()
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics(), log)
+  if (targetFile) {
+    if (process.env.NODE_ENV == 'test' && mockFileMap[targetFile]) {
+      updateWorkspaceFile(files, mockFileMap[targetFile], targetFile, targetFile.endsWith('.md') ? 'md' : 'gsql')
+    } else {
+      let content = readFileSync(path.resolve(config.root, targetFile), 'utf-8')
+      updateWorkspaceFile(files, content, targetFile, targetFile.endsWith('.md') ? 'md' : 'gsql')
+    }
+  }
+
+  let result = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions()})
+  if (result.diagnostics.length > 0) {
+    printDiagnostics(result.diagnostics, log)
     return false
   }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -7,7 +7,8 @@ import path from 'path'
 import {fileURLToPath} from 'url'
 
 import {config, loadConfig} from '../lang/config.ts'
-import {analyze, getDiagnostics, loadWorkspace, toSql, type Query} from '../lang/core.ts'
+import {analyzeProject, toSql, type Query} from '../lang/core.ts'
+import {listWorkspaceFiles, loadWorkspaceFiles, toAnalysisOptions} from '../lang/workspace.ts'
 import {loginPkce} from './auth.ts'
 import {runServeInBackground, stopGrapheneIfRunning} from './background.ts'
 import {check} from './check.ts'
@@ -33,10 +34,15 @@ program
   .description('Translate a query to SQL and print it')
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
   .action(async (input: string | undefined) => {
-    await loadWorkspace(process.cwd(), false)
+    let files = await loadWorkspaceFiles(process.cwd(), false)
     let sql = await readInput(input)
-    let queries = analyze(sql)
-    if (!validQuery(queries)) return
+    let result = analyzeProject({
+      files: [...listWorkspaceFiles(files), {path: '__input__.gsql', contents: sql, contentType: 'gsql'}],
+      targetPath: '__input__.gsql',
+      options: toAnalysisOptions(),
+    })
+    let queries = validQuery(result)
+    if (!queries) return
     console.log(toSql(queries[0]))
   })
 
@@ -68,10 +74,15 @@ program
       process.exit(1)
     }
 
-    await loadWorkspace(process.cwd(), false)
+    let files = await loadWorkspaceFiles(process.cwd(), false)
     let gsql = await readInput(input)
-    let queries = analyze(gsql)
-    if (!validQuery(queries)) return
+    let result = analyzeProject({
+      files: [...listWorkspaceFiles(files), {path: '__input__.gsql', contents: gsql, contentType: 'gsql'}],
+      targetPath: '__input__.gsql',
+      options: toAnalysisOptions(),
+    })
+    let queries = validQuery(result)
+    if (!queries) return
     let sql = toSql(queries[0])
     let res = await runQuery(sql)
     printTable(res.rows)
@@ -193,16 +204,16 @@ function getExistingPath(arg: string | undefined): string | null {
   return fs.existsSync(absolutePath) ? absolutePath : null
 }
 
-function validQuery(queries: Query[]): boolean {
-  if (getDiagnostics().length) {
-    printDiagnostics(getDiagnostics())
+function validQuery(result: {files: Record<string, any>; diagnostics: any[]; queries: Query[]}): Query[] | null {
+  if (result.diagnostics.length) {
+    printDiagnostics(result.diagnostics)
     process.exit(1)
   }
-  if (queries.length == 0) {
+  if (result.queries.length == 0) {
     console.warn('No queries found')
     process.exit(1)
   }
-  return true
+  return result.queries
 }
 
 function findCaseInsensitive(values: string[], needle: string): string | null {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -14,7 +14,7 @@ import {runServeInBackground, stopGrapheneIfRunning} from './background.ts'
 import {check} from './check.ts'
 import {getConnection, runQuery} from './connections/index.ts'
 import {printDiagnostics, printTable} from './printer.ts'
-import {runMdFile, runNamedQueryFromMd} from './run.ts'
+import {INLINE_INPUT_PATH, runMdFile, runNamedQueryFromMd} from './run.ts'
 
 const program = new Command()
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -37,8 +37,8 @@ program
     let files = await loadWorkspaceFiles(process.cwd(), false)
     let sql = await readInput(input)
     let result = analyzeProject({
-      files: [...listWorkspaceFiles(files), {path: '__input__.gsql', contents: sql, contentType: 'gsql'}],
-      targetPath: '__input__.gsql',
+      files: [...listWorkspaceFiles(files), {path: INLINE_INPUT_PATH, contents: sql, contentType: 'gsql'}],
+      targetPath: INLINE_INPUT_PATH,
       options: toAnalysisOptions(),
     })
     let queries = validQuery(result)
@@ -77,8 +77,8 @@ program
     let files = await loadWorkspaceFiles(process.cwd(), false)
     let gsql = await readInput(input)
     let result = analyzeProject({
-      files: [...listWorkspaceFiles(files), {path: '__input__.gsql', contents: gsql, contentType: 'gsql'}],
-      targetPath: '__input__.gsql',
+      files: [...listWorkspaceFiles(files), {path: INLINE_INPUT_PATH, contents: gsql, contentType: 'gsql'}],
+      targetPath: INLINE_INPUT_PATH,
       options: toAnalysisOptions(),
     })
     let queries = validQuery(result)

--- a/cli/printer.ts
+++ b/cli/printer.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import Table from 'cli-table3'
 import {styleText as nodeStyleText} from 'node:util'
 
-import {type GrapheneError} from '../lang/core.ts'
+import {type GrapheneError} from '../lang/types.ts'
 
 const styleText = (style: string, text: string) => {
   try {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -7,8 +7,9 @@ import path from 'path'
 import {type PluginOption, type ViteDevServer} from 'vite'
 import {WebSocketServer, type WebSocket} from 'ws'
 
-import {analyze, config, deleteFile, type GrapheneError, getDiagnostics, loadWorkspace, toSql, updateFile} from '../lang/core.ts'
+import {analyzeProject, config, type GrapheneError, toSql} from '../lang/core.ts'
 import {pollFor} from '../lang/util.ts'
+import {deleteWorkspaceFile, listWorkspaceFiles, loadWorkspaceFiles, toAnalysisOptions, updateWorkspaceFile} from '../lang/workspace.ts'
 import {openInBrowser} from './auth.ts'
 import {isServerRunning, runServeInBackground} from './background.ts'
 import {runQuery} from './connections/index.ts'
@@ -24,6 +25,7 @@ export interface RunMdFileOptions {
 
 let browserConnections: {url: string; socket: WebSocket}[] = []
 let pendingRequests: Record<string, {response: ServerResponse<IncomingMessage>}> = {}
+const INLINE_INPUT_PATH = '__input__.md'
 
 export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
   let log = options.log || console.log
@@ -33,21 +35,27 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
     return false
   }
 
-  await loadWorkspace(config.root, false)
+  let files = await loadWorkspaceFiles(config.root, false)
+  if (process.env.NODE_ENV == 'test') {
+    for (let [mockPath, contents] of Object.entries(mockFileMap)) {
+      if (mockPath.endsWith('.md') && mockPath != mdFile) continue
+      updateWorkspaceFile(files, contents, mockPath, mockPath.endsWith('.md') ? 'md' : 'gsql')
+    }
+  }
   if (process.env.NODE_ENV == 'test' && mockFileMap[mdFile]) {
-    updateFile(mockFileMap[mdFile], mdFile)
+    updateWorkspaceFile(files, mockFileMap[mdFile], mdFile, 'md')
   } else {
     let content = readFileSync(path.resolve(config.root, mdFile), 'utf-8')
-    updateFile(content, mdFile)
+    updateWorkspaceFile(files, content, mdFile, 'md')
   }
 
-  analyze()
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics(), log)
+  let result = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions()})
+  if (result.diagnostics.length > 0) {
+    printDiagnostics(result.diagnostics, log)
     return false
   }
 
-  if (process.env.NODE_ENV == 'test') deleteFile(mdFile)
+  if (process.env.NODE_ENV == 'test') deleteWorkspaceFile(files, mdFile)
 
   let host = `http://localhost:${config.port}`
   let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')
@@ -89,10 +97,19 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
     log('No errors found 💎')
   }
 
-  errors.forEach((e: GrapheneError) => {
-    if (e.file || e.frame) printDiagnostics([e], log)
-    else if (e.queryId) log(`${e.queryId}: ${e.message}`)
-    else log(e.message)
+  errors.forEach((e: any) => {
+    if (e.type === 'compile') {
+      let file = e.file && path.isAbsolute(e.file) ? path.relative(config.root, e.file) : e.file
+      let msg = e.message.replace(/^.*?:\d+:\d+\s*/, '').replace(/\s*https:\/\/svelte\.dev\/\S+/g, '')
+      log(`${styleText('red', 'ERROR')}: ${file} line ${e.line}: ${msg}`)
+      for (let frameLine of e.frame.split('\n')) log('  ' + frameLine)
+    } else if (e.file && e.from) {
+      printDiagnostics([e], log)
+    } else if (e.queryId) {
+      log(`${e.queryId}: ${e.message}`)
+    } else {
+      log(e.message)
+    }
   })
 
   if (resp?.stillLoading) {
@@ -111,25 +128,29 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
 }
 
 export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string): Promise<boolean> {
-  await loadWorkspace(process.cwd(), false)
+  let files = await loadWorkspaceFiles(process.cwd(), false)
   let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
   let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
 
-  updateFile(mdContents, mdRelativePath)
-  analyze()
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics())
+  updateWorkspaceFile(files, mdContents, mdRelativePath, 'md')
+  let pageResult = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions()})
+  if (pageResult.diagnostics.length > 0) {
+    printDiagnostics(pageResult.diagnostics)
     return false
   }
 
   let runQueryFence = [mdContents, '', '```sql', `from ${queryName} select *`, '```'].join('\n')
-  let queries = analyze(runQueryFence, 'md')
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics())
+  let queryResult = analyzeProject({
+    files: [...listWorkspaceFiles(files), {path: INLINE_INPUT_PATH, contents: runQueryFence, contentType: 'md'}],
+    targetPath: INLINE_INPUT_PATH,
+    options: toAnalysisOptions(),
+  })
+  if (queryResult.diagnostics.length > 0) {
+    printDiagnostics(queryResult.diagnostics)
     return false
   }
 
-  let sql = toSql(queries[queries.length - 1])
+  let sql = toSql(queryResult.queries[queryResult.queries.length - 1])
   let res = await runQuery(sql)
   printTable(res.rows)
   return true

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -25,7 +25,7 @@ export interface RunMdFileOptions {
 
 let browserConnections: {url: string; socket: WebSocket}[] = []
 let pendingRequests: Record<string, {response: ServerResponse<IncomingMessage>}> = {}
-const INLINE_INPUT_PATH = '__input__.md'
+export const INLINE_INPUT_PATH = 'input'
 
 export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
   let log = options.log || console.log

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -14,7 +14,7 @@ import {listWorkspaceFiles, loadWorkspaceFiles, toAnalysisOptions} from '../lang
 import {runQuery} from './connections/index.ts'
 import {injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 import {mockFileMap} from './mockFiles.ts'
-import {runVitePlugin} from './run.ts'
+import {INLINE_INPUT_PATH, runVitePlugin} from './run.ts'
 
 // Collect Svelte compiler warnings for test assertions
 export type SvelteWarning = {code: string; message: string; filename?: string}
@@ -121,8 +121,8 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
 
   await workspaceLoadPromise
   let result = analyzeProject({
-    files: [...listWorkspaceFiles(workspaceFiles), {path: '__input__.gsql', contents: gsql, contentType: 'gsql'}],
-    targetPath: '__input__.gsql',
+    files: [...listWorkspaceFiles(workspaceFiles), {path: INLINE_INPUT_PATH, contents: gsql, contentType: 'gsql'}],
+    targetPath: INLINE_INPUT_PATH,
     options: toAnalysisOptions(),
   })
 

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -8,7 +8,9 @@ import path from 'path'
 import {fileURLToPath} from 'url'
 import {createServer, type InlineConfig, optimizeDeps, resolveConfig, type ViteDevServer} from 'vite'
 
-import {loadWorkspace, config, clearWorkspace, analyze, getDiagnostics, toSql, getFiles} from '../lang/core.ts'
+import {analyzeProject, config, toSql} from '../lang/core.ts'
+import {type AnalysisFileInput} from '../lang/types.ts'
+import {listWorkspaceFiles, loadWorkspaceFiles, toAnalysisOptions} from '../lang/workspace.ts'
 import {runQuery} from './connections/index.ts'
 import {injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 import {mockFileMap} from './mockFiles.ts'
@@ -118,17 +120,20 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
   res.setHeader('Content-Type', 'application/json')
 
   await workspaceLoadPromise
-  let queries = analyze(gsql)
+  let result = analyzeProject({
+    files: [...listWorkspaceFiles(workspaceFiles), {path: '__input__.gsql', contents: gsql, contentType: 'gsql'}],
+    targetPath: '__input__.gsql',
+    options: toAnalysisOptions(),
+  })
 
-  let diagnostics = getDiagnostics()
-  if (diagnostics.length) {
+  if (result.diagnostics.length) {
     res.statusCode = 400
-    res.end(JSON.stringify(diagnostics[0]))
+    res.end(JSON.stringify(result.diagnostics))
     return
   }
 
-  if (queries.length > 1) throw new Error('Found multiple queries, which could be a parsing error')
-  let sql = toSql(queries[0], params)
+  if (result.queries.length > 1) throw new Error('Found multiple queries, which could be a parsing error')
+  let sql = toSql(result.queries[0], params)
 
   // If the client already has this data, dont run the query
   let hash = crypto.createHash('SHA1').update(sql).digest('hex')
@@ -141,7 +146,7 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
   let queryResults = await runQuery(sql)
   let totalRows = queryResults.totalRows ?? queryResults.rows.length
   if (totalRows > queryResults.rows.length) throw new Error('Query returns too many rows')
-  let fields = queries[0].fields.map(f => ({name: f.name, type: f.type}))
+  let fields = result.queries[0].fields.map(f => ({name: f.name, type: f.type}))
   res.end(JSON.stringify({rows: queryResults.rows, hash, fields, sql}))
 }
 
@@ -222,6 +227,7 @@ function fixHmrForFailedModules() {
 // Also tracks all the md files in the workspace to populate the nav sidebar
 let workspaceLoadPromise: Promise<void> | undefined
 let mdFiles: string[] = []
+let workspaceFiles: Record<string, AnalysisFileInput> = {}
 const updateWorkspacePlugin = {
   name: 'updateWorkspace',
   resolveId(id: string) {
@@ -239,10 +245,11 @@ const updateWorkspacePlugin = {
   },
   configureServer: (s: ViteDevServer) => {
     let refresh = async () => {
-      clearWorkspace()
-      workspaceLoadPromise = loadWorkspace(config.root, true)
+      workspaceLoadPromise = loadWorkspaceFiles(config.root, true).then(files => {
+        workspaceFiles = files
+      })
       await workspaceLoadPromise
-      mdFiles = getFiles()
+      mdFiles = listWorkspaceFiles(workspaceFiles)
         .filter(f => f.path.endsWith('.md'))
         .map(f => f.path)
       mdFiles = mdFiles.filter(f => !config.ignoredFiles?.includes(path.basename(f).toLowerCase()))

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -1,28 +1,13 @@
-import {glob} from 'glob'
-import {readFile} from 'node:fs/promises'
-import path from 'node:path'
-
 import {analyzeQuery, analyzeTableFully, applyExtends, createAnalysisContext, findTables, recordSyntaxErrors} from './analyze.ts'
 import {config, loadConfig} from './config.ts'
 import {parseMarkdown} from './markdown.ts'
 import {fillInParams} from './params.ts'
 import {parser} from './parser.js'
-import {type AnalysisFileInput, type AnalysisInput, type AnalysisOptions, type WorkspaceAnalysis, type FileInfo, type Location, type Query, type Table} from './types.ts'
+import {type AnalysisFileInput, type AnalysisInput, type WorkspaceAnalysis, type FileInfo, type Location, type Query} from './types.ts'
 import {getSourceOffset} from './util.ts'
 
 export {config, loadConfig}
 export type {AnalysisFileInput, AnalysisInput, AnalysisOptions, WorkspaceAnalysis as AnalysisResult, Query, Table, GrapheneError} from './types.ts'
-
-// `analyzeProject(...)` is the real pure API now. These module-level values only exist
-// to preserve the older stateful `core.ts` interface used by the CLI/tests/IDE helpers:
-// callers mutate a workspace snapshot with `updateFile/loadWorkspace`, then `analyze()`
-// materializes a fresh pure result and stores it here for the legacy getter functions.
-let legacyWorkspace: Record<string, FileInfo> = {}
-let legacyResult: WorkspaceAnalysis = {files: {}, diagnostics: [], queries: []}
-
-function toAnalysisOptions(options: Partial<AnalysisOptions> = config): AnalysisOptions {
-  return {dialect: options.dialect || 'duckdb', defaultNamespace: options.defaultNamespace}
-}
 
 function createFileInfo(input: AnalysisFileInput): FileInfo {
   return {
@@ -77,101 +62,24 @@ export function analyzeProject(input: AnalysisInput): WorkspaceAnalysis {
   }
 }
 
-export function clearWorkspace() {
-  legacyWorkspace = {}
-  legacyResult = {files: {}, diagnostics: [], queries: []}
-}
-
-// Loads all gsql files within a directory into the legacy workspace state.
-export async function loadWorkspace(dir: string, includeMd: boolean) {
-  let ignore = ['node_modules/**', '**/.*/**', ...(config.ignoredFiles || [])]
-  let files = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore, follow: false})
-  for await (let file of files) {
-    try {
-      let contents = await readFile(path.join(dir, file), 'utf-8')
-      updateFile(contents, file)
-    } catch (e: any) {
-      console.error('Failed to read file', file, e.message)
-    }
-  }
-}
-
-export function updateFile(contents: string, path: string, contentType?: 'gsql' | 'md') {
-  legacyWorkspace[path] ||= createFileInfo({path, contents, contentType})
-  Object.assign(legacyWorkspace[path], {
-    contents,
-    tree: null,
-    tables: [],
-    queries: [],
-    navigation: {symbols: [], references: []},
-  })
-  delete legacyWorkspace[path].virtualContents
-  delete legacyWorkspace[path].virtualToMarkdownOffset
-  return legacyWorkspace[path]
-}
-
-export function deleteFile(path: string) {
-  delete legacyWorkspace[path]
-  if (legacyResult.files[path]) {
-    let files = {...legacyResult.files}
-    delete files[path]
-    legacyResult = {...legacyResult, files}
-  }
-}
-
-// Legacy compatibility wrapper. If content is provided, it is analyzed as a temporary "input" file.
-export function analyze(contents?: string, contentType?: 'gsql' | 'md'): Query[] {
-  let files = Object.values(legacyWorkspace).map(fi => ({path: fi.path, contents: fi.contents, contentType: fi.path.endsWith('.md') ? 'md' : 'gsql'}) as AnalysisFileInput)
-  let targetPath: string | undefined
-
-  if (contents != null) {
-    targetPath = 'input'
-    files.push({path: 'input', contents, contentType})
-  }
-
-  legacyResult = analyzeProject({files, targetPath, options: toAnalysisOptions()})
-  for (let [path, fi] of Object.entries(legacyResult.files)) {
-    if (path == 'input') continue
-    legacyWorkspace[path] = fi
-  }
-  return legacyResult.queries
-}
-
 export function toSql(query: Query, params: Record<string, any> = {}): string {
   query = structuredClone(query)
   fillInParams(query, params)
   return query.sql
 }
 
-function currentFiles(result?: WorkspaceAnalysis) {
-  if (result) return result.files
-  return {...legacyWorkspace, ...legacyResult.files}
-}
-
-export function getDiagnostics() {
-  return legacyResult.diagnostics
-}
-
-export function getTable(name: string): Table | undefined
-export function getTable(result: WorkspaceAnalysis, name: string): Table | undefined
-export function getTable(arg1: string | WorkspaceAnalysis, arg2?: string) {
-  let [result, name] = typeof arg1 == 'string' ? [undefined, arg1] : [arg1, arg2!]
-  return Object.values(currentFiles(result))
+export function getTable(result: WorkspaceAnalysis, name: string) {
+  return Object.values(result.files)
     .flatMap(file => file.tables)
     .find(table => table.name == name)
 }
 
-export function getFile(name: string): FileInfo | undefined
-export function getFile(result: WorkspaceAnalysis, name: string): FileInfo | undefined
-export function getFile(arg1: string | WorkspaceAnalysis, arg2?: string) {
-  let [result, name] = typeof arg1 == 'string' ? [undefined, arg1] : [arg1, arg2!]
-  return currentFiles(result)[name]
+export function getFile(result: WorkspaceAnalysis, name: string) {
+  return result.files[name]
 }
 
-export function getFiles(): FileInfo[]
-export function getFiles(result: WorkspaceAnalysis): FileInfo[]
-export function getFiles(result?: WorkspaceAnalysis) {
-  return Object.values(currentFiles(result))
+export function getFiles(result: WorkspaceAnalysis) {
+  return Object.values(result.files)
 }
 
 function findColumn(result: WorkspaceAnalysis, symbolId: string) {
@@ -205,10 +113,7 @@ function getNavigationTarget(result: WorkspaceAnalysis, path: string, line: numb
   return fi.navigation.symbols.find(symbol => containsOffset(symbol.location, offset)) || null
 }
 
-export function getHover(path: string, line: number, col: number): string
-export function getHover(result: WorkspaceAnalysis, path: string, line: number, col: number): string
-export function getHover(arg1: string | WorkspaceAnalysis, arg2: string | number, arg3?: number, arg4?: number) {
-  let [result, path, line, col] = typeof arg1 == 'string' ? [legacyResult, arg1, arg2 as number, arg3 as number] : [arg1, arg2 as string, arg3 as number, arg4 as number]
+export function getHover(result: WorkspaceAnalysis, path: string, line: number, col: number): string {
   let symbol = getNavigationTarget(result, path, line, col)
   if (!symbol) return ''
 
@@ -225,19 +130,12 @@ export function getHover(arg1: string | WorkspaceAnalysis, arg2: string | number
   return `#### ${table.name}${desc}`
 }
 
-export function getDefinition(path: string, line: number, col: number): Location | null
-export function getDefinition(result: WorkspaceAnalysis, path: string, line: number, col: number): Location | null
-export function getDefinition(arg1: string | WorkspaceAnalysis, arg2: string | number, arg3?: number, arg4?: number) {
-  let [result, path, line, col] = typeof arg1 == 'string' ? [legacyResult, arg1, arg2 as number, arg3 as number] : [arg1, arg2 as string, arg3 as number, arg4 as number]
+export function getDefinition(result: WorkspaceAnalysis, path: string, line: number, col: number): Location | null {
   let symbol = getNavigationTarget(result, path, line, col)
   return symbol?.location || null
 }
 
-export function getReferences(path: string, line: number, col: number, includeDeclaration?: boolean): Location[]
-export function getReferences(result: WorkspaceAnalysis, path: string, line: number, col: number, includeDeclaration?: boolean): Location[]
-export function getReferences(arg1: string | WorkspaceAnalysis, arg2: string | number, arg3?: number, arg4?: number | boolean, arg5?: boolean) {
-  let [result, path, line, col, includeDeclaration] =
-    typeof arg1 == 'string' ? [legacyResult, arg1, arg2 as number, arg3 as number, (arg4 as boolean) || false] : [arg1, arg2 as string, arg3 as number, arg4 as number, arg5 || false]
+export function getReferences(result: WorkspaceAnalysis, path: string, line: number, col: number, includeDeclaration = false): Location[] {
   let symbol = getNavigationTarget(result, path, line, col)
   if (!symbol) return []
 

--- a/lang/features.test.ts
+++ b/lang/features.test.ts
@@ -1,7 +1,8 @@
 import {expect} from 'vitest'
 
 /// <reference types="vitest/globals" />
-import {analyze, analyzeProject, getDefinition, getFile, getHover, getReferences, clearWorkspace, updateFile} from './core.ts'
+import {analyzeProject, getDefinition, getFile, getHover, getReferences} from './core.ts'
+import {analyzeInline, createTestWorkspace} from './testHelpers.ts'
 
 function simple(location: ReturnType<typeof getDefinition>) {
   if (!location) return null
@@ -21,44 +22,36 @@ function simpleList(locations: ReturnType<typeof getReferences>) {
 }
 
 describe('hover', () => {
-  beforeEach(() => {
-    clearWorkspace()
-  })
-
   it('returns column info when hovering a selected column', () => {
-    analyze(`table users (
+    let result = analyzeInline(`table users (
       id int,
       -- first and last
       name text
     )
     from users select id, name`)
 
-    let hover = getHover('input', 4, 33)
+    let hover = getHover(result, 'input', 4, 33)
     expect(hover).toBe('#### users.name\n\nfirst and last')
   })
 
   it('returns table info when hovering a table', () => {
-    analyze(`
+    let result = analyzeInline(`
       -- all the users in our system
       table users (id int, name text)
     from users select id, name`)
 
     // Hover over 'f' in 'from' (line 4, col 0)
-    let hover = getHover('input', 3, 12)
+    let hover = getHover(result, 'input', 3, 12)
     expect(hover).toBe('#### users\n\nall the users in our system')
   })
 })
 
 describe('definition navigation', () => {
-  beforeEach(() => {
-    clearWorkspace()
-  })
-
   it('returns the table definition for a FROM reference', () => {
-    analyze(`table users (id int, name text)
+    let result = analyzeInline(`table users (id int, name text)
 from users select name`)
 
-    expect(simple(getDefinition('input', 1, 6))).toEqual({
+    expect(simple(getDefinition(result, 'input', 1, 6))).toEqual({
       file: 'input',
       from: [0, 6],
       to: [0, 11],
@@ -66,10 +59,10 @@ from users select name`)
   })
 
   it('returns the column definition for a column reference', () => {
-    analyze(`table users (id int, name text)
+    let result = analyzeInline(`table users (id int, name text)
 from users select name`)
 
-    expect(simple(getDefinition('input', 1, 18))).toEqual({
+    expect(simple(getDefinition(result, 'input', 1, 18))).toEqual({
       file: 'input',
       from: [0, 21],
       to: [0, 25],
@@ -77,13 +70,13 @@ from users select name`)
   })
 
   it('returns the view output definition for a referenced view column', () => {
-    analyze(`table users (id int, name text)
+    let result = analyzeInline(`table users (id int, name text)
 table active_users as (
   from users select name as display_name
 )
 from active_users select display_name`)
 
-    expect(simple(getDefinition('input', 4, 25))).toEqual({
+    expect(simple(getDefinition(result, 'input', 4, 25))).toEqual({
       file: 'input',
       from: [2, 28],
       to: [2, 40],
@@ -91,24 +84,24 @@ from active_users select display_name`)
   })
 
   it('returns definitions for join condition references', () => {
-    analyze(`table users (id int, name text)
+    let result = analyzeInline(`table users (id int, name text)
 table orders (
   id int,
   user_id int,
   join one users on users.id = user_id
 )`)
 
-    expect(simple(getDefinition('input', 4, 11))).toEqual({
+    expect(simple(getDefinition(result, 'input', 4, 11))).toEqual({
       file: 'input',
       from: [0, 6],
       to: [0, 11],
     })
-    expect(simple(getDefinition('input', 4, 26))).toEqual({
+    expect(simple(getDefinition(result, 'input', 4, 26))).toEqual({
       file: 'input',
       from: [0, 13],
       to: [0, 15],
     })
-    expect(simple(getDefinition('input', 4, 31))).toEqual({
+    expect(simple(getDefinition(result, 'input', 4, 31))).toEqual({
       file: 'input',
       from: [3, 2],
       to: [3, 9],
@@ -116,16 +109,15 @@ table orders (
   })
 
   it('maps markdown table definitions back to the fence header', () => {
-    analyze(
+    let result = analyzeInline(
       `\`\`\`gsql users
 select 1 as id
 \`\`\`
 
 <Value data="users" value="id" />`,
-      'md',
     )
 
-    expect(simple(getDefinition('input', 4, 13))).toEqual({
+    expect(simple(getDefinition(result, 'input', 4, 13))).toEqual({
       file: 'input',
       from: [0, 8],
       to: [0, 13],
@@ -134,17 +126,15 @@ select 1 as id
 })
 
 describe('reference navigation', () => {
-  beforeEach(() => {
-    clearWorkspace()
-  })
-
   it('finds references across files for a table definition', () => {
-    updateFile('table users (id int, name text)', 'schema.gsql')
-    updateFile('from users select name', 'page1.gsql')
-    updateFile('from users select users.name', 'page2.gsql')
-    analyze()
+    let workspace = createTestWorkspace({
+      'schema.gsql': 'table users (id int, name text)',
+      'page1.gsql': 'from users select name',
+      'page2.gsql': 'from users select users.name',
+    })
+    let result = workspace.analyze()
 
-    expect(simpleList(getReferences('schema.gsql', 0, 7))).toEqual([
+    expect(simpleList(getReferences(result, 'schema.gsql', 0, 7))).toEqual([
       {file: 'page1.gsql', from: [0, 5], to: [0, 10]},
       {file: 'page2.gsql', from: [0, 5], to: [0, 10]},
       {file: 'page2.gsql', from: [0, 18], to: [0, 23]},
@@ -152,12 +142,14 @@ describe('reference navigation', () => {
   })
 
   it('finds references across files for a column definition', () => {
-    updateFile('table users (id int, name text)', 'schema.gsql')
-    updateFile('from users select name', 'page1.gsql')
-    updateFile('from users select users.name', 'page2.gsql')
-    analyze()
+    let workspace = createTestWorkspace({
+      'schema.gsql': 'table users (id int, name text)',
+      'page1.gsql': 'from users select name',
+      'page2.gsql': 'from users select users.name',
+    })
+    let result = workspace.analyze()
 
-    expect(simpleList(getReferences('schema.gsql', 0, 22, true))).toEqual([
+    expect(simpleList(getReferences(result, 'schema.gsql', 0, 22, true))).toEqual([
       {file: 'schema.gsql', from: [0, 21], to: [0, 25]},
       {file: 'page1.gsql', from: [0, 18], to: [0, 22]},
       {file: 'page2.gsql', from: [0, 24], to: [0, 28]},
@@ -165,10 +157,10 @@ describe('reference navigation', () => {
   })
 
   it('does not navigate query-local aliases', () => {
-    analyze(`table users (id int, name text)
+    let result = analyzeInline(`table users (id int, name text)
 from users as u select u.name as display_name`)
 
-    expect(getDefinition('input', 1, 33)).toBeNull()
+    expect(getDefinition(result, 'input', 1, 33)).toBeNull()
   })
 })
 

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -5,9 +5,10 @@ import {expect} from 'vitest'
 
 /// <reference types="vitest/globals" />
 import {setConfig} from './config.ts'
-import {clearWorkspace, getTable, analyze, toSql, getDiagnostics, updateFile, loadWorkspace, getFile} from './core.ts'
-import {prepareEcommerceTables} from './testHelpers.ts'
+import {getFile as getFileFromResult, getTable as getTableFromResult, toSql, type AnalysisResult} from './core.ts'
+import {clearDefaultTestFiles, createTestWorkspace, prepareEcommerceTables, setDefaultTestFiles} from './testHelpers.ts'
 import {trimIndentation} from './util.ts'
+import {loadWorkspaceFiles} from './workspace.ts'
 
 const testTables = `
   table users (
@@ -60,6 +61,44 @@ const testTables = `
   )
 
 `
+
+let workspace = createTestWorkspace()
+let lastResult: AnalysisResult = {files: {}, diagnostics: [], queries: []}
+
+function clearWorkspace() {
+  workspace = createTestWorkspace()
+  lastResult = {files: {}, diagnostics: [], queries: []}
+  clearDefaultTestFiles()
+}
+
+function updateFile(contents: string, path: string, contentType?: 'gsql' | 'md') {
+  workspace.updateFile(contents, path, contentType)
+  setDefaultTestFiles(workspace.files())
+}
+
+function analyze(contents?: string, contentType?: 'gsql' | 'md') {
+  lastResult = contents == null ? workspace.analyze() : workspace.analyzeInline(contents, contentType)
+  return lastResult.queries
+}
+
+function getDiagnostics() {
+  return lastResult.diagnostics
+}
+
+function getTable(name: string) {
+  return getTableFromResult(lastResult, name)
+}
+
+function getFile(name: string) {
+  return getFileFromResult(lastResult, name) || workspace.files().find(file => file.path == name)
+}
+
+async function loadWorkspace(dir: string, includeMd: boolean) {
+  let loaded = await loadWorkspaceFiles(dir, includeMd)
+  workspace = createTestWorkspace(Object.fromEntries(Object.values(loaded).map(file => [file.path, file.contents])))
+  lastResult = {files: {}, diagnostics: [], queries: []}
+  setDefaultTestFiles(workspace.files())
+}
 
 describe('lang', () => {
   beforeAll(async () => {

--- a/lang/testHelpers.ts
+++ b/lang/testHelpers.ts
@@ -1,8 +1,12 @@
 import {type DuckDBConnection, DuckDBInstance} from '@duckdb/node-api'
 import {expect as vitestExpect} from 'vitest'
 
-import {toSql, analyze, getDiagnostics, type GrapheneError} from './core.ts'
+import {analyzeProject, getFile, getTable, toSql, type AnalysisFileInput, type AnalysisResult, type GrapheneError} from './core.ts'
 import {trimIndentation} from './util.ts'
+import {listWorkspaceFiles, toAnalysisOptions, updateWorkspaceFile, deleteWorkspaceFile} from './workspace.ts'
+
+const INLINE_INPUT_PATH = 'input'
+let defaultFiles: AnalysisFileInput[] = []
 
 const ECOMM_SETUP = `
   create table users (
@@ -61,6 +65,59 @@ function formatDiagnostics(_source: string, diagnostics: GrapheneError[]): strin
 
 let conn: DuckDBConnection
 
+export function setDefaultTestFiles(files: AnalysisFileInput[]) {
+  defaultFiles = files.map(file => ({...file}))
+}
+
+export function clearDefaultTestFiles() {
+  defaultFiles = []
+}
+
+export function analyzeInline(content: string, files: AnalysisFileInput[] = defaultFiles) {
+  return analyzeProject({
+    files: [...files, {path: INLINE_INPUT_PATH, contents: content, contentType: content.includes('```') ? 'md' : 'gsql'}],
+    targetPath: INLINE_INPUT_PATH,
+    options: toAnalysisOptions(),
+  })
+}
+
+export function createTestWorkspace(initialFiles: Record<string, string> = {}) {
+  let files: Record<string, AnalysisFileInput> = {}
+  for (let [path, contents] of Object.entries(initialFiles)) updateWorkspaceFile(files, contents, path, path.endsWith('.md') ? 'md' : 'gsql')
+
+  function analyze() {
+    return analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions()})
+  }
+
+  function analyzeInlineFile(content: string, contentType?: 'gsql' | 'md') {
+    return analyzeProject({
+      files: [...listWorkspaceFiles(files), {path: INLINE_INPUT_PATH, contents: content, contentType: contentType || (content.includes('```') ? 'md' : 'gsql')}],
+      targetPath: INLINE_INPUT_PATH,
+      options: toAnalysisOptions(),
+    })
+  }
+
+  return {
+    analyze,
+    analyzeInline: analyzeInlineFile,
+    updateFile(contents: string, path: string, contentType?: 'gsql' | 'md') {
+      updateWorkspaceFile(files, contents, path, contentType || (path.endsWith('.md') ? 'md' : 'gsql'))
+    },
+    deleteFile(path: string) {
+      deleteWorkspaceFile(files, path)
+    },
+    getFile(result: AnalysisResult, path: string) {
+      return getFile(result, path)
+    },
+    getTable(result: AnalysisResult, name: string) {
+      return getTable(result, name)
+    },
+    files() {
+      return listWorkspaceFiles(files)
+    },
+  }
+}
+
 export async function prepareEcommerceTables() {
   let db = await DuckDBInstance.create(':memory:')
   conn = await db.connect()
@@ -77,8 +134,8 @@ if (process.env.GRAPHENE_DEBUG) {
 vitestExpect.extend({
   toRenderSql(received: string, expectedSql: string, opts: {preserveCase?: boolean} = {}) {
     let content = trimIndentation(received)
-    let queries = analyze(content, content.includes('```') ? 'md' : 'gsql')
-    let errors = getDiagnostics().filter(d => d.severity === 'error')
+    let result = analyzeInline(content)
+    let errors = result.diagnostics.filter(d => d.severity === 'error')
 
     if (errors.length > 0) {
       return {
@@ -92,7 +149,7 @@ vitestExpect.extend({
       return s.replace(/[\s\n]+/g, ' ').replace(/\s+$/, '')
     }
 
-    let sql = toSql(queries[0])
+    let sql = toSql(result.queries[0])
     let pass = normalizeSql(sql) === normalizeSql(expectedSql)
     return {
       pass,
@@ -104,8 +161,8 @@ vitestExpect.extend({
 
   async toReturnRows(received: string, ...expectedRows: unknown[][]) {
     let content = trimIndentation(received)
-    let queries = analyze(content, content.includes('```') ? 'md' : 'gsql')
-    let errors = getDiagnostics().filter(d => d.severity === 'error')
+    let result = analyzeInline(content)
+    let errors = result.diagnostics.filter(d => d.severity === 'error')
 
     if (errors.length > 0) {
       return {
@@ -113,7 +170,7 @@ vitestExpect.extend({
         message: () => `Expected no errors, but found ${errors.length}:\n\n${formatDiagnostics(content, errors)}`,
       }
     }
-    let sql = toSql(queries[0])
+    let sql = toSql(result.queries[0])
 
     try {
       let reader = await conn.runAndReadAll(sql)
@@ -138,9 +195,8 @@ vitestExpect.extend({
 
   toHaveDiagnostic(received: string, pattern: RegExp | string) {
     let content = trimIndentation(received)
-    analyze(content, content.includes('```') ? 'md' : 'gsql')
-
-    let diagnostics = getDiagnostics()
+    let result = analyzeInline(content)
+    let diagnostics = result.diagnostics
 
     let regex = typeof pattern === 'string' ? new RegExp(pattern, 'i') : pattern
     let match = diagnostics.find(d => regex.test(d.message))
@@ -157,9 +213,8 @@ vitestExpect.extend({
 
   toHaveNoErrors(received: string) {
     let content = trimIndentation(received)
-    analyze(content, content.includes('```') ? 'md' : 'gsql')
-
-    let errors = getDiagnostics().filter(d => d.severity === 'error')
+    let result = analyzeInline(content)
+    let errors = result.diagnostics.filter(d => d.severity === 'error')
     return {
       pass: errors.length === 0,
       message: () => (errors.length === 0 ? 'No errors found.' : `Expected no errors, but found ${errors.length}.\n\n${formatDiagnostics(content, errors)}`),

--- a/lang/testHelpers.ts
+++ b/lang/testHelpers.ts
@@ -1,11 +1,11 @@
 import {type DuckDBConnection, DuckDBInstance} from '@duckdb/node-api'
 import {expect as vitestExpect} from 'vitest'
 
+import {INLINE_INPUT_PATH} from '../cli/run.ts'
 import {analyzeProject, getFile, getTable, toSql, type AnalysisFileInput, type AnalysisResult, type GrapheneError} from './core.ts'
 import {trimIndentation} from './util.ts'
 import {listWorkspaceFiles, toAnalysisOptions, updateWorkspaceFile, deleteWorkspaceFile} from './workspace.ts'
 
-const INLINE_INPUT_PATH = 'input'
 let defaultFiles: AnalysisFileInput[] = []
 
 const ECOMM_SETUP = `

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -32,8 +32,7 @@ export interface AnalysisOptions {
 export interface AnalysisFileInput {
   path: string
   contents: string
-  // Only needed for legacy inline `analyze(contents, contentType)` calls, where the
-  // synthetic "input" path has no extension to tell md from gsql.
+  // Used for synthetic inline inputs whose path does not carry a file extension.
   contentType?: 'gsql' | 'md'
 }
 

--- a/lang/workspace.ts
+++ b/lang/workspace.ts
@@ -1,0 +1,38 @@
+import {glob} from 'glob'
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+
+import {config} from './config.ts'
+import {type AnalysisFileInput, type AnalysisOptions} from './types.ts'
+
+export function toAnalysisOptions(options: Partial<AnalysisOptions> = config): AnalysisOptions {
+  return {dialect: options.dialect || 'duckdb', defaultNamespace: options.defaultNamespace}
+}
+
+export async function loadWorkspaceFiles(dir: string, includeMd: boolean): Promise<Record<string, AnalysisFileInput>> {
+  let ignore = ['node_modules/**', '**/.*/**', ...(config.ignoredFiles || [])]
+  let paths = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore, follow: false})
+  let files: Record<string, AnalysisFileInput> = {}
+
+  for await (let file of paths) {
+    try {
+      files[file] = {path: file, contents: await readFile(path.join(dir, file), 'utf-8')}
+    } catch (e: any) {
+      console.error('Failed to read file', file, e.message)
+    }
+  }
+
+  return files
+}
+
+export function updateWorkspaceFile(files: Record<string, AnalysisFileInput>, contents: string, filePath: string, contentType?: 'gsql' | 'md') {
+  files[filePath] = {path: filePath, contents, contentType}
+}
+
+export function deleteWorkspaceFile(files: Record<string, AnalysisFileInput>, filePath: string) {
+  delete files[filePath]
+}
+
+export function listWorkspaceFiles(files: Record<string, AnalysisFileInput>) {
+  return Object.values(files)
+}

--- a/language-server/src/service.ts
+++ b/language-server/src/service.ts
@@ -14,8 +14,9 @@ import {
 } from 'vscode-languageserver-protocol'
 import {URI, Utils as URIs} from 'vscode-uri'
 
-import {deleteFile, updateFile, analyze, getDefinition, getDiagnostics, getFiles, getHover, getReferences, loadConfig, loadWorkspace} from '../../lang/core.ts'
-import {type GrapheneError, type Location as GrapheneLocation} from '../../lang/types.ts'
+import {analyzeProject, getDefinition, getFiles, getHover, getReferences, loadConfig} from '../../lang/core.ts'
+import {type AnalysisFileInput, type WorkspaceAnalysis, type GrapheneError, type Location as GrapheneLocation} from '../../lang/types.ts'
+import {deleteWorkspaceFile, listWorkspaceFiles, loadWorkspaceFiles, toAnalysisOptions, updateWorkspaceFile} from '../../lang/workspace.ts'
 
 export function createGrapheneService(server: ReturnType<typeof createServer>): LanguageServicePlugin {
   return {
@@ -31,10 +32,14 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
     },
     create(context): LanguageServicePluginInstance {
       let [workspace] = context.env.workspaceFolders
+      let files: Record<string, AnalysisFileInput> = {}
+      let result: WorkspaceAnalysis = {files: {}, diagnostics: [], queries: []}
       let analysis = createWorkspaceAnalysis({
         load: () => {
           loadConfig(workspace.fsPath)
-          return loadWorkspace(workspace.fsPath, true)
+          return loadWorkspaceFiles(workspace.fsPath, true).then(loaded => {
+            files = loaded
+          })
         },
         analyze: tryAnalyze,
         delay: 200,
@@ -52,20 +57,20 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
           await analysis.pending
 
           let path = workspacePath(document.uri)
-          return path ? {contents: getHover(path, position.line, position.character)} : null
+          return path ? {contents: getHover(result, path, position.line, position.character)} : null
         },
         async provideDefinition(document, position, _token) {
           await analysis.pending
 
           let path = workspacePath(document.uri)
-          let location = path ? getDefinition(path, position.line, position.character) : null
+          let location = path ? getDefinition(result, path, position.line, position.character) : null
           return location ? [toLocationLink(workspace, location)] : []
         },
         async provideReferences(document, position, context, _token) {
           await analysis.pending
 
           let path = workspacePath(document.uri)
-          return path ? getReferences(path, position.line, position.character, context.includeDeclaration).map(location => toLocation(workspace, location)) : []
+          return path ? getReferences(result, path, position.line, position.character, context.includeDeclaration).map(location => toLocation(workspace, location)) : []
         },
         async provideDiagnostics(document) {
           await analysis.pending
@@ -104,11 +109,11 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
             if (!path) continue
 
             if (change.type === FileChangeType.Deleted) {
-              deleteFile(path)
+              deleteWorkspaceFile(files, path)
             } else {
               let document = server.documents.get(URI.parse(change.uri))
               if (document) {
-                updateFile(document.getText(), path)
+                updateWorkspaceFile(files, document.getText(), path, path.endsWith('.md') ? 'md' : 'gsql')
               }
             }
           }
@@ -119,7 +124,7 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         changeContent = server.documents.onDidChangeContent(({document}) => {
           let path = workspacePath(document.uri)
           if (path) {
-            updateFile(document.getText(), path)
+            updateWorkspaceFile(files, document.getText(), path, path.endsWith('.md') ? 'md' : 'gsql')
             analysis.invalidate()
           }
         })
@@ -135,7 +140,7 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
 
       async function tryAnalyze() {
         try {
-          analyze()
+          result = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions()})
           await server.languageFeatures.requestRefresh(false)
         } catch (err) {
           let message = err instanceof Error ? err.stack || err.message : String(err)
@@ -144,13 +149,11 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
       }
 
       function diagnosticsFor(path: string) {
-        return getDiagnostics()
-          .filter(diagnostic => diagnostic.file === path)
-          .map(toDiagnostic)
+        return result.diagnostics.filter(diagnostic => diagnostic.file === path).map(toDiagnostic)
       }
 
       function workspaceDiagnostics() {
-        return getFiles().map(file => {
+        return getFiles(result).map(file => {
           return {
             kind: DocumentDiagnosticReportKind.Full,
             uri: URIs.joinPath(workspace, file.path).toString(),

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -31,6 +31,17 @@ interface QueryNode {
   error?: GrapheneError
 }
 
+function normalizeQueryError(body: unknown, queryId: string): GrapheneError {
+  if (Array.isArray(body)) {
+    let first = body[0]
+    if (first && typeof first === 'object') return {...(first as GrapheneError), queryId: (first as GrapheneError).queryId || queryId}
+    return {queryId, message: 'Unknown error'}
+  }
+  if (body && typeof body === 'object') return {...(body as GrapheneError), queryId: (body as GrapheneError).queryId || queryId}
+  if (typeof body === 'string') return {queryId, message: body}
+  return {queryId, message: 'Unknown error'}
+}
+
 let runPending: Promise<void> | null = null
 let queries = [] as QueryNode[]
 let queryResults = {} as Record<string, {rows: any[]; fields?: Field[]}>
@@ -138,8 +149,7 @@ async function runNode(n: QueryNode) {
   }
 
   // otherwise, the query failed
-  error = (await response.json()) as GrapheneError
-  error.queryId ||= queryId
+  error = normalizeQueryError(await response.json(), queryId)
   n.error = error
   finish({error: n.error})
 }

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -1,8 +1,8 @@
 import stripAnsi from 'strip-ansi'
 
 import {check} from '../../cli/check.ts'
+import {mockFileMap} from '../../cli/mockFiles.ts'
 import {runMdFile} from '../../cli/run.ts'
-import {updateFile} from '../../lang/core.ts'
 import {trimIndentation} from '../../lang/util.ts'
 import {test, expect} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
@@ -21,24 +21,22 @@ function outputLines() {
 
 test.beforeEach(() => {
   logs = ''
+  Object.keys(mockFileMap).forEach(key => delete mockFileMap[key])
 })
 
 test('check defaults to analyzing the whole workspace', async () => {
-  updateFile(
-    `
+  mockFileMap['tmp_bad.gsql'] = trimIndentation(`
     table tmp_bad as (
       from flights select not_a_function()
     )
-  `,
-    'tmp_bad.gsql',
-  )
+  `)
 
   await check({log})
   expect(outputLines()).toEqual(
     `
-    ERROR: tmp_bad.gsql line 3: Unknown function: not_a_function
-      from flights select not_a_function()
-                          ^^^^^^^^^^^^^^^^
+    ERROR: tmp_bad.gsql line 2: Unknown function: not_a_function
+   |   from flights select not_a_function()
+   |                       ^^^^^^^^^^^^^^^^
   `.trim(),
   )
 })

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -35,8 +35,8 @@ test('check defaults to analyzing the whole workspace', async () => {
   expect(outputLines()).toEqual(
     `
     ERROR: tmp_bad.gsql line 2: Unknown function: not_a_function
-   |   from flights select not_a_function()
-   |                       ^^^^^^^^^^^^^^^^
+  from flights select not_a_function()
+                      ^^^^^^^^^^^^^^^^
   `.trim(),
   )
 })

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -6,8 +6,7 @@ import {test as base, onTestFinished} from 'vitest'
 
 import {mockFileMap} from '../../cli/mockFiles.ts'
 import {serve2, svelteWarnings, clearSvelteWarnings} from '../../cli/serve2.ts'
-import {type Config, config, setConfig} from '../../lang/config.ts'
-import {clearWorkspace, loadWorkspace} from '../../lang/core.ts'
+import {type Config, setConfig} from '../../lang/config.ts'
 import {trackBrowserConsole} from './logWatcher.ts'
 import {playwrightExpect as expect} from './matchers.ts'
 
@@ -87,7 +86,6 @@ export const test = base.extend<{browser: Browser; page: Page; server: ServerFix
       let server = await serve2()
 
       function cleanup() {
-        clearWorkspace()
         Object.keys(mockFileMap).forEach(key => delete mockFileMap[key])
 
         // Vite caches our mocked files, so we need to clear them out after each test.
@@ -105,7 +103,6 @@ export const test = base.extend<{browser: Browser; page: Page; server: ServerFix
       await use({
         url: (options: Partial<Config> = {}) => {
           setConfig({...options, root: options.root || viteRoot, port} as any)
-          loadWorkspace(config.root, false)
           onTestFinished(cleanup)
           return `http://localhost:${port}`
         },
@@ -198,7 +195,6 @@ export const test = base.extend<{browser: Browser; page: Page; server: ServerFix
 test.beforeEach(() => {
   let root = path.join(fileURLToPath(import.meta.url), '../../../examples/flights')
   setConfig({root})
-  clearWorkspace()
 })
 
 async function getAvailablePort(): Promise<number> {


### PR DESCRIPTION
I opted to create a separate PR to finish refactoring #217 as I think it may be easier to read this way. This PR refactors out the global `legacyWorkspace` and `legacyResult` variables which were added in #217 to preserve the workspace semantics while threading the `AnalysisContext` through. Now the CLI, LSP and tests use the core analysis API directly where all relevant context is passed explicitly, and all results (including diagnostics) are passed back explicitly.