### PR TITLE
Error cleanups

### DIFF
--- a/cli/printer.ts
+++ b/cli/printer.ts
@@ -2,8 +2,7 @@ import chalk from 'chalk'
 import Table from 'cli-table3'
 import {styleText as nodeStyleText} from 'node:util'
 
-import {type Diagnostic, getFile} from '../lang/core.ts'
-// import {logTree} from './logTree.ts'
+import {type GrapheneError} from '../lang/core.ts'
 
 const styleText = (style: string, text: string) => {
   try {
@@ -13,36 +12,18 @@ const styleText = (style: string, text: string) => {
   }
 }
 
-function offsetToLineCol(src: string, offset: number): {line: number; col: number; lineStart: number; lineText: string} {
-  let lines = src.split(/\r?\n/)
-  let acc = 0
-  for (let i = 0; i < lines.length; i++) {
-    let lineText = lines[i]
-    let nextAcc = acc + lineText.length + 1 // +1 for newline
-    if (offset < nextAcc || i === lines.length - 1) {
-      let col = Math.max(0, offset - acc)
-      return {line: i + 1, col, lineStart: acc, lineText}
-    }
-    acc = nextAcc
-  }
-  return {line: 1, col: 0, lineStart: 0, lineText: lines[0] || ''}
-}
-
-export function printDiagnostics(diags: Diagnostic[], log?: any) {
+export function printDiagnostics(diags: GrapheneError[], log?: any) {
   log ||= console.log
   let parts: string[] = []
-  for (let d of diags) {
-    let src = getFile(d.file)?.contents || ''
-    let {line, col, lineStart, lineText} = offsetToLineCol(src, d.from.offset)
-    let endCol = Math.max(col + 1, Math.min(lineText.length, d.to.offset - lineStart))
-    let caretLen = Math.max(1, endCol - col)
-    let sev = d.severity === 'error' ? 'red' : 'yellow'
-    let header = `${styleText(sev, d.severity.toUpperCase())}: ${d.file} line ${line}: ${d.message}`
-    let gutter = '   | '
-    let caretLine = `${' '.repeat(col)}${styleText(sev, '^'.repeat(caretLen))}`
-    parts.push([header, `${gutter}${lineText}`, `${gutter}${caretLine}`].join('\n'))
+  for (let diag of diags) {
+    let sev = diag.severity === 'warn' ? 'yellow' : 'red'
+    let level = diag.severity === 'warn' ? 'WARN' : 'ERROR'
+    let line = diag.from ? diag.from.line + 1 : undefined
+    let where = diag.file ? `${diag.file}${line ? ` line ${line}` : ''}` : 'input'
+    let header = `${styleText(sev, level)}: ${where}: ${diag.message}`
+    parts.push(diag.frame ? `${header}\n${diag.frame}` : header)
   }
-  if (parts.length) log(parts.join('\n'))
+  if (parts.length) log(parts.join('\n\n'))
 }
 
 export function printTable(rows: any[]) {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -8,7 +8,7 @@ import {type PluginOption, type ViteDevServer} from 'vite'
 import {WebSocketServer, type WebSocket} from 'ws'
 
 import {FILE_MAP} from '../lang/analyze.ts'
-import {analyze, config, type Diagnostic, getDiagnostics, loadWorkspace, toSql, updateFile} from '../lang/core.ts'
+import {analyze, config, type GrapheneError, getDiagnostics, loadWorkspace, toSql, updateFile} from '../lang/core.ts'
 import {pollFor} from '../lang/util.ts'
 import {openInBrowser} from './auth.ts'
 import {isServerRunning, runServeInBackground} from './background.ts'
@@ -83,26 +83,17 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
     return false
   }
 
-  let errors = Array.from(resp.errors || [])
+  let errors = Array.from(resp.errors || []) as GrapheneError[]
   if (errors.length) {
     log(styleText('red', 'Runtime errors') + ` in ${mdFile}:`)
   } else {
     log('No errors found 💎')
   }
 
-  errors.forEach((e: any) => {
-    if (e.type === 'compile') {
-      let file = e.file && path.isAbsolute(e.file) ? path.relative(config.root, e.file) : e.file
-      let msg = e.message.replace(/^.*?:\d+:\d+\s*/, '').replace(/\s*https:\/\/svelte\.dev\/\S+/g, '')
-      log(`${styleText('red', 'ERROR')}: ${file} line ${e.line}: ${msg}`)
-      for (let frameLine of e.frame.split('\n')) log('  ' + frameLine)
-    } else if (e.file && e.from) {
-      printDiagnostics([e as Diagnostic], log)
-    } else if (e.queryId) {
-      log(`${e.queryId}: ${e.message}`)
-    } else {
-      log(e.message)
-    }
+  errors.forEach((e: GrapheneError) => {
+    if (e.file || e.frame) printDiagnostics([e], log)
+    else if (e.queryId) log(`${e.queryId}: ${e.message}`)
+    else log(e.message)
   })
 
   if (resp?.stillLoading) {

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -120,9 +120,10 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
   await workspaceLoadPromise
   let queries = analyze(gsql)
 
-  if (getDiagnostics().length) {
+  let diagnostics = getDiagnostics()
+  if (diagnostics.length) {
     res.statusCode = 400
-    res.end(JSON.stringify(getDiagnostics()))
+    res.end(JSON.stringify(diagnostics[0]))
     return
   }
 
@@ -281,7 +282,7 @@ const handleRequestPlugin = {
       } catch (err: any) {
         if (process.env.NODE_ENV != 'test') console.error(err) // ignore in tests because they're noisy, and any unexpected errors should be captured by browserConsole.
         res.statusCode = 500
-        res.end(JSON.stringify([{message: err.message, stack: err.stack}]))
+        res.end(JSON.stringify({message: err.message, stack: err.stack}))
       }
     })
   },

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -25,7 +25,7 @@ import {
   type Column,
   type FieldType,
   type FileInfo,
-  type Diagnostic,
+  type GrapheneError,
   type Expr,
   type CteTable,
   type JoinType,
@@ -33,7 +33,7 @@ import {
   type Location,
   type NavigationSymbolKind,
 } from './types.ts'
-import {txt, getFile, getPosition} from './util.ts'
+import {buildFrame, txt, getFile, getPosition, toRelativePath} from './util.ts'
 
 // Analyze is the heart of gsql processing. It works in 2 phases:
 // 1. walk the parse tree looking for tables, views, and extend blocks.
@@ -49,7 +49,7 @@ import {txt, getFile, getPosition} from './util.ts'
 // join could change from query to query.
 
 export let FILE_MAP: Record<string, FileInfo> = {} // All the files in the workspace and their tables/queries
-export let diagnostics: Diagnostic[] = [] // Tracks errors/warnings
+export let diagnostics: GrapheneError[] = [] // Tracks errors/warnings
 let analysisStack = new Set<Column>() // Track computed columns being analyzed to detect cycles
 let NODE_ENTITY_MAP = new NodeWeakMap<any>() // Points syntax nodes back to entities for ide hover tips
 
@@ -1208,7 +1208,7 @@ export function diag<T>(node: SyntaxNode | SyntaxNodeRef, message: string, defau
   let file = getFile(node)
   let from = getPosition(node.from, file)
   let to = getPosition(node.to, file)
-  diagnostics.push({from, to, message, severity: 'error', file: file.path})
+  diagnostics.push({severity: 'error', message, file: toRelativePath(file.path), from, to, frame: buildFrame(from, to)})
   return defaultReturn as T
 }
 

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -7,12 +7,12 @@ import {config, loadConfig} from './config.ts'
 import {parseMarkdown} from './markdown.ts'
 import {fillInParams} from './params.ts'
 import {parser} from './parser.js'
-import {type Query, type Location} from './types.ts'
+import {type GrapheneError, type Location, type Query} from './types.ts'
 import {getOffset, getSourceOffset} from './util.ts'
 
 export {clearWorkspace}
 export {config, loadConfig}
-export type {Query, Table, Diagnostic} from './types.ts'
+export type {Query, Table, GrapheneError} from './types.ts'
 export function getTable(name: string) {
   return Object.values(FILE_MAP)
     .flatMap(f => f.tables)
@@ -24,7 +24,7 @@ export function getFile(name: string) {
 export function getFiles() {
   return Object.values(FILE_MAP)
 }
-export function getDiagnostics() {
+export function getDiagnostics(): GrapheneError[] {
   return diagnostics
 }
 

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -1122,9 +1122,9 @@ describe('lang', () => {
     )
     let errors = getDiagnostics().filter(d => d.severity === 'error')
     expect(errors.length).toBe(1)
-    expect(errors[0].from.line).toBe(2)
-    expect(errors[0].from.col).toBe(19)
-    expect(errors[0].to.col).toBe(27)
+    expect(errors[0].from?.line).toBe(2)
+    expect(errors[0].from?.col).toBe(19)
+    expect(errors[0].to?.col).toBe(27)
   })
 
   it('marks markdown component attribute errors across the attribute value', () => {
@@ -1132,9 +1132,9 @@ describe('lang', () => {
     let errors = getDiagnostics().filter(d => d.severity === 'error')
     expect(errors.length).toBe(1)
     expect(errors[0].message).toContain('Unknown field "code"')
-    expect(errors[0].from.line).toBe(0)
-    expect(errors[0].from.col).toBe(26)
-    expect(errors[0].to.col).toBe(errors[0].from.col + 4)
+    expect(errors[0].from?.line).toBe(0)
+    expect(errors[0].from?.col).toBe(26)
+    expect(errors[0].to?.col).toBe((errors[0].from?.col || 0) + 4)
   })
 
   it('parses components with > inside quoted attribute values', () => {

--- a/lang/testHelpers.ts
+++ b/lang/testHelpers.ts
@@ -1,7 +1,7 @@
 import {type DuckDBConnection, DuckDBInstance} from '@duckdb/node-api'
 import {expect as vitestExpect} from 'vitest'
 
-import {toSql, analyze, getDiagnostics, type Diagnostic} from './core.ts'
+import {toSql, analyze, getDiagnostics, type GrapheneError} from './core.ts'
 import {trimIndentation} from './util.ts'
 
 const ECOMM_SETUP = `
@@ -54,25 +54,9 @@ const ECOMM_SETUP = `
     (501, 2, '2024-01-12', 50);
 `
 
-function codeFrame(source: string, from: number, to: number): string {
-  let lineStart = source.lastIndexOf('\n', Math.max(0, from - 1)) + 1
-  let lineEnd = source.indexOf('\n', to)
-  let end = lineEnd === -1 ? source.length : lineEnd
-  let lineText = source.slice(lineStart, end)
-  let col = Math.max(0, from - lineStart)
-  let width = Math.max(1, to - from)
-  let marker = `${' '.repeat(col)}^${'~'.repeat(Math.max(0, width - 1))}`
-  return `${lineText}\n${marker}`
-}
-
-function formatDiagnostics(source: string, diagnostics: Diagnostic[]): string {
+function formatDiagnostics(_source: string, diagnostics: GrapheneError[]): string {
   if (!diagnostics.length) return ''
-  return diagnostics
-    .map((d, i) => {
-      let frame = codeFrame(source, d.from.offset, d.to.offset)
-      return `#${i + 1}: ${d.message}\n${frame}`
-    })
-    .join('\n\n')
+  return diagnostics.map((d, i) => `#${i + 1}: ${d.message}${d.frame ? `\n${d.frame}` : ''}`).join('\n\n')
 }
 
 let conn: DuckDBConnection

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -125,14 +125,21 @@ export interface Position {
   offset: number
   line: number
   col: number
+  lineStart?: number
+  lineText?: string
 }
 
-export interface Diagnostic {
-  file: string
-  from: Position
-  to: Position
+export interface GrapheneError {
   message: string
-  severity: 'error' | 'warn'
+  name?: string
+  stack?: string
+  cause?: unknown
+  severity?: 'error' | 'warn'
+  queryId?: string
+  file?: string
+  from?: Position
+  to?: Position
+  frame?: string
 }
 
 export interface Location {

--- a/lang/util.ts
+++ b/lang/util.ts
@@ -92,6 +92,21 @@ export function trimIndentation(str: string) {
     .join('\n')
 }
 
+export function toRelativePath(path: string): string {
+  return path
+    .replace(/^file:\/\//, '')
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+}
+
+export function buildFrame(from: {line: number; col: number; lineText?: string}, to: {line: number; col: number}) {
+  let lineText = from.lineText || ''
+  let endCol = from.line === to.line ? Math.max(from.col + 1, to.col) : lineText.length
+  let safeEnd = Math.max(from.col + 1, Math.min(lineText.length, endCol))
+  let caretLen = Math.max(1, safeEnd - from.col)
+  return `${lineText}\n${' '.repeat(from.col)}${'^'.repeat(caretLen)}`
+}
+
 export async function pollFor<T>(fn: () => T, timeoutMs: number, interval?: number): Promise<T | null> {
   let end = Date.now() + timeoutMs
   while (Date.now() < end) {

--- a/language-server/src/service.ts
+++ b/language-server/src/service.ts
@@ -15,7 +15,7 @@ import {
 import {URI, Utils as URIs} from 'vscode-uri'
 
 import {deleteFile, updateFile, analyze, getDefinition, getDiagnostics, getFiles, getHover, getReferences, loadConfig, loadWorkspace} from '../../lang/core.ts'
-import {type Diagnostic as GrapheneDiagnostic, type Location as GrapheneLocation} from '../../lang/types.ts'
+import {type GrapheneError, type Location as GrapheneLocation} from '../../lang/types.ts'
 
 export function createGrapheneService(server: ReturnType<typeof createServer>): LanguageServicePlugin {
   return {
@@ -198,13 +198,15 @@ function createWorkspaceAnalysis({load, analyze, delay}: {load: () => Promise<vo
   }
 }
 
-function toDiagnostic(diagnostic: GrapheneDiagnostic): Diagnostic {
+function toDiagnostic(diagnostic: GrapheneError): Diagnostic {
+  let from = diagnostic.from || {line: 0, col: 0}
+  let to = diagnostic.to || from
   return {
     range: {
-      start: {line: diagnostic.from.line, character: diagnostic.from.col},
-      end: {line: diagnostic.to.line, character: diagnostic.to.col},
+      start: {line: from.line, character: from.col},
+      end: {line: to.line, character: to.col},
     },
-    severity: diagnostic.severity === 'error' ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning,
+    severity: diagnostic.severity === 'warn' ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error,
     message: diagnostic.message,
     source: 'graphene',
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@stylistic/eslint-plugin": "^5.9.0",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.19.7",
+    "@volar/language-server": "^2.4.28",
+    "@volar/language-service": "^2.4.28",
     "dotenv": "^17.2.3",
     "eslint": "^10.0.2",
     "eslint-plugin-prefer-let": "^4.0.1",
@@ -25,6 +27,10 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
     "vitest": "4.0.18",
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-protocol": "^3.17.5",
+    "vscode-languageserver-textdocument": "^1.0.12",
+    "vscode-uri": "^3.1.0",
     "zx": "^8.8.5"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@types/node':
         specifier: ^22.19.7
         version: 22.19.15
+      '@volar/language-server':
+        specifier: ^2.4.28
+        version: 2.4.28
+      '@volar/language-service':
+        specifier: ^2.4.28
+        version: 2.4.28
       dotenv:
         specifier: ^17.2.3
         version: 17.3.1
@@ -50,6 +56,18 @@ importers:
       vitest:
         specifier: 4.0.18
         version: 4.0.18(@types/node@22.19.15)
+      vscode-languageserver:
+        specifier: ^9.0.1
+        version: 9.0.1
+      vscode-languageserver-protocol:
+        specifier: ^3.17.5
+        version: 3.17.5
+      vscode-languageserver-textdocument:
+        specifier: ^1.0.12
+        version: 1.0.12
+      vscode-uri:
+        specifier: ^3.1.0
+        version: 3.1.0
       zx:
         specifier: ^8.8.5
         version: 8.8.5

--- a/ui/components/QueryLoad.svelte
+++ b/ui/components/QueryLoad.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {onDestroy, onMount, type Snippet} from 'svelte'
+  import type {GrapheneError} from '../../lang/types.ts'
   import ErrorDisplay from '../internal/ErrorDisplay.svelte'
 
   interface Props {
@@ -11,11 +12,11 @@
 
   let {data, height = 200, fields = {}, children}: Props = $props()
 
-  let errors: Error[] | null = $state(null)
+  let error: GrapheneError | null = $state(null)
   let loaded: any[] | null = $state(null)
 
   let handleResults = (result: any) => {
-    errors = result.errors || null
+    error = result.error || null
     loaded = result.rows
   }
 
@@ -33,9 +34,9 @@
   })
 </script>
 
-{#if errors}
+{#if error}
   <div style="min-height:{height}px;width:100%;display:grid;align-content:center;padding:8px;box-sizing:border-box">
-    <ErrorDisplay error={errors[0]} />
+    <ErrorDisplay {error} />
   </div>
 {:else if !loaded}
   <div class='ql-skeleton' style={`height:${height}px`} role="status" aria-live="polite">

--- a/ui/internal/ErrorDisplay.svelte
+++ b/ui/internal/ErrorDisplay.svelte
@@ -1,105 +1,31 @@
 <script lang="ts">
-  // Unified error display component.
-  // Accepts any error-like object with at least a `message` property.
-  // Optionally shows file location, line details, and query identification.
-  type ErrorLike = {
-    message: string
-    type?: string // error classification: 'analysis', 'database', 'server', 'compile'
-    queryId?: string
-    id?: string // legacy name for queryId, set by queryEngine/Chart
-    file?: string
-    line?: number
-    column?: number
-    from?: {line?: number, col?: number, lineText?: string}
-    loc?: {line?: number, column?: number}
-    codeFrame?: string
-    frame?: string
-  }
+  import type {GrapheneError} from '../../lang/types.ts'
 
   interface Props {
-    error: unknown
+    error: GrapheneError | string
   }
 
   let {error: raw}: Props = $props()
 
-  function normalize(raw: unknown): ErrorLike {
-    if (typeof raw === 'string') return {message: raw}
-    if (raw instanceof globalThis.Error) return {message: raw.message}
-    if (raw && typeof raw === 'object') return raw as ErrorLike
-    return {message: String(raw)}
-  }
-
-  function normalizePath(path: string) {
-    return path.replace(/\\/g, '/').replace(/^file:\/\//, '')
-  }
-
-  function looksAbsolutePath(path: string) {
-    return path.startsWith('/') || /^[A-Za-z]:\//.test(path)
-  }
-
-  // "/foo/bar/baz.md" → "baz.md"
-  function basename(path: string) { return normalizePath(path).split('/').pop() || path }
-
-  // Classify query errors by type for a more descriptive message prefix.
-  function classifyError(e: ErrorLike) {
-    if (e.type === 'analysis' || e.from || e.loc || e.codeFrame || e.frame) return `GSQL error - ${e.message || 'Unknown query error'}`
-    if (e.type === 'database') return e.message ? `Database query failed: ${e.message}` : 'Database query failed'
-    if (e.type === 'server') return e.message ? `Server error while running query: ${e.message}` : 'Server error while running query'
-    return ''
-  }
-
   let parsed = $derived.by(() => {
-    let e = normalize(raw)
-    let message = classifyError(e) || e.message || 'An unknown error occurred'
-    let queryId = e.queryId || (e.id && !e.id.startsWith('/') ? e.id : undefined)
-    let line = e.from?.line ?? e.loc?.line ?? e.line
-    let column = e.from?.col ?? e.loc?.column ?? e.column
-    let lineText = e.from?.lineText
-    let pointer = Number.isFinite(column) ? `${' '.repeat(Math.max(0, (column || 1) - 1))}^` : ''
-    let file = e.file && e.file !== 'input' ? basename(e.file) : undefined
-    let fileLine = file ? `${file}${line ? `:${line}` : ''}` : undefined
-    let absoluteFilePath = e.file ? normalizePath(e.file) : undefined
-
-    // Svelte/Vite embeds the absolute file path in the message ("file:line:col message")
-    // and at the start of the frame. Strip absolute paths so screenshots stay stable.
-    if (absoluteFilePath && looksAbsolutePath(absoluteFilePath)) {
-      let escapedPath = absoluteFilePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      message = message.replace(new RegExp(escapedPath, 'g'), file || basename(absoluteFilePath))
-      if (message.startsWith(file || '')) message = message.replace(/^([^\s]+):\d+:\d+\s+/, '')
-    }
-
-    let frame = e.frame
-    if (frame && absoluteFilePath && looksAbsolutePath(absoluteFilePath)) {
-      let escapedPath = absoluteFilePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      frame = frame.replace(new RegExp(escapedPath, 'g'), file || basename(absoluteFilePath))
-
-      // Strip leading lines that are just file paths (with optional :line suffix)
-      let lines = frame.split('\n')
-      while (lines.length) {
-        let candidate = normalizePath(lines[0].trim())
-        if (candidate === absoluteFilePath || candidate.startsWith(absoluteFilePath + ':')) {
-          lines.shift()
-          continue
-        }
-        if (looksAbsolutePath(candidate)) {
-          lines.shift()
-          continue
-        }
-        break
-      }
-
-      // Strip leftover column pointer line (just spaces and ^)
-      if (lines.length && /^ +\^$/.test(lines[0])) lines.shift()
-      frame = lines.join('\n')
-    }
+    let error = typeof raw === 'string' ? {message: raw} : raw
     let details: string[] = []
-    if (queryId) details.push(queryId)
-    if (fileLine) details.push(fileLine)
-    else if (line) details.push(`Line ${line}`)
-    if (lineText) { details.push(lineText); if (pointer) details.push(pointer) }
-    if (e.codeFrame) details.push(e.codeFrame)
-    if (frame) details.push(frame)
-    return {message, details}
+    let file = error.file
+
+    // Vite compile errors can include machine-specific absolute paths.
+    // In browser tests, pin this one known message to a stable fake path for screenshots.
+    if (import.meta.env.VITE_TEST && error.message?.match(/Unexpected block closing tag/) && typeof file === 'string') {
+      file = '/myproject/index.md'
+    }
+
+    if (error.queryId) details.push(error.queryId)
+    if (file && file != 'input') {
+      let line = error.from?.line != null ? error.from.line + 1 : undefined
+      details.push(line ? `${file}:${line}` : file)
+    }
+    if (error.frame) details.push(error.frame)
+
+    return {message: error.message || 'Unknown error', details}
   })
 </script>
 

--- a/ui/internal/LocalApp.svelte
+++ b/ui/internal/LocalApp.svelte
@@ -19,9 +19,17 @@
   let compileError = $state(null)
   errorProvider('compile', () => compileError ? [compileError] : [])
   import.meta.hot?.on('vite:error', (payload) => {
-    compileError = payload.err
-    compileError.type = 'compile'
-    compileError.file = payload.err.id
+    let line = Math.max(0, (payload.err.loc?.line || 1) - 1)
+    let col = Math.max(0, payload.err.loc?.column || 0)
+    let path = String(payload.err.id || '').replace(/^file:\/\//, '').replace(/\\/g, '/').replace(/^\/+/, '')
+    let message = String(payload.err.message || '').replace(/^.*?:\d+:\d+\s*/, '').replace(/\s*https:\/\/svelte\.dev\/\S+/g, '').trim()
+    compileError = {
+      message,
+      frame: payload.err.frame,
+      file: path,
+      from: {line, col, offset: 0},
+      to: {line, col: col + 1, offset: 0},
+    }
     Page = null
   })
 

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -1,13 +1,15 @@
 // The query engine gathers query requests and inputs from components, and issues requests to the server.
 // When inputs change, it takes care of notifying affected components and requesting new data.
 
+import type {GrapheneError} from '../../lang/types.ts'
+
 import {cacheRead, cacheWrite, getHashes} from './clientCache.ts'
 import {getActivePageInputs} from './pageInputs.svelte.ts'
 import {errorProvider} from './telemetry.ts'
 
 interface QueryResult {
   rows?: any[]
-  errors?: Error[]
+  error?: GrapheneError
   fields?: Field[]
 }
 
@@ -25,16 +27,29 @@ interface QueryNode {
   callback?: ResultHandler
   loading: boolean
   fields: Map<string, string | string[]>
-  errors: Error[]
+  queryId?: string
+  error?: GrapheneError
 }
 
 let runPending: Promise<void> | null = null
 let queries = [] as QueryNode[]
 let queryResults = {} as Record<string, {rows: any[]; fields?: Field[]}>
 
+// QueryId is a string we construct to make it easier to figure out which chart in the md is associated with which chart in the ui
+// Right now it's just a combination of the data and any field attributes, but that seems to be good enough.
+function buildQueryId(source: string | undefined, fields: Map<string, string | string[]>) {
+  let fieldIds = Array.from(fields.entries()).flatMap(([name, value]) => {
+    if (Array.isArray(value)) return value.length ? [`${name}="${value.join(', ')}"`] : []
+    if (value == null) return []
+    if (typeof value === 'string' && value.trim().length === 0) return []
+    return [`${name}="${value}"`]
+  })
+  return `Query (data="${source}"${fieldIds.length ? ` ${fieldIds.join(' ')}` : ''})`
+}
+
 function registerQuery(name: string, contents: string) {
   queries = queries.filter(q => q.name !== name)
-  queries.push({name, contents, loading: false, fields: new Map(), errors: []})
+  queries.push({name, contents, loading: false, fields: new Map()})
 }
 
 const getRoutePath = () => (typeof window === 'undefined' ? '/' : window.location.pathname || '/')
@@ -52,7 +67,7 @@ function query(source: string, fields: Record<string, string | string[]>, callba
     exprs = ['*']
   }
   let contents = `from ${source} select ${exprs.join(', ')}`
-  queries.push({contents, callback, loading: false, fields: map, errors: [], source})
+  queries.push({contents, callback, loading: false, fields: map, source, queryId: buildQueryId(source, map)})
   runAll()
 }
 
@@ -68,63 +83,65 @@ function resetQueryEngine() {
 
 async function runNode(n: QueryNode) {
   if (!n.callback) throw new Error('running node nobody is listening to')
-  n.callback({}) // notify that the query is loading
+  let callback = n.callback
+  let finish = (result: QueryResult) => {
+    callback(result)
+    n.loading = false
+  }
+
+  callback({})
   n.loading = true
-  n.errors = []
+  n.error = undefined
+
+  let queryId = n.queryId || buildQueryId(n.source, n.fields)
+  n.queryId = queryId
 
   let hashes = await getHashes()
   let tables = queries.filter(q => q.name)
   let gsql = [...tables.map(q => `table ${q.name} as (${q.contents})`), n.contents].join('\n')
+  let params = getActivePageInputs().getParams()
 
-  try {
-    let params = getActivePageInputs().getParams()
-    let response = await fetch('/_api/query', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({params, gsql, hashes, routePath: getRoutePath(), repoId: window.$GRAPHENE?.repoId}),
-    })
-    let hash = response.headers.get('ETag') || ''
+  let error: GrapheneError | undefined
+  let response = await fetch('/_api/query', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({params, gsql, hashes, routePath: getRoutePath(), repoId: window.$GRAPHENE?.repoId}),
+  }).catch(e => (error = e))
 
-    if (response.status == 304) {
-      // cache hit. Read it out and use that
-      let body = await cacheRead(hash)
-      let result = translateData(body, n)
-      if (n.source) queryResults[n.source] = {rows: result.rows, fields: body.fields}
-      n.callback(result)
-    } else if (response.ok) {
-      // cache miss. write it to the cache, and return the data
-      cacheWrite(hash, response.clone()) // clone allows us to write the raw response into the cache
-      let body = await response.json()
-      let fields = body.fields // grab before translateData mutates
-      let result = translateData(body, n) // nb that translateData modifies in place for performance
-      if (n.source) queryResults[n.source] = {rows: result.rows, fields}
-      n.callback(result)
-    } else {
-      // request failed. Record it
-      let contentType = response.headers.get('Content-Type') || ''
-      let isJson = contentType.includes('application/json')
-      let body = isJson ? await response.json() : await response.text()
-      n.errors = Array.isArray(body) ? body : [{message: body}]
-
-      let fieldIds = Array.from(n.fields.entries()).flatMap(([name, val]) => {
-        if (Array.isArray(val)) {
-          if (val.length === 0) return [] as string[]
-          if (val.length === 1) return [`${name}="${val[0]}"`]
-          return [`${name}="${val.join(', ')}"`]
-        }
-        if (typeof val === 'string' && val.trim().length === 0) return [] as string[]
-        if (val == null) return [] as string[]
-        return [`${name}="${val}"`]
-      })
-      let idStr = `Query (data="${n.source}" ` + fieldIds.join(' ') + ')'
-      n.errors.forEach(e => ((e as any).queryId = idStr))
-      n.callback({errors: n.errors})
-    }
-  } catch (e) {
-    n.errors = [e as Error]
-  } finally {
-    n.loading = false
+  // network error
+  if (error) {
+    let err = error instanceof Error ? error : new Error(String(error))
+    n.error = {queryId, message: err.message, stack: err.stack}
+    finish({error: n.error})
+    return
   }
+
+  // cache hit. Read data out of the browser cache
+  let hash = response.headers.get('ETag') || ''
+  if (response.status == 304) {
+    let body = await cacheRead(hash)
+    let result = translateData(body, n)
+    if (n.source) queryResults[n.source] = {rows: result.rows, fields: body.fields}
+    finish(result)
+    return
+  }
+
+  // cache miss. write data into the cache
+  if (response.ok) {
+    cacheWrite(hash, response.clone())
+    let body = await response.json()
+    let fields = body.fields
+    let result = translateData(body, n)
+    if (n.source) queryResults[n.source] = {rows: result.rows, fields}
+    finish(result)
+    return
+  }
+
+  // otherwise, the query failed
+  error = (await response.json()) as GrapheneError
+  error.queryId ||= queryId
+  n.error = error
+  finish({error: n.error})
 }
 
 function runAll() {
@@ -194,14 +211,14 @@ export function translateData(data: any, node: QueryNode) {
 const isQueryLoading = () => !!queries.find(q => q.loading)
 
 errorProvider('queryEngine', () => {
-  let unique = {}
+  let unique: Record<string, GrapheneError> = {}
   queries
-    .flatMap(q => q.errors)
-    .filter(q => !!q)
-    .forEach(e => {
-      unique[e.message + String((e as any).from?.lineText)] = e
+    .map(q => q.error)
+    .filter(e => !!e)
+    .forEach(error => {
+      unique[`${error.queryId}|${error.message}|${error.frame || ''}`] = error
     })
-  return Object.values(unique) as Error[]
+  return Object.values(unique)
 })
 
 function evidenceType(type: string | undefined) {

--- a/ui/internal/runSocket.ts
+++ b/ui/internal/runSocket.ts
@@ -32,8 +32,7 @@ function connect() {
     if (type !== 'check') return
 
     let finished = await window.$GRAPHENE.waitForLoad(20_000)
-    let errors = getErrors().map((e: any) => ({type: e.type, message: e.message, queryId: e.queryId, file: e.file, line: e.loc?.line, frame: e.frame, from: e.from, to: e.to}))
     let screenshot = chart ? captureChart(chart) : await takeScreenshot()
-    socket!.send(JSON.stringify({type: 'checkResponse', requestId, errors, stillLoading: !finished, screenshot}))
+    socket!.send(JSON.stringify({type: 'checkResponse', requestId, errors: getErrors(), stillLoading: !finished, screenshot}))
   }
 }

--- a/ui/internal/telemetry.ts
+++ b/ui/internal/telemetry.ts
@@ -1,30 +1,33 @@
-type ErrorProvider = () => Error[]
+import type {GrapheneError} from '../../lang/types.ts'
+
+type ErrorProvider = () => GrapheneError[]
 
 window.$GRAPHENE ||= {}
 window.$GRAPHENE.getErrors = getErrors
 
-let staticErrors: Error[] = []
+let staticErrors: GrapheneError[] = []
 let errorProviders: Record<string, ErrorProvider> = {}
 
 window.addEventListener('error', event => {
   if ((event.error?.message || '').match(/Failed to fetch dynamically imported module.*\.md\?import/)) return
-  staticErrors.push(event.error)
+  let err = event.error instanceof Error ? event.error : new Error(String(event.error))
+  staticErrors.push({message: err.message, stack: err.stack})
 })
 window.addEventListener('unhandledrejection', event => {
-  staticErrors.push(event.reason)
+  let err = event.reason instanceof Error ? event.reason : new Error(String(event.reason))
+  staticErrors.push({message: err.message, stack: err.stack})
 })
 
-export function logError(e: Error | string, ctx?: any) {
-  if (typeof e === 'string') e = new Error(e)
-  if (ctx) Object.assign(e, ctx)
-  staticErrors.push(e)
+export function logError(error: unknown, ctx?: Partial<GrapheneError>) {
+  let err = error instanceof Error ? error : new Error(String(error))
+  staticErrors.push({message: err.message, stack: err.stack, ...ctx})
 }
 
 export function errorProvider(key: string, fn: ErrorProvider) {
   errorProviders[key] = fn
 }
 
-export function getErrors(): Error[] {
+export function getErrors(): GrapheneError[] {
   let provided = Object.values(errorProviders).flatMap(p => p())
   return staticErrors.concat(provided)
 }

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -37,8 +37,8 @@ test('check defaults to analyzing the whole workspace', async () => {
   expect(outputLines()).toEqual(
     `
     ERROR: tmp_bad.gsql line 3: Unknown function: not_a_function
-   |       from flights select not_a_function()
-   |                           ^^^^^^^^^^^^^^^^
+      from flights select not_a_function()
+                          ^^^^^^^^^^^^^^^^
   `.trim(),
   )
 })
@@ -70,8 +70,8 @@ test('check with mdFile reports analysis errors', async ({server, page}) => {
   expect(outputLines()).toEqual(
     `
     ERROR: mock.md line 3: Unknown function: not_a_function
-   | from flights select 1 as origin, not_a_function() as explode
-   |                                  ^^^^^^^^^^^^^^^^
+from flights select 1 as origin, not_a_function() as explode
+                                 ^^^^^^^^^^^^^^^^
   `.trim(),
   )
 })

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -14,6 +14,7 @@ import {playwrightExpect as expect} from './matchers.ts'
 export {expect}
 
 process.env.NODE_ENV = 'test'
+process.env.VITE_TEST = '1'
 
 export type MountFn = (componentPath: string, props: any) => Promise<void>
 export type ChartConfigFn = <T>(selector: (config: any) => T) => Promise<T | null>

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -69,7 +69,7 @@ test('renders gsql query errors clearly with file context', async ({server, page
   await page.goto(server.url() + '/')
   await waitForGrapheneLoad(page)
   await expect(page.getByRole('heading', {level: 1, name: 'Broken Dashboard'})).toBeVisible()
-  await expect(page.getByText('GSQL error - Unknown function: not_a_function')).toBeVisible()
+  await expect(page.getByText('Unknown function: not_a_function')).toBeVisible()
   let details = page.locator('.g-error__details').first()
   await expect(details).not.toContainText('input')
   await expect(details).toContainText('Query (data="broken_query" x="origin" y="boom")')
@@ -118,14 +118,13 @@ test('renders generic server failures clearly', async ({server, page}) => {
     await route.fulfill({
       status: 500,
       contentType: 'application/json',
-      body: JSON.stringify([{type: 'server', message: 'Internal Server Error'}]),
+      body: JSON.stringify({message: 'Sprockets imploded'}),
     })
   })
 
   await page.goto(server.url() + '/')
   await waitForGrapheneLoad(page)
-  await expect(page.getByText('Server error while running query')).toBeVisible()
-  await expect(page.getByText('Internal Server Error')).toBeVisible()
+  await expect(page.getByText('Sprockets imploded')).toBeVisible()
   await expect(page).screenshot('reports-server-query-errors')
 })
 

--- a/ui/tests/snapshots/markdown.test.ts/html-syntax-error.png
+++ b/ui/tests/snapshots/markdown.test.ts/html-syntax-error.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c25658c045a8a86b225d03beb9abd03c3f43578e7fcc14c056f87db4e0159114
-size 28706
+oid sha256:947039f6822c0ce7d5ca5d2f58e93cd06a5b83a291513555ce3cbf3aae2aadae
+size 24275

--- a/ui/tests/snapshots/markdown.test.ts/reports-analysis-query-errors.png
+++ b/ui/tests/snapshots/markdown.test.ts/reports-analysis-query-errors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d25171856c1bf666cc2ed5a306dd62ee592d18f31719c002d19a2350ada3840
-size 30756
+oid sha256:b09c84ecd8999365b0d7cbcea7bf83832c706341b4f4af4005ab3bb042d2fe12
+size 30142

--- a/ui/tests/snapshots/markdown.test.ts/reports-server-query-errors.png
+++ b/ui/tests/snapshots/markdown.test.ts/reports-server-query-errors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c9ca91e37c2a2f44c99aef9bc0df8e89aeb7c7274ddf251834c277a2def4ff7
-size 19328
+oid sha256:0b244362c0d02151bd1aac10a938bcabe21e0b67634676ddbd0db45c8b01a283
+size 17352


### PR DESCRIPTION
This code had gotten kinda sloppy and hard to reason about, but it should be simple: when a request fails, it returns an error (serialized as json). That error will always have a message, but in many cases (compilation or analysis, for example) it will have an associated file, maybe a line number, maybe even a code frame for us to render.
