### PR TITLE
add field metadata inferred and propagated through analysis

### DIFF
--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -141,7 +141,7 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
   let queryResults = await runQuery(sql)
   let totalRows = queryResults.totalRows ?? queryResults.rows.length
   if (totalRows > queryResults.rows.length) throw new Error('Query returns too many rows')
-  let fields = queries[0].fields.map(f => ({name: f.name, type: f.type}))
+  let fields = queries[0].fields.map(f => ({name: f.name, type: f.type, fieldMetadata: f.fieldMetadata}))
   res.end(JSON.stringify({rows: queryResults.rows, hash, fields, sql}))
 }
 

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -863,7 +863,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       let targetType = txt(typeNode).toUpperCase()
       let resultType = convertDataType(targetType)
       if (!resultType) return diag(typeNode, `Unsupported cast type: ${targetType.toLowerCase()}`, {sql: 'NULL', type: 'error'})
-      return {...e, sql: `CAST(${e.sql} AS ${targetType})`, type: resultType, fieldMetadata: preserveTemporalMetadata(e, resultType)}
+      return {...e, sql: `CAST(${e.sql} AS ${targetType})`, type: resultType, fieldMetadata: preserveTemporalMetadataThroughCast(e, resultType)}
     }
 
     case 'ExtractExpression': {
@@ -976,7 +976,7 @@ function coerceToTemporal(expr: Expr, targetType: 'date' | 'timestamp', node: Sy
   return {...expr, sql: `${targetType.toUpperCase()} '${parsed.literal}'`, type: targetType}
 }
 
-function preserveTemporalMetadata(expr: Expr, resultType: FieldType) {
+function preserveTemporalMetadataThroughCast(expr: Expr, resultType: FieldType) {
   if (!expr.fieldMetadata?.temporal) return
   if (resultType != 'date' && resultType != 'timestamp') return
   return expr.fieldMetadata

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -32,6 +32,7 @@ import {
   type Scope,
   type Location,
   type NavigationSymbolKind,
+  type TemporalFieldMetadata,
 } from './types.ts'
 import {buildFrame, txt, getFile, getPosition, toRelativePath} from './util.ts'
 
@@ -169,7 +170,7 @@ function analyzeView(table: Table) {
   if (!query) return
 
   let viewCols = query.fields.map(f => {
-    let col = {name: f.name, type: f.type, metadata: f.metadata, location: f.definitionLocation} as Column
+    let col = {name: f.name, type: f.type, metadata: f.metadata, fieldMetadata: f.fieldMetadata, location: f.definitionLocation} as Column
     if (f.definitionLocation) {
       col.symbolId = symbolId('column', f.definitionLocation, `${table.symbolId}:${f.name}`)
       getFile(table.syntaxNode!).navigation.symbols.push({id: col.symbolId, kind: 'column', name: col.name, location: f.definitionLocation, tableId: table.symbolId})
@@ -187,7 +188,9 @@ export function analyzeTableFully(table: Table) {
   table.columns.forEach(c => {
     if (!c.exprNode) return
     let expr = analyzeExpr(c.exprNode, scope)
+    c.type = expr.type
     c.isAgg = expr.isAgg
+    c.fieldMetadata = expr.fieldMetadata
     analyzeComputedFieldExpr(c.exprNode, expr)
   })
   table.joins.forEach(j => {
@@ -224,6 +227,7 @@ function expandColumns(table: Table | null, alias: string, query: Query, scope: 
         sql: expr.sql,
         type: expr.type,
         metadata: col.metadata,
+        fieldMetadata: expr.fieldMetadata,
         fanout: expr.fanout,
         definitionLocation: col.location,
       })
@@ -233,6 +237,7 @@ function expandColumns(table: Table | null, alias: string, query: Query, scope: 
         sql: `${alias}.${col.name}`,
         type: col.type,
         metadata: col.metadata,
+        fieldMetadata: col.fieldMetadata,
         fanout: normalizeExprFanout({path: scope.fanoutPath}),
         definitionLocation: col.location,
       })
@@ -257,7 +262,7 @@ function analyzeQueryExpression(queryNode: SyntaxNode, outerCtes?: Table[]): Que
     let name = txt(cteDef.getChild('Alias'))
     let query = analyzeQuery(cteDef.getChild('QueryExpression')!, scope.otherTables)
     if (!query) return
-    let columns = query.fields.map(f => ({name: f.name, type: f.type, metadata: f.metadata}) as Column)
+    let columns = query.fields.map(f => ({name: f.name, type: f.type, metadata: f.metadata, fieldMetadata: f.fieldMetadata}) as Column)
     let cte: CteTable = {name, type: 'cte', tablePath: name, columns, joins: [], query}
     ctes.set(name, cte)
     scope.otherTables!.push(cte)
@@ -296,7 +301,7 @@ function analyzeSimpleQuery(simpleNode: SyntaxNode, queryNode: SyntaxNode, paren
     if (tablePrimary.getChild('SubqueryExpression')) {
       let subquery = analyzeQuery(tablePrimary.getChild('SubqueryExpression')!.getChild('QueryExpression')!, scope.otherTables)
       if (!subquery) return
-      let columns = subquery.fields.map(f => ({name: f.name, type: f.type, metadata: f.metadata}) as Column)
+      let columns = subquery.fields.map(f => ({name: f.name, type: f.type, metadata: f.metadata, fieldMetadata: f.fieldMetadata}) as Column)
       table = {name: 'subquery', type: 'subquery', tablePath: alias, columns, joins: [], query: subquery}
       alias ||= 'subquery'
     }
@@ -346,6 +351,7 @@ function analyzeSimpleQuery(simpleNode: SyntaxNode, queryNode: SyntaxNode, paren
         sql: expr.sql,
         type: expr.type,
         isAgg: expr.isAgg,
+        fieldMetadata: expr.fieldMetadata,
         fanout: expr.fanout,
         definitionLocation: locationForNode(aliasNode || exprNode),
       })
@@ -385,7 +391,7 @@ function analyzeSimpleQuery(simpleNode: SyntaxNode, queryNode: SyntaxNode, paren
 
       // If it's not in there, add it to the select.
       if (!query.fields.find(f => f.name == name)) {
-        query.fields.unshift({name, sql: expr.sql, type: expr.type, fanout: expr.fanout, definitionLocation: locationForNode(g.getChild('Alias') || exprNode)})
+        query.fields.unshift({name, sql: expr.sql, type: expr.type, fieldMetadata: expr.fieldMetadata, fanout: expr.fanout, definitionLocation: locationForNode(g.getChild('Alias') || exprNode)})
       }
       fanoutExprs.push({node: g.getChild('Expression')!, expr})
     }
@@ -440,9 +446,16 @@ function analyzeSetQuery(queryNode: SyntaxNode, scope: Scope, ctes: Map<string, 
   }
 
   let setOps = queryNode.getChildren('SetOperator')
+  let fields = first.fields.map((field, idx) => {
+    let next = {...field}
+    let matches = branches.slice(1).every(branch => sameFieldMetadata(branch.query?.fields[idx]?.fieldMetadata, field.fieldMetadata))
+    if (!matches) delete next.fieldMetadata
+    return next
+  })
+
   let query: Query = {
     sql: '',
-    fields: first.fields.map(field => ({...field})),
+    fields,
     joins: [],
     filters: [],
     groupBy: [],
@@ -586,7 +599,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       // SELECT aliases instead of the table's computed columns.
       if (scope.query && !scope.table && pathNodes.length == 0) {
         let outField = scope.query.fields.find(f => f.name == fieldName)
-        if (outField) return {sql: outField.sql, type: outField.type, isAgg: outField.isAgg, fanout: outField.fanout}
+        if (outField) return {sql: outField.sql, type: outField.type, isAgg: outField.isAgg, fanout: outField.fanout, fieldMetadata: outField.fieldMetadata}
       }
 
       // Follow any dot path (e.g., `users.orders` in `users.orders.amount`), then find the field
@@ -619,7 +632,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       addReference('column', fieldNode, col.symbolId)
 
       // Simple case: this is just a regular column on a table
-      if (!col.exprNode) return {sql: `${alias}.${col.name}`, type: col.type, fanout: normalizeExprFanout({path: matches[0].fanoutPath})}
+      if (!col.exprNode) return {sql: `${alias}.${col.name}`, type: col.type, fanout: normalizeExprFanout({path: matches[0].fanoutPath}), fieldMetadata: col.fieldMetadata}
 
       // Computed column: analyze its expression in the matched table's scope
       if (analysisStack.has(col)) return diag(col.exprNode, 'Cycles are not allowed between computed columns', {sql: 'NULL', type: 'error'})
@@ -631,6 +644,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
         type: expr.type,
         isAgg: expr.isAgg,
         fanout: expr.fanout,
+        fieldMetadata: expr.fieldMetadata,
       }
     }
 
@@ -746,16 +760,16 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
     case 'UnaryExpression': {
       let op = txt(node.firstChild).toLowerCase()
       let child = analyzeExpr(node.lastChild!, scope)
-      if (op == 'not') return {...child, sql: `NOT (${child.sql})`, type: 'boolean'}
-      if (op == '-') return {...child, sql: `-(${child.sql})`}
-      if (op == '+') return {...child, sql: `(${child.sql})`}
+      if (op == 'not') return {sql: `NOT (${child.sql})`, type: 'boolean', isAgg: child.isAgg, fanout: child.fanout}
+      if (op == '-') return {sql: `-(${child.sql})`, type: child.type, isAgg: child.isAgg, fanout: child.fanout}
+      if (op == '+') return {sql: `(${child.sql})`, type: child.type, isAgg: child.isAgg, fanout: child.fanout}
       return diag(node, `Unknown unary operator: ${op}`, {sql: 'NULL', type: 'error'})
     }
 
     case 'NullTestExpression': {
       let isNot = !!node.getChildren('Kw').find(n => txt(n).toLowerCase() == 'not')
       let e = analyzeExpr(node.firstChild!, scope)
-      return {...e, sql: `${e.sql} IS ${isNot ? 'NOT ' : ''}NULL`, type: 'boolean'}
+      return {sql: `${e.sql} IS ${isNot ? 'NOT ' : ''}NULL`, type: 'boolean', isAgg: e.isAgg, fanout: e.fanout}
     }
 
     case 'CaseExpression': {
@@ -801,7 +815,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
         let subquery = analyzeQuery(subqueryNode, scope.otherTables)
         if (!subquery) return {sql: 'NULL', type: 'error'}
         if (subquery.fields.length != 1) return diag(subqueryNode, 'Subquery in IN must return exactly one column', {sql: 'NULL', type: 'error'})
-        return {...e, sql: `${e.sql} ${not ? 'NOT IN' : 'IN'} (${subquery.sql})`, type: 'boolean'}
+        return {sql: `${e.sql} ${not ? 'NOT IN' : 'IN'} (${subquery.sql})`, type: 'boolean', isAgg: e.isAgg, fanout: e.fanout}
       }
       if (!valueList) {
         return diag(node, 'IN expression must provide either values or a subquery', {sql: 'NULL', type: 'error'})
@@ -814,7 +828,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
         }
         return val.sql
       })
-      return {...e, sql: `${e.sql} ${not ? 'NOT IN' : 'IN'} (${values.join(',')})`, type: 'boolean'}
+      return {sql: `${e.sql} ${not ? 'NOT IN' : 'IN'} (${values.join(',')})`, type: 'boolean', isAgg: e.isAgg, fanout: e.fanout}
     }
 
     case 'BetweenExpression': {
@@ -849,7 +863,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       let targetType = txt(typeNode).toUpperCase()
       let resultType = convertDataType(targetType)
       if (!resultType) return diag(typeNode, `Unsupported cast type: ${targetType.toLowerCase()}`, {sql: 'NULL', type: 'error'})
-      return {...e, sql: `CAST(${e.sql} AS ${targetType})`, type: resultType}
+      return {...e, sql: `CAST(${e.sql} AS ${targetType})`, type: resultType, fieldMetadata: preserveTemporalMetadata(e, resultType)}
     }
 
     case 'ExtractExpression': {
@@ -859,7 +873,7 @@ export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
       let unit = txt(node.getChild('ExtractUnit')!)
         .replace(/^['"]|['"]$/g, '')
         .toLowerCase()
-      return {...e, sql: `EXTRACT(${unit} FROM ${e.sql})`, type: 'number'}
+      return {sql: `EXTRACT(${unit} FROM ${e.sql})`, type: 'number', isAgg: e.isAgg, fanout: e.fanout}
     }
 
     case 'IntervalExpression': {
@@ -960,6 +974,24 @@ function coerceToTemporal(expr: Expr, targetType: 'date' | 'timestamp', node: Sy
     return expr
   }
   return {...expr, sql: `${targetType.toUpperCase()} '${parsed.literal}'`, type: targetType}
+}
+
+function preserveTemporalMetadata(expr: Expr, resultType: FieldType) {
+  if (!expr.fieldMetadata?.temporal) return
+  if (resultType != 'date' && resultType != 'timestamp') return
+  return expr.fieldMetadata
+}
+
+function sameFieldMetadata(left?: Expr['fieldMetadata'], right?: Expr['fieldMetadata']) {
+  if (!left && !right) return true
+  if (!left || !right) return false
+  return sameTemporalMetadata(left.temporal, right.temporal)
+}
+
+function sameTemporalMetadata(left?: TemporalFieldMetadata, right?: TemporalFieldMetadata) {
+  if (!left && !right) return true
+  if (!left || !right) return false
+  return left.grain == right.grain
 }
 
 function isPercentileFunctionCall(node: SyntaxNode): boolean {

--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -213,6 +213,10 @@ function inferFunctionFieldMetadata(name: string, overload: Overload, args: Expr
   return {temporal}
 }
 
+// date_trunc part syntax varies by dialect:
+// - BigQuery commonly uses bare keywords like `month`, plus special values like `isoweek` and `week(monday)`.
+// - DuckDB and Snowflake typically pass the part as a string literal like `'month'`.
+// We normalize the supported forms into our shared grain enum and intentionally drop any finer detail.
 function inferTemporalMetadata(rawPart: string): TemporalFieldMetadata | undefined {
   let normalized = rawPart
     .trim()

--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -8,7 +8,7 @@ import {config} from './config.ts'
 import {duckDbFunctions} from './duckDbFunctions.ts'
 import {extendFanoutPath, mergeFanoutPaths, mergeSensitiveFanouts, normalizeExprFanout} from './fanout.ts'
 import {snowflakeFunctions} from './snowflakeFunctions.ts'
-import {type Expr, type FieldType, type Scope} from './types.ts'
+import {type Expr, type FieldMetadata, type FieldType, type Scope, type TemporalFieldMetadata, type TemporalGrain} from './types.ts'
 import {txt} from './util.ts'
 
 // The shape that analyzeFunction works with. Converted from FunctionDef at startup.
@@ -153,12 +153,14 @@ export function analyzeFunction(node: SyntaxNode, scope: Scope, analyzeExpr: Ana
   }
   let fnName = overload.sqlName || name
   let sql = `${fnName}(${args.map(a => a.sql).join(',')})`
+  let fieldMetadata = inferFunctionFieldMetadata(name, overload, args, argNodes)
   return {
     sql,
     type: returnType,
     isAgg,
     canWindow,
     fanout: normalizeExprFanout({path: isAgg ? undefined : fanout.path, sensitivePaths: fanoutSensitivePaths, conflict: fanoutConflict}),
+    fieldMetadata,
   }
 }
 
@@ -197,4 +199,44 @@ function analyzePercentile(node: SyntaxNode, args: Expr[], digits: string, scope
       conflict: args.some(a => a.fanout?.conflict),
     }),
   }
+}
+
+function inferFunctionFieldMetadata(name: string, overload: Overload, args: Expr[], argNodes: SyntaxNode[]): FieldMetadata | undefined {
+  if (name != 'date_trunc') return
+
+  let partIdx = overload.params.findIndex(param => param.name.includes('part'))
+  if (partIdx < 0 || !args[partIdx]) return
+  if (args[partIdx].type != 'string' && args[partIdx].type != 'sql native') return
+
+  let temporal = inferTemporalMetadata(txt(argNodes[partIdx]))
+  if (!temporal) return
+  return {temporal}
+}
+
+function inferTemporalMetadata(rawPart: string): TemporalFieldMetadata | undefined {
+  let normalized = rawPart
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .toLowerCase()
+  if (!normalized) return
+
+  if (/^week(?:\([a-z]+\))?$/.test(normalized) || normalized == 'isoweek') return {grain: 'week'}
+  if (normalized == 'isoyear') return {grain: 'year'}
+
+  let grain = normalizeTemporalGrain(normalized)
+  if (!grain) return
+  return {grain}
+}
+
+function normalizeTemporalGrain(value: string): TemporalGrain | undefined {
+  let grains: Record<string, TemporalGrain> = {
+    year: 'year',
+    quarter: 'quarter',
+    month: 'month',
+    day: 'day',
+    hour: 'hour',
+    minute: 'minute',
+    second: 'second',
+  }
+  return grains[value]
 }

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -875,6 +875,55 @@ describe('lang', () => {
     expect("from events select date_trunc('month', event_date)").toRenderSql("select DATE_TRUNC('month',EVENTS.EVENT_DATE) as COL_0 from EVENTS as EVENTS")
   })
 
+  it('infers temporal grain from date_trunc across dialects', () => {
+    updateFile('table events (event_date date)', 'events.gsql')
+
+    setConfig({root: '', bigquery: {}})
+    let [bigQuery] = analyze('from events select date_trunc(event_date, month) as month_start')
+    expect(bigQuery.fields[0].fieldMetadata).toEqual({temporal: {grain: 'month'}})
+
+    setConfig({root: ''})
+    let [duckDb] = analyze("from events select date_trunc('quarter', event_date) as quarter_start")
+    expect(duckDb.fields[0].fieldMetadata).toEqual({temporal: {grain: 'quarter'}})
+
+    setConfig({dialect: 'snowflake', root: ''})
+    let [snowflake] = analyze("from events select date_trunc('year', event_date) as year_start")
+    expect(snowflake.fields[0].fieldMetadata).toEqual({temporal: {grain: 'year'}})
+  })
+
+  it('propagates temporal grain through refs and drops it for reshaping expressions', () => {
+    updateFile(
+      `
+      table events (
+        event_date date
+        month_start: date_trunc('month', event_date)
+      )
+    `,
+      'events.gsql',
+    )
+
+    let [throughRef] = analyze('from events select month_start')
+    expect(throughRef.fields[0].fieldMetadata).toEqual({temporal: {grain: 'month'}})
+
+    let [throughCast] = analyze('from events select cast(month_start as date) as month_date')
+    expect(throughCast.fields[0].fieldMetadata).toEqual({temporal: {grain: 'month'}})
+
+    let [reshaped] = analyze('from events select extract(year from month_start) as year_num')
+    expect(reshaped.fields[0].fieldMetadata).toBeUndefined()
+  })
+
+  it('drops temporal grain on set operations when branches disagree', () => {
+    updateFile('table events (event_date date)', 'events.gsql')
+
+    let [query] = analyze(`
+      from events select date_trunc('month', event_date) as bucket
+      union all
+      from events select date_trunc('year', event_date) as bucket
+    `)
+
+    expect(query.fields[0].fieldMetadata).toBeUndefined()
+  })
+
   it('supports extract expressions', () => {
     expect('from users select extract(hour from created_at)').toRenderSql('select extract(hour from users.created_at) as col_0 from users as users')
   })

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -10,6 +10,15 @@ declare module '@lezer/common' {
 }
 
 export type FieldType = 'string' | 'number' | 'boolean' | 'date' | 'timestamp' | 'json' | 'sql native' | 'error' | 'null' | 'interval' | 'array' | 'record'
+export type TemporalGrain = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second'
+
+export interface TemporalFieldMetadata {
+  grain: TemporalGrain
+}
+
+export interface FieldMetadata {
+  temporal?: TemporalFieldMetadata
+}
 
 // An analyzed expression - contains the SQL string plus metadata for validation
 export interface Expr {
@@ -19,12 +28,14 @@ export interface Expr {
   canWindow?: boolean // true if expression can be used with an OVER clause
   interval?: IntervalExpr
   fanout?: ExprFanout
+  fieldMetadata?: FieldMetadata
 }
 
 // A field in a query's SELECT clause
 export interface QueryField extends Expr {
   name: string // output column name
   metadata?: Record<string, string>
+  fieldMetadata?: FieldMetadata
   definitionLocation?: Location // where this field is defined when materialized into a view
 }
 
@@ -90,6 +101,7 @@ export interface Column {
   isAgg?: boolean // for computed columns that are aggregates
   exprNode?: SyntaxNode // for computed columns, the expression AST node (analyzed lazily in query context)
   metadata?: Record<string, string>
+  fieldMetadata?: FieldMetadata
   symbolId?: string
   location?: Location
 }

--- a/ui/component-utilities/getColumnSummary.js
+++ b/ui/component-utilities/getColumnSummary.js
@@ -14,6 +14,7 @@ const EvidenceType = {
  * @property {string} title
  * @property {string} type
  * @property {Object} evidenceColumnType
+ * @property {Object | undefined} fieldMetadata
  * @property {ReturnType<typeof lookupColumnFormat>} format
  * @property {ReturnType<typeof getColumnUnitSummary>} columnUnitSummary
  */
@@ -49,6 +50,7 @@ export default function getColumnSummary(data, returnType = 'object') {
       title: formatTitle(colName, format),
       type,
       evidenceColumnType,
+      fieldMetadata: evidenceColumnType.fieldMetadata,
       format,
       columnUnitSummary,
     }

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -1,7 +1,7 @@
 // The query engine gathers query requests and inputs from components, and issues requests to the server.
 // When inputs change, it takes care of notifying affected components and requesting new data.
 
-import type {GrapheneError} from '../../lang/types.ts'
+import type {FieldMetadata, GrapheneError} from '../../lang/types.ts'
 
 import {cacheRead, cacheWrite, getHashes} from './clientCache.ts'
 import {getActivePageInputs} from './pageInputs.svelte.ts'
@@ -16,6 +16,7 @@ interface QueryResult {
 interface Field {
   name: string
   type?: string
+  fieldMetadata?: FieldMetadata
 }
 
 type ResultHandler = (res: QueryResult) => void
@@ -202,7 +203,7 @@ export function translateData(data: any, node: QueryNode) {
     }
 
     // map graphene types down to the ones evidence expects
-    rows._evidenceColumnTypes.push({name, evidenceType: evidenceType(field.type)})
+    rows._evidenceColumnTypes.push({name, evidenceType: evidenceType(field.type), fieldMetadata: field.fieldMetadata})
   })
 
   return {rows}

--- a/ui/tests/queryEngine.test.ts
+++ b/ui/tests/queryEngine.test.ts
@@ -1,6 +1,7 @@
 import {beforeAll, test, expect} from 'vitest'
 
 let translateData: (data: any, node: any) => {rows: any[]}
+let getColumnSummary: (data: any, returnType?: string) => any
 
 beforeAll(async () => {
   ;(globalThis as any).window = {
@@ -9,6 +10,7 @@ beforeAll(async () => {
     removeEventListener: () => {},
   }
   ;({translateData} = await import('../internal/queryEngine.ts'))
+  ;({default: getColumnSummary} = await import('../component-utilities/getColumnSummary.js'))
 })
 
 test('translateData remaps Snowflake-style uppercase row keys to requested field casing', () => {
@@ -30,4 +32,26 @@ test('translateData remaps Snowflake-style uppercase row keys to requested field
 
   expect(result.rows[0]).toEqual({location_state_code: 'CA', num: 3})
   expect((result.rows as any)._evidenceColumnTypes.map((c: any) => c.name)).toEqual(['location_state_code', 'num'])
+})
+
+test('translateData preserves field metadata for UI column summaries', () => {
+  let data = {
+    rows: [{month_start: '2021-01-01', sales: 3}],
+    fields: [
+      {name: 'month_start', type: 'date', fieldMetadata: {temporal: {grain: 'month'}}},
+      {name: 'sales', type: 'number'},
+    ],
+  }
+  let node = {
+    fields: new Map([
+      ['x', 'month_start'],
+      ['y', 'sales'],
+    ]),
+  }
+
+  let result = translateData(data, node)
+  let summary = getColumnSummary(result.rows)
+
+  expect((result.rows as any)._evidenceColumnTypes[0].fieldMetadata).toEqual({temporal: {grain: 'month'}})
+  expect(summary.month_start.fieldMetadata).toEqual({temporal: {grain: 'month'}})
 })


### PR DESCRIPTION
This PR adds `FieldMetadata` inferred from analysis and propagated through to be used by the UI/Viz. Currently the only metadata we infer is temporal grain via `date_trunc`, but the intent is to be generic enough to support other metadata we might want to propagate.