### PR TITLE
Better handling for unexpected browser errors

### DIFF
--- a/ui/tests/logWatcher.ts
+++ b/ui/tests/logWatcher.ts
@@ -42,12 +42,12 @@ export function trackBrowserConsole(page: Page) {
 
     let location = msg.location()
     let locationText = location.url ? ` (${location.url}:${location.lineNumber}:${location.columnNumber})` : ''
-    throw new Error(`Unexpected log ${text}${locationText}`)
+    unexpected.push(`${text}${locationText}`)
   })
   page.on('pageerror', err => {
     let text = String(err?.message || err)
     if (isExpected(text)) return
-    throw new Error(`Unexpected error ${text}`)
+    unexpected.push(text)
   })
 }
 


### PR DESCRIPTION
Previously we threw, which would just make them unhandled errors not
attached to any test. Now you can see which test failed.