### PR TITLE
support multi-root projects/analysis in language-server/vscode

### DIFF
--- a/cli/check.ts
+++ b/cli/check.ts
@@ -21,7 +21,7 @@ export async function check(options: CheckOptions): Promise<boolean> {
     return false
   }
 
-  let files = await loadWorkspaceFiles(config.root, !targetFile)
+  let files = await loadWorkspaceFiles(config.root, !targetFile, config.ignoredFiles)
   if (process.env.NODE_ENV == 'test') {
     for (let [mockPath, contents] of Object.entries(mockFileMap)) {
       if (targetFile && (mockPath == targetFile || mockPath.endsWith('.md'))) continue
@@ -38,7 +38,7 @@ export async function check(options: CheckOptions): Promise<boolean> {
     }
   }
 
-  let result = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions()})
+  let result = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions(config)})
   if (result.diagnostics.length > 0) {
     printDiagnostics(result.diagnostics, log)
     return false

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -34,12 +34,12 @@ program
   .description('Translate a query to SQL and print it')
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
   .action(async (input: string | undefined) => {
-    let files = await loadWorkspaceFiles(process.cwd(), false)
+    let files = await loadWorkspaceFiles(process.cwd(), false, config.ignoredFiles)
     let sql = await readInput(input)
     let result = analyzeProject({
       files: [...listWorkspaceFiles(files), {path: INLINE_INPUT_PATH, contents: sql, contentType: 'gsql'}],
       targetPath: INLINE_INPUT_PATH,
-      options: toAnalysisOptions(),
+      options: toAnalysisOptions(config),
     })
     let queries = validQuery(result)
     if (!queries) return
@@ -74,12 +74,12 @@ program
       process.exit(1)
     }
 
-    let files = await loadWorkspaceFiles(process.cwd(), false)
+    let files = await loadWorkspaceFiles(process.cwd(), false, config.ignoredFiles)
     let gsql = await readInput(input)
     let result = analyzeProject({
       files: [...listWorkspaceFiles(files), {path: INLINE_INPUT_PATH, contents: gsql, contentType: 'gsql'}],
       targetPath: INLINE_INPUT_PATH,
-      options: toAnalysisOptions(),
+      options: toAnalysisOptions(config),
     })
     let queries = validQuery(result)
     if (!queries) return

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -35,7 +35,7 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
     return false
   }
 
-  let files = await loadWorkspaceFiles(config.root, false)
+  let files = await loadWorkspaceFiles(config.root, false, config.ignoredFiles)
   if (process.env.NODE_ENV == 'test') {
     for (let [mockPath, contents] of Object.entries(mockFileMap)) {
       if (mockPath.endsWith('.md') && mockPath != mdFile) continue
@@ -49,7 +49,7 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
     updateWorkspaceFile(files, content, mdFile, 'md')
   }
 
-  let result = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions()})
+  let result = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions(config)})
   if (result.diagnostics.length > 0) {
     printDiagnostics(result.diagnostics, log)
     return false
@@ -128,12 +128,12 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
 }
 
 export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string): Promise<boolean> {
-  let files = await loadWorkspaceFiles(process.cwd(), false)
+  let files = await loadWorkspaceFiles(process.cwd(), false, config.ignoredFiles)
   let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
   let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
 
   updateWorkspaceFile(files, mdContents, mdRelativePath, 'md')
-  let pageResult = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions()})
+  let pageResult = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions(config)})
   if (pageResult.diagnostics.length > 0) {
     printDiagnostics(pageResult.diagnostics)
     return false
@@ -143,7 +143,7 @@ export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: str
   let queryResult = analyzeProject({
     files: [...listWorkspaceFiles(files), {path: INLINE_INPUT_PATH, contents: runQueryFence, contentType: 'md'}],
     targetPath: INLINE_INPUT_PATH,
-    options: toAnalysisOptions(),
+    options: toAnalysisOptions(config),
   })
   if (queryResult.diagnostics.length > 0) {
     printDiagnostics(queryResult.diagnostics)

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -123,7 +123,7 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
   let result = analyzeProject({
     files: [...listWorkspaceFiles(workspaceFiles), {path: INLINE_INPUT_PATH, contents: gsql, contentType: 'gsql'}],
     targetPath: INLINE_INPUT_PATH,
-    options: toAnalysisOptions(),
+    options: toAnalysisOptions(config),
   })
 
   if (result.diagnostics.length) {
@@ -245,7 +245,7 @@ const updateWorkspacePlugin = {
   },
   configureServer: (s: ViteDevServer) => {
     let refresh = async () => {
-      workspaceLoadPromise = loadWorkspaceFiles(config.root, true).then(files => {
+      workspaceLoadPromise = loadWorkspaceFiles(config.root, true, config.ignoredFiles).then(files => {
         workspaceFiles = files
       })
       await workspaceLoadPromise

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -35,24 +35,29 @@ export type ConfigInput = Omit<Config, 'dialect' | 'ignoredFiles' | 'envFile'> &
 
 export let config: Config = {dialect: 'duckdb', root: ''} as Config
 
-export function setConfig(cfg: ConfigInput) {
+function normalizeConfig(cfg: ConfigInput, fallbackRoot: string): Config {
   if (cfg.namespace && !cfg.defaultNamespace) cfg.defaultNamespace = cfg.namespace
   let dialect = cfg.dialect || 'duckdb'
   if (cfg.bigquery) dialect = 'bigquery'
   else if (cfg.snowflake) dialect = 'snowflake'
   else if (cfg.duckdb) dialect = 'duckdb'
-  Object.keys(config).forEach(key => delete config[key])
-  Object.assign(config, cfg)
-  config.dialect = dialect
-  config.root ||= process.cwd()
-  config.port ||= Number(process.env.GRAPHENE_PORT) || 4000
-  config.ignoredFiles ||= ['agents.md', 'claude.md']
+
+  let root = cfg.root ? path.resolve(fallbackRoot, cfg.root) : fallbackRoot
+  let envFile = ['.env']
+  if (Array.isArray(cfg.envFile)) envFile = cfg.envFile
+  else if (cfg.envFile) envFile = [cfg.envFile]
+  let ignoredFiles = cfg.ignoredFiles || ['agents.md', 'claude.md']
+  return {...cfg, root, envFile, ignoredFiles, dialect} as Config
 }
 
-// Read graphene config out of package.json
-export function loadConfig(dir: string, envLoader?: (envFiles: string[] | string) => void) {
-  if (config.root) return
+export function setConfig(cfg: ConfigInput) {
+  let next = normalizeConfig(cfg, process.cwd())
+  Object.keys(config).forEach(key => delete config[key])
+  Object.assign(config, next)
+  config.port ||= Number(process.env.GRAPHENE_PORT) || 4000
+}
 
+export function readConfig(dir: string): Config {
   let packageJsonObject = {} as any
   try {
     let txt = fs.readFileSync(path.join(dir, 'package.json'), 'utf8')
@@ -61,7 +66,16 @@ export function loadConfig(dir: string, envLoader?: (envFiles: string[] | string
     console.warn('No package.json found in current directory')
   }
 
-  if (envLoader) envLoader(packageJsonObject.envFile || ['.env'])
+  let cfg = normalizeConfig(packageJsonObject, dir)
+  cfg.port ||= Number(process.env.GRAPHENE_PORT) || 4000
+  return cfg
+}
 
-  setConfig({...packageJsonObject, root: packageJsonObject.root || process.cwd()})
+// Read graphene config out of package.json
+export function loadConfig(dir: string, envLoader?: (envFiles: string[] | string) => void) {
+  if (config.root) return
+
+  let next = readConfig(dir)
+  if (envLoader) envLoader(next.envFile || ['.env'])
+  setConfig(next)
 }

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -1,13 +1,13 @@
 import {analyzeQuery, analyzeTableFully, applyExtends, createAnalysisContext, findTables, recordSyntaxErrors} from './analyze.ts'
-import {config, loadConfig} from './config.ts'
+import {config, loadConfig, readConfig} from './config.ts'
 import {parseMarkdown} from './markdown.ts'
 import {fillInParams} from './params.ts'
 import {parser} from './parser.js'
 import {type AnalysisFileInput, type AnalysisInput, type WorkspaceAnalysis, type FileInfo, type Location, type Query} from './types.ts'
 import {getSourceOffset} from './util.ts'
 
-export {config, loadConfig}
-export type {AnalysisFileInput, AnalysisInput, AnalysisOptions, WorkspaceAnalysis as AnalysisResult, Query, Table, GrapheneError} from './types.ts'
+export {config, loadConfig, readConfig}
+export type {AnalysisFileInput, AnalysisInput, AnalysisOptions, WorkspaceAnalysis, Query, Table, GrapheneError} from './types.ts'
 
 function createFileInfo(input: AnalysisFileInput): FileInfo {
   return {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -4,8 +4,8 @@ import path from 'node:path'
 import {expect} from 'vitest'
 
 /// <reference types="vitest/globals" />
-import {setConfig} from './config.ts'
-import {getFile as getFileFromResult, getTable as getTableFromResult, toSql, type AnalysisResult} from './core.ts'
+import {config, readConfig, setConfig} from './config.ts'
+import {getFile as getFileFromResult, getTable as getTableFromResult, toSql, type WorkspaceAnalysis} from './core.ts'
 import {clearDefaultTestFiles, createTestWorkspace, prepareEcommerceTables, setDefaultTestFiles} from './testHelpers.ts'
 import {trimIndentation} from './util.ts'
 import {loadWorkspaceFiles} from './workspace.ts'
@@ -63,7 +63,7 @@ const testTables = `
 `
 
 let workspace = createTestWorkspace()
-let lastResult: AnalysisResult = {files: {}, diagnostics: [], queries: []}
+let lastResult: WorkspaceAnalysis = {files: {}, diagnostics: [], queries: []}
 
 function clearWorkspace() {
   workspace = createTestWorkspace()
@@ -94,7 +94,7 @@ function getFile(name: string) {
 }
 
 async function loadWorkspace(dir: string, includeMd: boolean) {
-  let loaded = await loadWorkspaceFiles(dir, includeMd)
+  let loaded = await loadWorkspaceFiles(dir, includeMd, config.ignoredFiles)
   workspace = createTestWorkspace(Object.fromEntries(Object.values(loaded).map(file => [file.path, file.contents])))
   lastResult = {files: {}, diagnostics: [], queries: []}
   setDefaultTestFiles(workspace.files())
@@ -169,6 +169,17 @@ describe('lang', () => {
       expect(getFile('models.gsql')).toBeDefined()
       expect(getFile('nested/agents.md')).toBeUndefined()
       expect(getFile('dist/ignored.gsql')).toBeUndefined()
+    } finally {
+      await rm(root, {recursive: true, force: true})
+    }
+  })
+
+  it('defaults readConfig.root to the package directory', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-config-root-'))
+
+    try {
+      await writeFile(path.join(root, 'package.json'), JSON.stringify({graphene: {duckdb: {}}}))
+      expect(readConfig(root).root).toBe(root)
     } finally {
       await rm(root, {recursive: true, force: true})
     }

--- a/lang/testHelpers.ts
+++ b/lang/testHelpers.ts
@@ -2,7 +2,7 @@ import {type DuckDBConnection, DuckDBInstance} from '@duckdb/node-api'
 import {expect as vitestExpect} from 'vitest'
 
 import {INLINE_INPUT_PATH} from '../cli/run.ts'
-import {analyzeProject, getFile, getTable, toSql, type AnalysisFileInput, type AnalysisResult, type GrapheneError} from './core.ts'
+import {analyzeProject, getFile, getTable, toSql, type AnalysisFileInput, type WorkspaceAnalysis, type GrapheneError} from './core.ts'
 import {trimIndentation} from './util.ts'
 import {listWorkspaceFiles, toAnalysisOptions, updateWorkspaceFile, deleteWorkspaceFile} from './workspace.ts'
 
@@ -106,10 +106,10 @@ export function createTestWorkspace(initialFiles: Record<string, string> = {}) {
     deleteFile(path: string) {
       deleteWorkspaceFile(files, path)
     },
-    getFile(result: AnalysisResult, path: string) {
+    getFile(result: WorkspaceAnalysis, path: string) {
       return getFile(result, path)
     },
-    getTable(result: AnalysisResult, name: string) {
+    getTable(result: WorkspaceAnalysis, name: string) {
       return getTable(result, name)
     },
     files() {

--- a/lang/workspace.ts
+++ b/lang/workspace.ts
@@ -9,8 +9,8 @@ export function toAnalysisOptions(options: Partial<AnalysisOptions> = config): A
   return {dialect: options.dialect || 'duckdb', defaultNamespace: options.defaultNamespace}
 }
 
-export async function loadWorkspaceFiles(dir: string, includeMd: boolean): Promise<Record<string, AnalysisFileInput>> {
-  let ignore = ['node_modules/**', '**/.*/**', ...(config.ignoredFiles || [])]
+export async function loadWorkspaceFiles(dir: string, includeMd: boolean, ignoredFiles: string[] = config.ignoredFiles || []): Promise<Record<string, AnalysisFileInput>> {
+  let ignore = ['node_modules/**', '**/.*/**', ...ignoredFiles]
   let paths = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore, follow: false})
   let files: Record<string, AnalysisFileInput> = {}
 

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -7,6 +7,7 @@
     "@volar/language-core": "^2.4.28",
     "@volar/language-server": "^2.4.28",
     "@volar/language-service": "^2.4.28",
+    "glob": "^13.0.1",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-uri": "^3.1.0"
   }

--- a/language-server/src/service.test.ts
+++ b/language-server/src/service.test.ts
@@ -1,0 +1,46 @@
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {expect} from 'vitest'
+/// <reference types="vitest/globals" />
+import {URI} from 'vscode-uri'
+
+import {discoverGrapheneProjects, findOwningProject} from './service.ts'
+
+describe('graphene language service', () => {
+  it('discovers graphene projects from package.json and skips node_modules', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-language-server-'))
+
+    try {
+      await writeFile(path.join(root, 'package.json'), JSON.stringify({name: 'workspace-root'}))
+      await mkdir(path.join(root, 'examples', 'flights'), {recursive: true})
+      await writeFile(path.join(root, 'examples', 'flights', 'package.json'), JSON.stringify({graphene: {duckdb: {}}}))
+      await mkdir(path.join(root, 'node_modules', 'ignored'), {recursive: true})
+      await writeFile(path.join(root, 'node_modules', 'ignored', 'package.json'), JSON.stringify({graphene: {duckdb: {}}}))
+
+      let projects = await discoverGrapheneProjects([URI.file(root)])
+      expect(projects.map(project => project.root)).toEqual([path.join(root, 'examples', 'flights')])
+    } finally {
+      await rm(root, {recursive: true, force: true})
+    }
+  })
+
+  it('prefers the nearest discovered project for nested files', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-language-server-nested-'))
+    let parent = path.join(root, 'examples')
+    let nested = path.join(parent, 'flights')
+
+    try {
+      await mkdir(nested, {recursive: true})
+      await writeFile(path.join(parent, 'package.json'), JSON.stringify({graphene: {duckdb: {}}}))
+      await writeFile(path.join(nested, 'package.json'), JSON.stringify({graphene: {duckdb: {}}}))
+
+      let projects = await discoverGrapheneProjects([URI.file(root)])
+      expect(projects.map(project => project.root)).toEqual([nested, parent])
+      expect(findOwningProject(projects, path.join(nested, 'models.gsql'))?.root).toBe(nested)
+      expect(findOwningProject(projects, path.join(parent, 'shared.gsql'))?.root).toBe(parent)
+    } finally {
+      await rm(root, {recursive: true, force: true})
+    }
+  })
+})

--- a/language-server/src/service.ts
+++ b/language-server/src/service.ts
@@ -1,6 +1,8 @@
 import {type createServer} from '@volar/language-server/node.js'
 import {type LanguageServicePlugin, type LanguageServicePluginInstance} from '@volar/language-service'
-import {relative as relativePath} from 'node:path'
+import {glob} from 'glob'
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
 import {
   DiagnosticSeverity,
   DocumentDiagnosticReportKind,
@@ -14,9 +16,38 @@ import {
 } from 'vscode-languageserver-protocol'
 import {URI, Utils as URIs} from 'vscode-uri'
 
-import {analyzeProject, getDefinition, getFiles, getHover, getReferences, loadConfig} from '../../lang/core.ts'
+import {type Config} from '../../lang/config.ts'
+import {analyzeProject, getDefinition, getFiles, getHover, getReferences, readConfig} from '../../lang/core.ts'
 import {type AnalysisFileInput, type WorkspaceAnalysis, type GrapheneError, type Location as GrapheneLocation} from '../../lang/types.ts'
 import {deleteWorkspaceFile, listWorkspaceFiles, loadWorkspaceFiles, toAnalysisOptions, updateWorkspaceFile} from '../../lang/workspace.ts'
+
+export interface GrapheneProject {
+  packageDir: string
+  root: string
+  config: Config
+}
+
+export async function discoverGrapheneProjects(workspaceFolders: readonly URI[]): Promise<GrapheneProject[]> {
+  let projects = new Map<string, GrapheneProject>()
+
+  for (let workspace of workspaceFolders) {
+    let packagePaths = await glob('**/package.json', {cwd: workspace.fsPath, ignore: ['node_modules/**', '**/.*/**'], follow: false})
+    for (let packagePath of packagePaths) {
+      let absolutePackage = path.join(workspace.fsPath, packagePath)
+      let parsed = await readPackageJson(absolutePackage)
+      if (!parsed || parsed.graphene == null) continue
+
+      let packageDir = path.dirname(absolutePackage)
+      projects.set(packageDir, {packageDir, root: packageDir, config: readConfig(packageDir)})
+    }
+  }
+
+  return [...projects.values()].sort((a, b) => b.root.length - a.root.length || a.root.localeCompare(b.root))
+}
+
+export function findOwningProject<T extends {root: string}>(projects: readonly T[], fsPath: string): T | null {
+  return projects.find(project => containsPath(project.root, fsPath)) || null
+}
 
 export function createGrapheneService(server: ReturnType<typeof createServer>): LanguageServicePlugin {
   return {
@@ -31,138 +62,218 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
       referencesProvider: true,
     },
     create(context): LanguageServicePluginInstance {
-      let [workspace] = context.env.workspaceFolders
-      let files: Record<string, AnalysisFileInput> = {}
-      let result: WorkspaceAnalysis = {files: {}, diagnostics: [], queries: []}
-      let analysis = createWorkspaceAnalysis({
-        load: () => {
-          loadConfig(workspace.fsPath)
-          return loadWorkspaceFiles(workspace.fsPath, true).then(loaded => {
-            files = loaded
-          })
-        },
-        analyze: tryAnalyze,
-        delay: 200,
-      })
-      let workspaceWatcher = watchWorkspace()
-
-      console.log('started Graphene language server', workspace.fsPath)
+      let registry = createProjectRegistry(server, context.env.workspaceFolders)
 
       return {
         dispose() {
-          analysis.dispose()
-          workspaceWatcher.dispose()
+          registry.dispose()
         },
         async provideHover(document, position) {
-          await analysis.pending
-
-          let path = workspacePath(document.uri)
-          return path ? {contents: getHover(result, path, position.line, position.character)} : null
+          let project = await registry.projectForUri(document.uri)
+          return project ? project.provideHover(document.uri, position.line, position.character) : null
         },
         async provideDefinition(document, position, _token) {
-          await analysis.pending
-
-          let path = workspacePath(document.uri)
-          let location = path ? getDefinition(result, path, position.line, position.character) : null
-          return location ? [toLocationLink(workspace, location)] : []
+          let project = await registry.projectForUri(document.uri)
+          return project ? project.provideDefinition(document.uri, position.line, position.character) : []
         },
         async provideReferences(document, position, context, _token) {
-          await analysis.pending
-
-          let path = workspacePath(document.uri)
-          return path ? getReferences(result, path, position.line, position.character, context.includeDeclaration).map(location => toLocation(workspace, location)) : []
+          let project = await registry.projectForUri(document.uri)
+          return project ? project.provideReferences(document.uri, position.line, position.character, context.includeDeclaration) : []
         },
         async provideDiagnostics(document) {
-          await analysis.pending
-
-          let path = workspacePath(document.uri)
-          return path ? diagnosticsFor(path) : []
+          let project = await registry.projectForUri(document.uri)
+          return project ? project.provideDiagnostics(document.uri) : []
         },
         async provideWorkspaceDiagnostics() {
-          await analysis.pending
-
-          return workspaceDiagnostics()
+          await registry.pending
+          return registry.workspaceDiagnostics()
         },
       }
-
-      function workspacePath(uri: DocumentUri): string | null {
-        let parsed = URI.parse(uri)
-        if (parsed.scheme === 'file') {
-          return relativePath(workspace.fsPath, parsed.fsPath)
-        } else {
-          return null
-        }
-      }
-
-      function watchWorkspace(): Disposable {
-        let fileWatcher: Disposable | undefined
-        let changeWatchedFiles: Disposable | undefined
-        let changeContent: Disposable | undefined
-
-        server.onInitialized(async () => {
-          fileWatcher = await server.fileWatcher.watchFiles(['**/*.{md,gsql}'])
-        })
-
-        changeWatchedFiles = server.fileWatcher.onDidChangeWatchedFiles(({changes}) => {
-          for (let change of changes) {
-            let path = workspacePath(change.uri)
-            if (!path) continue
-
-            if (change.type === FileChangeType.Deleted) {
-              deleteWorkspaceFile(files, path)
-            } else {
-              let document = server.documents.get(URI.parse(change.uri))
-              if (document) {
-                updateWorkspaceFile(files, document.getText(), path, path.endsWith('.md') ? 'md' : 'gsql')
-              }
-            }
-          }
-
-          analysis.invalidate()
-        })
-
-        changeContent = server.documents.onDidChangeContent(({document}) => {
-          let path = workspacePath(document.uri)
-          if (path) {
-            updateWorkspaceFile(files, document.getText(), path, path.endsWith('.md') ? 'md' : 'gsql')
-            analysis.invalidate()
-          }
-        })
-
-        return {
-          dispose() {
-            fileWatcher?.dispose()
-            changeWatchedFiles?.dispose()
-            changeContent?.dispose()
-          },
-        }
-      }
-
-      async function tryAnalyze() {
-        try {
-          result = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions()})
-          await server.languageFeatures.requestRefresh(false)
-        } catch (err) {
-          let message = err instanceof Error ? err.stack || err.message : String(err)
-          console.error(`Analyze failed: ${message}`)
-        }
-      }
-
-      function diagnosticsFor(path: string) {
-        return result.diagnostics.filter(diagnostic => diagnostic.file === path).map(toDiagnostic)
-      }
-
-      function workspaceDiagnostics() {
-        return getFiles(result).map(file => {
-          return {
-            kind: DocumentDiagnosticReportKind.Full,
-            uri: URIs.joinPath(workspace, file.path).toString(),
-            version: null,
-            items: diagnosticsFor(file.path),
-          }
-        }) satisfies WorkspaceDocumentDiagnosticReport[]
-      }
     },
+  }
+}
+
+// The registry owns shared watchers and routes requests to the nearest project analysis.
+function createProjectRegistry(server: ReturnType<typeof createServer>, workspaceFolders: readonly URI[]) {
+  let disposed = false
+  let projects: GrapheneProjectAnalysis[] = []
+  let fileWatcher: Disposable | undefined
+  let changeWatchedFiles: Disposable | undefined
+  let changeContent: Disposable | undefined
+  let ready = discoverGrapheneProjects(workspaceFolders).then(discovered => {
+    let created = discovered.map(project => createProjectAnalysis(server, project))
+    if (disposed) created.forEach(project => project.dispose())
+    else projects = created
+
+    console.log(
+      'started Graphene language server',
+      created.map(project => project.root),
+    )
+  })
+
+  server.onInitialized(async () => {
+    fileWatcher = await server.fileWatcher.watchFiles(['**/*.{md,gsql}'])
+  })
+
+  changeWatchedFiles = server.fileWatcher.onDidChangeWatchedFiles(({changes}) => {
+    ready.then(async () => {
+      for (let change of changes) {
+        let project = projectForFsPath(filePathFromUri(change.uri))
+        if (project) await project.handleWatchedFileChange(change.uri, change.type)
+      }
+    })
+  })
+
+  changeContent = server.documents.onDidChangeContent(({document}) => {
+    ready.then(() => {
+      let project = projectForFsPath(filePathFromUri(document.uri))
+      project?.handleDocumentChange(document.uri, document.getText())
+    })
+  })
+
+  return {
+    get pending() {
+      return ready.then(() => Promise.all(projects.map(project => project.pending)).then(() => undefined))
+    },
+    async projectForUri(uri: DocumentUri) {
+      await ready
+      let project = projectForFsPath(filePathFromUri(uri))
+      if (!project) return null
+      await project.pending
+      return project
+    },
+    workspaceDiagnostics() {
+      return projects.flatMap(project => project.workspaceDiagnostics())
+    },
+    dispose() {
+      disposed = true
+      fileWatcher?.dispose()
+      changeWatchedFiles?.dispose()
+      changeContent?.dispose()
+      projects.forEach(project => project.dispose())
+    },
+  }
+
+  function projectForFsPath(fsPath: string | null) {
+    return fsPath ? findOwningProject(projects, fsPath) : null
+  }
+}
+
+interface GrapheneProjectAnalysis {
+  root: string
+  pending: Promise<void>
+  provideHover(uri: DocumentUri, line: number, col: number): {contents: string} | null
+  provideDefinition(uri: DocumentUri, line: number, col: number): LocationLink[]
+  provideReferences(uri: DocumentUri, line: number, col: number, includeDeclaration: boolean): Location[]
+  provideDiagnostics(uri: DocumentUri): Diagnostic[]
+  workspaceDiagnostics(): WorkspaceDocumentDiagnosticReport[]
+  handleWatchedFileChange(uri: DocumentUri, changeType: FileChangeType): Promise<void>
+  handleDocumentChange(uri: DocumentUri, contents: string): void
+  dispose(): void
+}
+
+// Each project analysis owns its files, scheduler, and URI mapping.
+function createProjectAnalysis(server: ReturnType<typeof createServer>, project: GrapheneProject): GrapheneProjectAnalysis {
+  let files: Record<string, AnalysisFileInput> = {}
+  let result: WorkspaceAnalysis = {files: {}, diagnostics: [], queries: []}
+  let ignoredFiles = project.config.ignoredFiles || []
+  let analysis = createWorkspaceAnalysis({
+    load: () =>
+      loadWorkspaceFiles(project.root, true, ignoredFiles).then(loaded => {
+        files = loaded
+      }),
+    analyze: tryAnalyze,
+    delay: 200,
+  })
+
+  return {
+    root: project.root,
+    get pending() {
+      return analysis.pending
+    },
+    provideHover(uri, line, col) {
+      let filePath = projectPath(uri)
+      if (!filePath) return null
+      return {contents: getHover(result, filePath, line, col)}
+    },
+    provideDefinition(uri, line, col) {
+      let filePath = projectPath(uri)
+      let location = filePath ? getDefinition(result, filePath, line, col) : null
+      return location ? [toLocationLink(project.root, location)] : []
+    },
+    provideReferences(uri, line, col, includeDeclaration) {
+      let filePath = projectPath(uri)
+      return filePath ? getReferences(result, filePath, line, col, includeDeclaration).map(location => toLocation(project.root, location)) : []
+    },
+    provideDiagnostics(uri) {
+      let filePath = projectPath(uri)
+      return filePath ? diagnosticsFor(filePath) : []
+    },
+    workspaceDiagnostics() {
+      return getFiles(result).map(file => {
+        return {
+          kind: DocumentDiagnosticReportKind.Full,
+          uri: URIs.joinPath(URI.file(project.root), file.path).toString(),
+          version: null,
+          items: diagnosticsFor(file.path),
+        }
+      }) satisfies WorkspaceDocumentDiagnosticReport[]
+    },
+    async handleWatchedFileChange(uri, changeType) {
+      let filePath = projectPath(uri)
+      if (!filePath || isIgnoredWorkspacePath(filePath, ignoredFiles)) return
+
+      if (changeType === FileChangeType.Deleted) {
+        deleteWorkspaceFile(files, filePath)
+        analysis.invalidate()
+        return
+      }
+
+      let document = server.documents.get(URI.parse(uri))
+      if (document) {
+        updateWorkspaceFile(files, document.getText(), filePath, contentType(filePath))
+      } else {
+        try {
+          updateWorkspaceFile(files, await readFile(filePathFromUri(uri)!, 'utf-8'), filePath, contentType(filePath))
+        } catch (err) {
+          let message = err instanceof Error ? err.message : String(err)
+          console.error(`Failed to refresh ${uri}: ${message}`)
+          return
+        }
+      }
+
+      analysis.invalidate()
+    },
+    handleDocumentChange(uri, contents) {
+      let filePath = projectPath(uri)
+      if (!filePath || isIgnoredWorkspacePath(filePath, ignoredFiles)) return
+
+      updateWorkspaceFile(files, contents, filePath, contentType(filePath))
+      analysis.invalidate()
+    },
+    dispose() {
+      analysis.dispose()
+    },
+  }
+
+  async function tryAnalyze() {
+    try {
+      result = analyzeProject({files: listWorkspaceFiles(files), options: toAnalysisOptions(project.config)})
+      await server.languageFeatures.requestRefresh(false)
+    } catch (err) {
+      let message = err instanceof Error ? err.stack || err.message : String(err)
+      console.error(`Analyze failed for ${project.root}: ${message}`)
+    }
+  }
+
+  function projectPath(uri: DocumentUri): string | null {
+    let fsPath = filePathFromUri(uri)
+    if (!fsPath) return null
+    return toWorkspacePath(project.root, fsPath)
+  }
+
+  function diagnosticsFor(filePath: string) {
+    return result.diagnostics.filter(diagnostic => diagnostic.file === filePath).map(toDiagnostic)
   }
 }
 
@@ -201,6 +312,42 @@ function createWorkspaceAnalysis({load, analyze, delay}: {load: () => Promise<vo
   }
 }
 
+async function readPackageJson(packagePath: string) {
+  try {
+    return JSON.parse(await readFile(packagePath, 'utf-8'))
+  } catch (err) {
+    let message = err instanceof Error ? err.message : String(err)
+    console.error(`Failed to read ${packagePath}: ${message}`)
+    return null
+  }
+}
+
+function containsPath(root: string, fsPath: string) {
+  let relative = path.relative(root, fsPath)
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+function filePathFromUri(uri: DocumentUri): string | null {
+  let parsed = URI.parse(uri)
+  return parsed.scheme === 'file' ? parsed.fsPath : null
+}
+
+function toWorkspacePath(root: string, fsPath: string): string | null {
+  if (!containsPath(root, fsPath)) return null
+  return path.relative(root, fsPath).replace(/\\/g, '/')
+}
+
+function isIgnoredWorkspacePath(filePath: string, ignoredFiles: string[]) {
+  let parts = filePath.split('/')
+  if (parts.includes('node_modules')) return true
+  if (parts.some(part => part.startsWith('.'))) return true
+  return ignoredFiles.some(pattern => path.posix.matchesGlob(filePath, pattern))
+}
+
+function contentType(filePath: string): 'md' | 'gsql' {
+  return filePath.endsWith('.md') ? 'md' : 'gsql'
+}
+
 function toDiagnostic(diagnostic: GrapheneError): Diagnostic {
   let from = diagnostic.from || {line: 0, col: 0}
   let to = diagnostic.to || from
@@ -215,9 +362,9 @@ function toDiagnostic(diagnostic: GrapheneError): Diagnostic {
   }
 }
 
-function toLocation(workspace: URI, location: GrapheneLocation): Location {
+function toLocation(root: string, location: GrapheneLocation): Location {
   return {
-    uri: URIs.joinPath(workspace, location.file).toString(),
+    uri: URIs.joinPath(URI.file(root), location.file).toString(),
     range: {
       start: {line: location.from.line, character: location.from.col},
       end: {line: location.to.line, character: location.to.col},
@@ -225,8 +372,8 @@ function toLocation(workspace: URI, location: GrapheneLocation): Location {
   }
 }
 
-function toLocationLink(workspace: URI, location: GrapheneLocation): LocationLink {
-  let uri = URIs.joinPath(workspace, location.file).toString()
+function toLocationLink(root: string, location: GrapheneLocation): LocationLink {
+  let uri = URIs.joinPath(URI.file(root), location.file).toString()
   let range = {
     start: {line: location.from.line, character: location.from.col},
     end: {line: location.to.line, character: location.to.col},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       '@volar/language-service':
         specifier: ^2.4.28
         version: 2.4.28
+      glob:
+        specifier: ^13.0.1
+        version: 13.0.6
       vscode-languageserver-protocol:
         specifier: ^3.17.5
         version: 3.17.5


### PR DESCRIPTION
This PR demonstrates some of the motivation for the refactor in #217/#219 by implementing something that would be trickier before: Supporting multiple graphene projects in the language server/VSCode extension, which are discovered by looking for `package.json` files with graphene configs. With this change the extension properly handles our own monorepo setup which contains examples that conflict if treated as a single project (since the two flights examples declare the same tables).

fixes #200