### PR TITLE
refactor analysis workspace state handling

### DIFF
--- a/cli/check.ts
+++ b/cli/check.ts
@@ -1,7 +1,10 @@
 import {readFileSync} from 'node:fs'
 import path from 'path'
 
-import {analyze, config, getDiagnostics, loadWorkspace, updateFile} from '../lang/core.ts'
+import type {WorkspaceFileInput} from '../lang/types.ts'
+
+import {config} from '../lang/config.ts'
+import {analyzeWorkspace, loadWorkspace} from '../lang/core.ts'
 import {mockFileMap} from './mockFiles.ts'
 import {normalizeFile} from './normalizeFile.ts'
 import {printDiagnostics} from './printer.ts'
@@ -20,22 +23,35 @@ export async function check(options: CheckOptions): Promise<boolean> {
     return false
   }
 
-  await loadWorkspace(config.root, !targetFile)
-  if (targetFile) {
-    if (process.env.NODE_ENV == 'test' && mockFileMap[targetFile]) {
-      updateFile(mockFileMap[targetFile], targetFile)
-    } else {
-      let content = readFileSync(path.resolve(config.root, targetFile), 'utf-8')
-      updateFile(content, targetFile)
+  let files = await loadWorkspace(config.root, !targetFile, config.ignoredFiles)
+  if (process.env.NODE_ENV == 'test') {
+    for (let [path, contents] of Object.entries(mockFileMap)) {
+      if (targetFile && path != targetFile) continue
+      upsertFile(files, {path, contents})
     }
   }
+  if (targetFile) {
+    let contents: string
+    if (process.env.NODE_ENV == 'test' && mockFileMap[targetFile]) {
+      contents = mockFileMap[targetFile]
+    } else {
+      contents = readFileSync(path.resolve(config.root, targetFile), 'utf-8')
+    }
+    upsertFile(files, {path: targetFile, contents})
+  }
 
-  analyze()
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics(), log)
+  let result = analyzeWorkspace({config, files})
+  if (result.diagnostics.length > 0) {
+    printDiagnostics(result.diagnostics, log)
     return false
   }
 
   log('No errors found 💎')
   return true
+}
+
+function upsertFile(files: WorkspaceFileInput[], next: WorkspaceFileInput) {
+  let idx = files.findIndex(file => file.path == next.path)
+  if (idx >= 0) files[idx] = next
+  else files.push(next)
 }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -8,7 +8,7 @@ import {fileURLToPath} from 'url'
 
 import {config, loadConfig} from '../lang/config.ts'
 import {analyzeWorkspace, getFile, loadWorkspace, toSql, type Query} from '../lang/core.ts'
-import {formatType, isArrayType, parseWarehouseFieldType} from '../lang/types.ts'
+import {formatType, isArrayType, parseWarehouseFieldType, type AnalysisResult} from '../lang/types.ts'
 import {loginPkce} from './auth.ts'
 import {runServeInBackground, stopGrapheneIfRunning} from './background.ts'
 import {check} from './check.ts'
@@ -36,10 +36,9 @@ program
   .action(async (input: string | undefined) => {
     let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
     let sql = await readInput(input)
-    let result = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: sql})}, 'input')
-    let queries = getFile(result, 'input')?.queries || []
-    if (!validQuery(result, queries)) return
-    console.log(toSql(queries[0]))
+    let analysis = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: sql})}, 'input')
+    let [query] = validateInputQuery(analysis)
+    console.log(toSql(query))
   })
 
 program
@@ -72,10 +71,9 @@ program
 
     let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
     let gsql = await readInput(input)
-    let result = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: gsql})}, 'input')
-    let queries = getFile(result, 'input')?.queries || []
-    if (!validQuery(result, queries)) return
-    let sql = toSql(queries[0])
+    let analysis = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: gsql})}, 'input')
+    let [query] = validateInputQuery(analysis)
+    let sql = toSql(query)
     let res = await runQuery(sql)
     printTable(res.rows)
   })
@@ -200,16 +198,18 @@ function getExistingPath(arg: string | undefined): string | null {
   return fs.existsSync(absolutePath) ? absolutePath : null
 }
 
-function validQuery(result: {diagnostics: any[]}, queries: Query[]): boolean {
-  if (result.diagnostics.length) {
-    printDiagnostics(result.diagnostics)
+function validateInputQuery(analysis: AnalysisResult): Query[] {
+  if (analysis.diagnostics.length) {
+    printDiagnostics(analysis.diagnostics)
     process.exit(1)
   }
+
+  let queries = getFile(analysis, 'input')?.queries || []
   if (queries.length == 0) {
     console.warn('No queries found')
     process.exit(1)
   }
-  return true
+  return queries
 }
 
 function findCaseInsensitive(values: string[], needle: string): string | null {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -7,7 +7,7 @@ import path from 'path'
 import {fileURLToPath} from 'url'
 
 import {config, loadConfig} from '../lang/config.ts'
-import {analyze, getDiagnostics, loadWorkspace, toSql, type Query} from '../lang/core.ts'
+import {analyzeWorkspace, getFile, loadWorkspace, toSql, type Query} from '../lang/core.ts'
 import {formatType, isArrayType, parseWarehouseFieldType} from '../lang/types.ts'
 import {loginPkce} from './auth.ts'
 import {runServeInBackground, stopGrapheneIfRunning} from './background.ts'
@@ -34,10 +34,11 @@ program
   .description('Translate a query to SQL and print it')
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
   .action(async (input: string | undefined) => {
-    await loadWorkspace(process.cwd(), false)
+    let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
     let sql = await readInput(input)
-    let queries = analyze(sql)
-    if (!validQuery(queries)) return
+    let result = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: sql})}, 'input')
+    let queries = getFile(result, 'input')?.queries || []
+    if (!validQuery(result, queries)) return
     console.log(toSql(queries[0]))
   })
 
@@ -69,10 +70,11 @@ program
       process.exit(1)
     }
 
-    await loadWorkspace(process.cwd(), false)
+    let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
     let gsql = await readInput(input)
-    let queries = analyze(gsql)
-    if (!validQuery(queries)) return
+    let result = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: gsql})}, 'input')
+    let queries = getFile(result, 'input')?.queries || []
+    if (!validQuery(result, queries)) return
     let sql = toSql(queries[0])
     let res = await runQuery(sql)
     printTable(res.rows)
@@ -198,9 +200,9 @@ function getExistingPath(arg: string | undefined): string | null {
   return fs.existsSync(absolutePath) ? absolutePath : null
 }
 
-function validQuery(queries: Query[]): boolean {
-  if (getDiagnostics().length) {
-    printDiagnostics(getDiagnostics())
+function validQuery(result: {diagnostics: any[]}, queries: Query[]): boolean {
+  if (result.diagnostics.length) {
+    printDiagnostics(result.diagnostics)
     process.exit(1)
   }
   if (queries.length == 0) {

--- a/cli/normalizeFile.ts
+++ b/cli/normalizeFile.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra'
 import path from 'path'
 
-import {config} from '../lang/core.ts'
+import {config} from '../lang/config.ts'
 import {mockFileMap} from './mockFiles.ts'
 
 export function normalizeFile(file: string): string | null {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -7,8 +7,9 @@ import path from 'path'
 import {type PluginOption, type ViteDevServer} from 'vite'
 import {WebSocketServer, type WebSocket} from 'ws'
 
-import {FILE_MAP} from '../lang/analyze.ts'
-import {analyze, config, type GrapheneError, getDiagnostics, loadWorkspace, toSql, updateFile} from '../lang/core.ts'
+import {config} from '../lang/config.ts'
+import {analyzeWorkspace, getFile, loadWorkspace, toSql} from '../lang/core.ts'
+import {type AnalysisResult, type GrapheneError, type WorkspaceFileInput} from '../lang/types.ts'
 import {pollFor} from '../lang/util.ts'
 import {openInBrowser} from './auth.ts'
 import {isServerRunning, runServeInBackground} from './background.ts'
@@ -34,21 +35,19 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
     return false
   }
 
-  await loadWorkspace(config.root, false)
+  let files = await loadWorkspace(config.root, false, config.ignoredFiles)
+  let mdContents: string
   if (process.env.NODE_ENV == 'test' && mockFileMap[mdFile]) {
-    updateFile(mockFileMap[mdFile], mdFile)
+    mdContents = mockFileMap[mdFile]
   } else {
-    let content = readFileSync(path.resolve(config.root, mdFile), 'utf-8')
-    updateFile(content, mdFile)
+    mdContents = readFileSync(path.resolve(config.root, mdFile), 'utf-8')
   }
 
-  analyze()
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics(), log)
+  let result = analyzeWorkspace({config, files: files.filter(file => file.path != mdFile).concat({path: mdFile, contents: mdContents, kind: 'md'})}, mdFile)
+  if (result.diagnostics.length > 0) {
+    printDiagnostics(result.diagnostics, log)
     return false
   }
-
-  if (process.env.NODE_ENV == 'test') delete FILE_MAP[mdFile]
 
   let host = `http://localhost:${config.port}`
   let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')
@@ -112,25 +111,27 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
 }
 
 export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string): Promise<boolean> {
-  await loadWorkspace(process.cwd(), false)
+  let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
   let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
   let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
 
-  updateFile(mdContents, mdRelativePath)
-  analyze()
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics())
+  let result = analyzeWorkspace({config, files: files.filter(file => file.path != mdRelativePath).concat({path: mdRelativePath, contents: mdContents, kind: 'md'})}, mdRelativePath)
+  if (result.diagnostics.length > 0) {
+    printDiagnostics(result.diagnostics)
     return false
   }
 
   let runQueryFence = [mdContents, '', '```sql', `from ${queryName} select *`, '```'].join('\n')
-  let queries = analyze(runQueryFence, 'md')
-  if (getDiagnostics().length > 0) {
-    printDiagnostics(getDiagnostics())
+  let queryFiles = toWorkspaceFiles(result)
+  let queryResult = analyzeWorkspace({config, files: queryFiles.filter(file => file.path != 'input.md').concat({path: 'input.md', contents: runQueryFence, kind: 'md'})}, 'input.md')
+  if (queryResult.diagnostics.length > 0) {
+    printDiagnostics(queryResult.diagnostics)
     return false
   }
 
-  let sql = toSql(queries[queries.length - 1])
+  let input = getFile(queryResult, 'input.md')
+  if (!input?.queries.length) return false
+  let sql = toSql(input.queries[input.queries.length - 1])
   let res = await runQuery(sql)
   printTable(res.rows)
   return true
@@ -182,6 +183,15 @@ export async function proxyRunRequest(req: IncomingMessage, res: ServerResponse<
 
   conn.socket.send(JSON.stringify({type: 'check', chart, requestId: id}))
   pendingRequests[id] = {response: res}
+}
+
+function toWorkspaceFiles(result: AnalysisResult): WorkspaceFileInput[] {
+  return result.files.map(file => ({
+    path: file.path,
+    contents: file.contents,
+    kind: file.path.endsWith('.md') ? 'md' : 'gsql',
+    parsed: {tree: file.tree!, virtualContents: file.virtualContents, virtualToMarkdownOffset: file.virtualToMarkdownOffset},
+  }))
 }
 
 export function runVitePlugin(): PluginOption {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -185,8 +185,8 @@ export async function proxyRunRequest(req: IncomingMessage, res: ServerResponse<
   pendingRequests[id] = {response: res}
 }
 
-function toWorkspaceFiles(result: AnalysisResult): WorkspaceFileInput[] {
-  return result.files.map(file => ({
+function toWorkspaceFiles(analysis: AnalysisResult): WorkspaceFileInput[] {
+  return analysis.files.map(file => ({
     path: file.path,
     contents: file.contents,
     kind: file.path.endsWith('.md') ? 'md' : 'gsql',

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -271,9 +271,9 @@ const updateWorkspacePlugin = {
   },
 }
 
-function updateParsedFiles(result: AnalysisResult) {
+function updateParsedFiles(analysis: AnalysisResult) {
   workspaceFiles = workspaceFiles.map(file => {
-    let analyzed = result.files.find(next => next.path == file.path)
+    let analyzed = analysis.files.find(next => next.path == file.path)
     if (!analyzed) return file
     return {
       ...file,

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -8,7 +8,10 @@ import path from 'path'
 import {fileURLToPath} from 'url'
 import {createServer, type InlineConfig, optimizeDeps, resolveConfig, type ViteDevServer} from 'vite'
 
-import {loadWorkspace, config, clearWorkspace, analyze, getDiagnostics, toSql, getFiles} from '../lang/core.ts'
+import type {AnalysisResult, WorkspaceFileInput} from '../lang/types.ts'
+
+import {config} from '../lang/config.ts'
+import {analyzeWorkspace, loadWorkspace, toSql} from '../lang/core.ts'
 import {runQuery} from './connections/index.ts'
 import {injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 import {mockFileMap} from './mockFiles.ts'
@@ -119,15 +122,17 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
   res.setHeader('Content-Type', 'application/json')
 
   await workspaceLoadPromise
-  let queries = analyze(gsql)
+  let result = analyzeWorkspace({config, files: [...workspaceFiles, {path: 'input', contents: gsql}]})
+  updateParsedFiles(result)
 
-  let diagnostics = getDiagnostics()
+  let diagnostics = result.diagnostics
   if (diagnostics.length) {
     res.statusCode = 400
     res.end(JSON.stringify(diagnostics[0]))
     return
   }
 
+  let queries = result.files.find(file => file.path == 'input')?.queries || []
   if (queries.length > 1) throw new Error('Found multiple queries, which could be a parsing error')
   let sql = toSql(queries[0], params)
 
@@ -222,6 +227,7 @@ function fixHmrForFailedModules() {
 // This reload blocks all requests, so we shouldn't ever analyze without a workspace.
 // Also tracks all the md files in the workspace to populate the nav sidebar
 let workspaceLoadPromise: Promise<void> | undefined
+let workspaceFiles: WorkspaceFileInput[] = []
 let mdFiles: string[] = []
 const updateWorkspacePlugin = {
   name: 'updateWorkspace',
@@ -240,12 +246,15 @@ const updateWorkspacePlugin = {
   },
   configureServer: (s: ViteDevServer) => {
     let refresh = async () => {
-      clearWorkspace()
-      workspaceLoadPromise = loadWorkspace(config.root, true)
+      workspaceLoadPromise = (async () => {
+        let loaded = await loadWorkspace(config.root, true, config.ignoredFiles)
+        workspaceFiles = loaded.map(file => {
+          let existing = workspaceFiles.find(existing => existing.path == file.path && existing.contents == file.contents)
+          return existing?.parsed ? {...file, parsed: existing.parsed} : file
+        })
+      })()
       await workspaceLoadPromise
-      mdFiles = getFiles()
-        .filter(f => f.path.endsWith('.md'))
-        .map(f => f.path)
+      mdFiles = workspaceFiles.filter(file => file.path.endsWith('.md')).map(file => file.path)
       mdFiles = mdFiles.filter(f => !config.ignoredFiles?.includes(path.basename(f).toLowerCase()))
       if (process.env.NODE_ENV == 'test') {
         mdFiles.push(...Object.keys(mockFileMap))
@@ -260,6 +269,21 @@ const updateWorkspacePlugin = {
     s.watcher.on('all', refresh)
     refresh()
   },
+}
+
+function updateParsedFiles(result: AnalysisResult) {
+  workspaceFiles = workspaceFiles.map(file => {
+    let analyzed = result.files.find(next => next.path == file.path)
+    if (!analyzed) return file
+    return {
+      ...file,
+      parsed: {
+        tree: analyzed.tree!,
+        virtualContents: analyzed.virtualContents,
+        virtualToMarkdownOffset: analyzed.virtualToMarkdownOffset,
+      },
+    }
+  })
 }
 
 const handleRequestPlugin = {

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -1,6 +1,5 @@
-import {NodeWeakMap, type SyntaxNode, type SyntaxNodeRef} from '@lezer/common'
+import {type SyntaxNode, type SyntaxNodeRef} from '@lezer/common'
 
-import {config} from './config.ts'
 import {
   aggregateFanoutMessage,
   normalizeExprFanout,
@@ -16,17 +15,22 @@ import {
   uniqueFanoutPaths,
 } from './fanout.ts'
 import {analyzeFunction} from './functions.ts'
+import {parseMarkdown} from './markdown.ts'
 import {extractLeadingMetadata} from './metadata.ts'
+import {parser} from './parser.js'
 import {parseTemporalLiteral, parseIntervalLiteral, parseIntervalUnit, renderTemporalArithmetic, renderStandaloneInterval} from './temporal.ts'
 import {
   scalarType,
-  type Table,
+  type AnalysisConfig,
+  type AnalysisResult,
+  type AnalysisWorkspace,
+  type FileInfo,
+  type GrapheneError,
   type Query,
+  type Table,
   type QueryJoin,
   type Column,
   type FieldType,
-  type FileInfo,
-  type GrapheneError,
   type Expr,
   type CteTable,
   type JoinType,
@@ -40,6 +44,7 @@ import {
   parseGsqlFieldType,
   type TypeKind,
   withTypeMetadata,
+  type WorkspaceFileInput,
 } from './types.ts'
 import {buildFrame, txt, getFile, getPosition, toRelativePath} from './util.ts'
 
@@ -56,502 +61,635 @@ import {buildFrame, txt, getFile, getPosition, toRelativePath} from './util.ts'
 // NB that while the first step of collecting tables can be used between runs, analysis kinda can't since the alias for a given
 // join could change from query to query.
 
-export let FILE_MAP: Record<string, FileInfo> = {} // All the files in the workspace and their tables/queries
-export let diagnostics: GrapheneError[] = [] // Tracks errors/warnings
-let analysisStack = new Set<Column>() // Track computed columns being analyzed to detect cycles
-let NODE_ENTITY_MAP = new NodeWeakMap<any>() // Points syntax nodes back to entities for ide hover tips
-
-function locationForNode(node: SyntaxNode): Location {
-  let file = getFile(node)
-  return {file: file.path, from: getPosition(node.from, file), to: getPosition(node.to, file)}
+export function analyzeWorkspace(workspace: AnalysisWorkspace, targetPath?: string): AnalysisResult {
+  return new AnalysisSession(workspace).analyze(targetPath)
 }
 
-function symbolId(kind: NavigationSymbolKind, location: Location, scopeKey = '') {
-  let suffix = scopeKey ? `:${scopeKey}` : ''
-  return `${kind}:${location.file}:${location.from.offset}:${location.to.offset}${suffix}`
+export interface Analyzer {
+  config: AnalysisConfig
+  analyzeExpr(node: SyntaxNode, scope: Scope): Expr
+  diag<T>(node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T
+  checkTypes(expr: Expr, expected: TypeKind[], node: SyntaxNode): void
 }
 
-function addSymbol(kind: NavigationSymbolKind, node: SyntaxNode, name: string, opts: {tableId?: string; scopeKey?: string} = {}) {
-  let file = getFile(node)
-  let location = locationForNode(node)
-  let id = symbolId(kind, location, opts.scopeKey)
-  file.navigation.symbols.push({id, kind, name, location, tableId: opts.tableId})
-  return {symbolId: id, location}
-}
+class AnalysisSession implements Analyzer {
+  config: AnalysisConfig
+  files: FileInfo[]
+  diagnostics: GrapheneError[] = []
+  filesByPath: Record<string, FileInfo> = {}
+  computedColumnStack = new Set<Column>() // Track computed columns being analyzed to detect cycles
+  viewStack = new Set<Table>() // Also detect view cycles
 
-function addReference(kind: NavigationSymbolKind, node: SyntaxNode, targetId?: string) {
-  if (!targetId) return
-  let file = getFile(node)
-  file.navigation.references.push({kind, targetId, location: locationForNode(node)})
-}
+  constructor(workspace: AnalysisWorkspace) {
+    this.config = workspace.config
+    this.files = workspace.files.map(file => this.createFile(file))
+    this.filesByPath = Object.fromEntries(this.files.map(file => [file.path, file]))
+  }
 
-// Creates tables without analyzing them.
-export function findTables(fi: FileInfo) {
-  let tn = fi.tree!.topNode
-  fi.tables = []
-  let nodes = tn.getChildren('TableStatement').concat(tn.getChildren('ViewStatement'))
-  for (let syntaxNode of nodes) {
-    let refNode = syntaxNode.getChild('Ref')!
-    let name = txt(refNode)
-
-    let existing = Object.values(FILE_MAP).find(f => {
-      if (f.path.endsWith('.md') && f.path != fi.path) return
-      return f.tables.find(t => t.name == name)
+  analyze(targetPath?: string): AnalysisResult {
+    this.files.forEach(file => {
+      file.tree!.fileInfo = file
+      this.recordSyntaxErrors(file)
+      this.findTables(file)
     })
-    if (existing) diag(refNode, `Table "${name}" is already defined`)
+    this.files.forEach(file => this.applyExtends(file))
 
-    let hasNamespace = name.includes('.')
-    let tablePath = !hasNamespace && config.defaultNamespace ? `${config.defaultNamespace}.${name}` : name
-    let type = syntaxNode.getChild('QueryExpression') ? 'view' : ('table' as const)
-    let table = {name, type, tablePath, columns: [], joins: [], metadata: extractLeadingMetadata(syntaxNode), syntaxNode} as Table
-    Object.assign(table, addSymbol('table', refNode, name))
-
-    syntaxNode.getChildren('ColumnDef').forEach(cn => addColumn(table, cn))
-    syntaxNode.getChildren('JoinDef').forEach(jn => addJoin(table, jn))
-    syntaxNode.getChildren('ComputedDef').forEach(cn => addComputedColumn(table, cn))
-
-    fi.tables.push(table)
-  }
-}
-
-// `extend` blocks add columns and joins to existing tables
-export function applyExtends(fi: FileInfo) {
-  fi.tree!.topNode.getChildren('ExtendStatement').forEach(node => {
-    let target = lookupTable(node.getChild('Ref')!)
-    if (!target) return
-    node.getChildren('JoinDef').forEach(jn => addJoin(target, jn))
-    node.getChildren('ComputedDef').forEach(cn => addComputedColumn(target, cn))
-  })
-}
-
-function addColumn(table: Table, node: SyntaxNode) {
-  let nameNode = node.getChild('ColumnName')!
-  let name = txt(nameNode)
-  let parsed = parseGsqlFieldType(txt(node.getChild('DataType')))
-  if (parsed.error) return diag(node, parsed.error)
-  if (!parsed.type) return diag(node, `Unsupported data type: ${txt(node.getChild('DataType'))}`)
-  let type = parsed.type
-  let col: Column = {name, type, metadata: extractLeadingMetadata(node)}
-  Object.assign(col, addSymbol('column', nameNode, name, {tableId: table.symbolId}))
-  if (getField(name, table)) return diag(node, `Table already has a field called "${name}"`)
-  table.columns.push(col)
-}
-
-function addJoin(table: Table, node: SyntaxNode) {
-  let aliasNode = node.getChild('Alias') || node.getChild('Ref')!.getChildren('Identifier').pop()
-  let alias = txt(aliasNode)
-
-  let joinTypeStr = txt(node.getChild('JoinType')).replace(/\s+/g, ' ')
-  let cardinality = {'join many': 'many', 'join one': 'one'}[joinTypeStr] as 'one' | 'many'
-  if (!cardinality) return diag(node, 'Unknown join type')
-
-  let targetNode = node.getChild('Ref')!
-  let targetTable = txt(targetNode)
-  let onExpr = node.getChild('BinaryExpression')!
-
-  let join: QueryJoin = {alias, source: 'implicit', targetTable, cardinality, onExpr, targetNode}
-  if (getField(alias, table)) return diag(node, `Table already has a field called "${alias}"`)
-  table.joins.push(join)
-}
-
-function addComputedColumn(table: Table, node: SyntaxNode) {
-  let nameNode = node.getChild('Alias')!
-  let name = txt(nameNode)
-  let col: Column = {name, type: scalarType('string'), exprNode: node.getChild('Expression')!, metadata: extractLeadingMetadata(node)}
-  Object.assign(col, addSymbol('column', nameNode, name, {tableId: table.symbolId}))
-  if (getField(name, table)) return diag(node, `Table already has a field called "${name}"`)
-  table.columns.push(col)
-}
-
-function getField(name: string, table: Table) {
-  return table.columns.find(c => c.name == name) || table.joins.find(j => j.alias == name)
-}
-
-// Analyze a view's underlying query to determine its output columns.
-// Converts a PhysicalTable with a QueryStatement into a ViewTable with a query.
-// Returns true if the table is (or was already) a successfully analyzed view.
-function analyzeView(table: Table) {
-  if (table.type != 'view') return
-  if (table.analyzed) return
-  table.analyzed = true
-
-  let query = analyzeQuery(table.syntaxNode!.getChild('QueryExpression')!)
-  if (!query) return
-
-  let viewCols = query.fields.map(f => {
-    let col = {name: f.name, type: f.type, metadata: f.metadata, location: f.definitionLocation} as Column
-    if (f.definitionLocation) {
-      col.symbolId = symbolId('column', f.definitionLocation, `${table.symbolId}:${f.name}`)
-      getFile(table.syntaxNode!).navigation.symbols.push({id: col.symbolId, kind: 'column', name: col.name, location: f.definitionLocation, tableId: table.symbolId})
+    if (targetPath) {
+      let target = this.fileForPath(targetPath)
+      if (!target) return {files: this.files, diagnostics: this.diagnostics}
+      target.tables.forEach(table => this.analyzeTableFully(table))
+      let nodes = target.tree!.topNode.getChildren('QueryStatement') || []
+      target.queries = nodes.map(node => this.analyzeQuery(node)).filter((query): query is Query => !!query)
+      return {files: this.files, diagnostics: this.diagnostics}
     }
-    return col
-  })
-  table.columns.push(...viewCols)
-  table.query = query
-}
 
-// Analyze everything in a table - used for full project analysis (e.g., `check` command)
-export function analyzeTableFully(table: Table) {
-  if (table.type == 'view') analyzeView(table)
-  let scope: Scope = {table, alias: table.name, fanoutPath: []}
-  table.columns.forEach(c => {
-    if (!c.exprNode) return
-    let expr = analyzeExpr(c.exprNode, scope)
-    c.type = expr.type
-    c.isAgg = expr.isAgg
-    analyzeComputedFieldExpr(c.exprNode, expr)
-  })
-  table.joins.forEach(j => {
-    j.table = lookupTable(j.targetNode!)
-    if (!j.table || !j.onExpr) return
-    let joinTarget = {name: j.alias, table: j.table, alias: j.alias}
-    analyzeExpr(j.onExpr, {table, alias: table.name, fanoutPath: [], joinTarget})
-  })
-}
+    this.files.flatMap(file => file.tables).forEach(table => this.analyzeTableFully(table))
+    this.files.forEach(file => {
+      let nodes = file.tree!.topNode.getChildren('QueryStatement') || []
+      file.queries = nodes.map(node => this.analyzeQuery(node)).filter((query): query is Query => !!query)
+    })
 
-// Expand non-aggregate columns into query fields.
-// When table is provided, expands that single table's columns.
-// When table is null, expands all root-visible query tables (base + ad-hoc joins).
-function expandColumns(table: Table | null, alias: string, query: Query, scope: Scope, namePrefix = '') {
-  if (!table) {
-    let baseJoin = query.joins.find(j => j.source == 'from')
-    if (!baseJoin?.table) return
-    expandColumns(baseJoin.table, baseJoin.alias, query, scope)
-    for (let join of query.joins.filter(j => j.source == 'ad-hoc')) {
-      if (join.table) expandColumns(join.table, join.alias, query, scope, join.alias)
-    }
-    return
+    return {files: this.files, diagnostics: this.diagnostics}
   }
-  for (let col of table.columns) {
-    let outName = namePrefix ? `${namePrefix}_${col.name}` : col.name
-    if (col.exprNode) {
-      // Determine if aggregate (without query context to avoid side-effect diagnostics), then skip measures
-      if (col.isAgg == null) col.isAgg = analyzeExpr(col.exprNode, {table, alias, fanoutPath: scope.fanoutPath}).isAgg
-      if (col.isAgg) continue
-      let expr = analyzeExpr(col.exprNode, {query: scope.query, table, alias, otherTables: scope.otherTables, fanoutPath: scope.fanoutPath})
-      if (isScalarType(expr.type, 'interval') && expr.interval?.form == 'scaled') diag(col.exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
-      query.fields.push({
-        name: outName,
-        sql: expr.sql,
-        type: expr.type,
-        metadata: col.metadata,
-        fanout: expr.fanout,
-        definitionLocation: col.location,
+
+  private createFile(file: WorkspaceFileInput): FileInfo {
+    let parsed = file.parsed || this.parseFile(file)
+    let next = {
+      path: file.path,
+      contents: file.contents,
+      tree: parsed.tree,
+      tables: [],
+      queries: [],
+      navigation: {symbols: [], references: []},
+      virtualContents: parsed.virtualContents,
+      virtualToMarkdownOffset: parsed.virtualToMarkdownOffset,
+    } as FileInfo
+    next.tree!.fileInfo = next
+    return next
+  }
+
+  private parseFile(file: WorkspaceFileInput) {
+    let kind = file.kind || (file.path.endsWith('.md') ? 'md' : 'gsql')
+    if (kind == 'md') return parseMarkdown(file)
+    return {tree: parser.parse(file.contents)}
+  }
+
+  private fileForPath(path: string) {
+    return this.filesByPath[path]
+  }
+
+  private locationForNode(node: SyntaxNode): Location {
+    let file = getFile(node)
+    return {file: file.path, from: getPosition(node.from, file), to: getPosition(node.to, file)}
+  }
+
+  private symbolId(kind: NavigationSymbolKind, location: Location, scopeKey = '') {
+    let suffix = scopeKey ? `:${scopeKey}` : ''
+    return `${kind}:${location.file}:${location.from.offset}:${location.to.offset}${suffix}`
+  }
+
+  private renderTableHover(table: Table) {
+    let desc = table.metadata?.description ? `\n\n${table.metadata.description}` : ''
+    return `#### ${table.name}${desc}`
+  }
+
+  private renderFieldHover(table: Table, field: Column) {
+    let desc = field.metadata?.description ? `\n\n${field.metadata.description}` : ''
+    return `#### ${table.name}.${field.name}${desc}`
+  }
+
+  private addSymbol(kind: NavigationSymbolKind, node: SyntaxNode, name: string, opts: {tableId?: string; scopeKey?: string; hover?: string} = {}) {
+    let file = getFile(node)
+    let location = this.locationForNode(node)
+    let id = this.symbolId(kind, location, opts.scopeKey)
+    file.navigation.symbols.push({id, kind, name, location, tableId: opts.tableId, hover: opts.hover})
+    return {symbolId: id, location}
+  }
+
+  private addReference(kind: NavigationSymbolKind, node: SyntaxNode, targetId?: string) {
+    if (!targetId) return
+    let file = getFile(node)
+    file.navigation.references.push({kind, targetId, location: this.locationForNode(node)})
+  }
+
+  // Creates tables without analyzing them.
+  findTables(fi: FileInfo) {
+    let tn = fi.tree!.topNode
+    fi.tables = []
+    let nodes = tn.getChildren('TableStatement').concat(tn.getChildren('ViewStatement'))
+    for (let syntaxNode of nodes) {
+      let refNode = syntaxNode.getChild('Ref')!
+      let name = txt(refNode)
+
+      let existing = this.files.find(file => {
+        if (file.path.endsWith('.md') && file.path != fi.path) return
+        return file.tables.find(table => table.name == name)
       })
-    } else {
-      query.fields.push({
-        name: outName,
-        sql: `${alias}.${col.name}`,
-        type: col.type,
-        metadata: col.metadata,
-        fanout: normalizeExprFanout({path: scope.fanoutPath}),
-        definitionLocation: col.location,
-      })
+      if (existing) this.diag(refNode, `Table "${name}" is already defined`)
+
+      let hasNamespace = name.includes('.')
+      let tablePath = !hasNamespace && this.config.defaultNamespace ? `${this.config.defaultNamespace}.${name}` : name
+      let type = syntaxNode.getChild('QueryExpression') ? 'view' : ('table' as const)
+      let table = {name, type, tablePath, filePath: fi.path, columns: [], joins: [], metadata: extractLeadingMetadata(syntaxNode), syntaxNode} as Table
+      Object.assign(table, this.addSymbol('table', refNode, name, {hover: this.renderTableHover(table)}))
+
+      syntaxNode.getChildren('ColumnDef').forEach(node => this.addColumn(table, node))
+      syntaxNode.getChildren('JoinDef').forEach(node => this.addJoin(table, node))
+      syntaxNode.getChildren('ComputedDef').forEach(node => this.addComputedColumn(table, node))
+
+      fi.tables.push(table)
     }
   }
-}
 
-// Main query analysis - analyzes and returns a Query with computed SQL
-export function analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query | void {
-  if (queryNode.name == 'QueryStatement') queryNode = queryNode.getChild('QueryExpression')!
-  return analyzeQueryExpression(queryNode.getChild('QueryExpression') || queryNode, outerCtes)
-}
+  // `extend` blocks add columns and joins to existing tables
+  applyExtends(fi: FileInfo) {
+    fi.tree!.topNode.getChildren('ExtendStatement').forEach(node => {
+      let target = this.lookupTable(node.getChild('Ref')!)
+      if (!target) return
+      node.getChildren('JoinDef').forEach(join => this.addJoin(target, join))
+      node.getChildren('ComputedDef').forEach(col => this.addComputedColumn(target, col))
+    })
+  }
 
-function analyzeQueryExpression(queryNode: SyntaxNode, outerCtes?: Table[]): Query | void {
-  let ctes = new Map<string, CteTable>()
-  let otherTables = [...(outerCtes || [])]
-  let scope: Scope = {alias: '', fanoutPath: [], otherTables}
+  private addColumn(table: Table, node: SyntaxNode) {
+    let nameNode = node.getChild('ColumnName')!
+    let name = txt(nameNode)
+    let parsed = parseGsqlFieldType(txt(node.getChild('DataType')))
+    if (parsed.error) return this.diag(node, parsed.error)
+    if (!parsed.type) return this.diag(node, `Unsupported data type: ${txt(node.getChild('DataType'))}`)
+    let type = parsed.type
+    let col: Column = {name, type, metadata: extractLeadingMetadata(node)}
+    Object.assign(col, this.addSymbol('column', nameNode, name, {tableId: table.symbolId, hover: this.renderFieldHover(table, col)}))
+    if (this.getField(name, table)) return this.diag(node, `Table already has a field called "${name}"`)
+    table.columns.push(col)
+  }
 
-  // WITH clause - analyze each CTE. Store them on Scope, as they're accessible to later CTEs, and valid tables for the query to from/join
-  let withClauses = queryNode.getChild('WithClause')?.getChildren('CteDef') || []
-  for (let cteDef of withClauses) {
-    let name = txt(cteDef.getChild('Alias'))
-    let query = analyzeQuery(cteDef.getChild('QueryExpression')!, scope.otherTables)
+  private addJoin(table: Table, node: SyntaxNode) {
+    let aliasNode = node.getChild('Alias') || node.getChild('Ref')!.getChildren('Identifier').pop()
+    let alias = txt(aliasNode)
+
+    let joinTypeStr = txt(node.getChild('JoinType')).replace(/\s+/g, ' ')
+    let cardinality = {'join many': 'many', 'join one': 'one'}[joinTypeStr] as 'one' | 'many'
+    if (!cardinality) return this.diag(node, 'Unknown join type')
+
+    let targetNode = node.getChild('Ref')!
+    let targetTable = txt(targetNode)
+    let onExpr = node.getChild('BinaryExpression')!
+
+    let join: QueryJoin = {alias, source: 'implicit', targetTable, cardinality, onExpr, targetNode}
+    if (this.getField(alias, table)) return this.diag(node, `Table already has a field called "${alias}"`)
+    table.joins.push(join)
+  }
+
+  private addComputedColumn(table: Table, node: SyntaxNode) {
+    let nameNode = node.getChild('Alias')!
+    let name = txt(nameNode)
+    let col: Column = {name, type: scalarType('string'), exprNode: node.getChild('Expression')!, metadata: extractLeadingMetadata(node)}
+    Object.assign(col, this.addSymbol('column', nameNode, name, {tableId: table.symbolId, hover: this.renderFieldHover(table, col)}))
+    if (this.getField(name, table)) return this.diag(node, `Table already has a field called "${name}"`)
+    table.columns.push(col)
+  }
+
+  private getField(name: string, table: Table) {
+    return table.columns.find(col => col.name == name) || table.joins.find(join => join.alias == name)
+  }
+
+  // Analyze a view's underlying query to determine its output columns.
+  // Converts a PhysicalTable with a QueryStatement into a ViewTable with a query.
+  // If analysis succeeds, populates the view's query and output columns.
+  private analyzeView(table: Table) {
+    if (table.type != 'view') return
+    if (table.query) return
+    if (this.viewStack.has(table)) {
+      this.diag(table.syntaxNode?.getChild('Ref') || table.syntaxNode!, 'Cycles are not allowed between views')
+      return
+    }
+    this.viewStack.add(table)
+
+    let query = this.analyzeQuery(table.syntaxNode!.getChild('QueryExpression')!)
+    this.viewStack.delete(table)
     if (!query) return
-    let columns = query.fields.map(f => ({name: f.name, type: f.type, metadata: f.metadata}) as Column)
-    let cte: CteTable = {name, type: 'cte', tablePath: name, columns, joins: [], query}
-    ctes.set(name, cte)
-    scope.otherTables!.push(cte)
+
+    let file = this.fileForPath(table.filePath)
+    let viewCols = query.fields.map(field => {
+      let col = {name: field.name, type: field.type, metadata: field.metadata, location: field.definitionLocation} as Column
+      if (field.definitionLocation) {
+        col.symbolId = this.symbolId('column', field.definitionLocation, `${table.symbolId}:${field.name}`)
+        file.navigation.symbols.push({id: col.symbolId, kind: 'column', name: col.name, location: field.definitionLocation, tableId: table.symbolId, hover: this.renderFieldHover(table, col)})
+      }
+      return col
+    })
+    table.columns.push(...viewCols)
+    table.query = query
   }
 
-  if (queryNode.getChildren('SetOperator').length) return analyzeSetQuery(queryNode, scope, ctes)
-  return analyzeSimpleQuery(queryNode.getChild('SimpleQuery')!, queryNode, scope, ctes)
-}
-
-function analyzeSimpleQuery(simpleNode: SyntaxNode, queryNode: SyntaxNode, parentScope: Scope, ctes: Map<string, CteTable>): Query | void {
-  let query: Query = {sql: '', fields: [], joins: [], filters: [], groupBy: [], orderBy: []}
-  let scope: Scope = {...parentScope, query}
-  let isAgg = false
-  let fanoutExprs: {node: SyntaxNode; expr: Expr}[] = []
-
-  // FROM / JOIN
-  // We represent both as `joins` on the query, since they're conceptually similar for most of analysis
-  let fromClause = simpleNode.getChild('FromClause')
-  let sources: SyntaxNode[] = fromClause ? [fromClause, ...fromClause.getChildren('JoinClause')] : []
-  for (let sourceNode of sources) {
-    let isJoin = sourceNode.name == 'JoinClause'
-    let unnestSource = sourceNode.getChild('UnnestSource')
-    let tablePrimary = unnestSource ? undefined : sourceNode.getChild('TablePrimary')
-    if (!tablePrimary && !unnestSource) return diag(sourceNode, `Invalid ${isJoin ? 'JOIN' : 'FROM'} source`)
-    let alias = txt((unnestSource || tablePrimary)!.getChild('Alias'))
-    let table: Table | undefined
-
-    // This might be referring to a table by name
-    let refNode = tablePrimary?.getChild('Ref') || undefined
-    if (refNode) {
-      table = lookupTable(refNode, scope)
-      if (!table) return
-      alias ||= txt(refNode.getChildren('Identifier').at(-1))
-    }
-
-    // or it could be a subquery
-    if (tablePrimary?.getChild('SubqueryExpression')) {
-      let subquery = analyzeQuery(tablePrimary.getChild('SubqueryExpression')!.getChild('QueryExpression')!, scope.otherTables)
-      if (!subquery) return
-      let columns = subquery.fields.map(f => ({name: f.name, type: f.type, metadata: f.metadata}) as Column)
-      table = {name: 'subquery', type: 'subquery', tablePath: alias, columns, joins: [], query: subquery}
-      alias ||= 'subquery'
-    }
-
-    let joinType: JoinType | undefined = isJoin ? 'inner' : undefined
-    let firstKw = txt(sourceNode.getChildren('Kw')[0]).toLowerCase()
-    if (firstKw == 'left' || firstKw == 'right' || firstKw == 'full' || firstKw == 'cross') joinType = firstKw
-
-    if (unnestSource) {
-      if (!isJoin) return diag(unnestSource, 'UNNEST requires a preceding FROM table')
-      if (firstKw == 'join') return diag(unnestSource, 'Bare JOIN UNNEST is not supported; use CROSS JOIN UNNEST')
-      if (joinType != 'cross') return diag(unnestSource, `${joinType!.toUpperCase()} JOIN UNNEST is not supported`)
-      let exprNode = unnestSource.firstChild?.nextSibling || undefined
-      if (!exprNode) return diag(unnestSource, 'UNNEST requires an array expression')
-      let expr = analyzeExpr(exprNode, {query, alias: '', otherTables: scope.otherTables})
-      if (!isArrayType(expr.type)) return diag(exprNode, `UNNEST requires an array expression, got ${formatType(expr.type)}`)
-      let onExpr = sourceNode.getChild('Expression') || undefined
-      if (onExpr) return diag(sourceNode, 'UNNEST join does not support an ON clause')
-      if (query.joins.find(j => j.alias == alias)) return diag(unnestSource, `Query already has table called "${alias}"`)
-      query.joins.push({alias, source: 'ad-hoc', joinType, fanoutPath: extendFanoutPath(undefined, alias), unnestExpr: expr})
-      continue
-    }
-
-    // Now that we have all the bits, construct the join for it.
-    if (query.joins.find(j => j.alias == alias)) return diag(tablePrimary!, `Query already has table called "${alias}"`)
-    let onExpr = sourceNode.getChild('Expression') || undefined
-    let qj: QueryJoin = {alias, source: isJoin ? 'ad-hoc' : 'from', table, joinType, fanoutPath: [], onExpr}
-    query.joins.push(qj)
-    NODE_ENTITY_MAP.set(tablePrimary!, {entityType: 'table', table})
-
-    // If this is a JOIN, analyze the ON expr
-    // It's important we do this _after_ adding the join to the query, since analyzing the expression looks at the query
-    if (joinType == 'cross' && onExpr) return diag(sourceNode, 'CROSS JOIN cannot have an ON clause')
-    if (isJoin && !onExpr && joinType != 'cross') return diag(sourceNode, `${joinType!.toUpperCase()} JOIN requires an ON clause`)
-    qj.onClause = onExpr && analyzeExpr(onExpr, {query, alias: '', otherTables: scope.otherTables}).sql
+  // Analyze everything in a table - used for full project analysis (e.g., `check` command)
+  analyzeTableFully(table: Table) {
+    if (table.type == 'view') this.analyzeView(table)
+    let file = this.fileForPath(table.filePath)
+    let scope: Scope = {file, table, alias: table.name, fanoutPath: []}
+    table.columns.forEach(col => {
+      if (!col.exprNode) return
+      let expr = this.analyzeExpr(col.exprNode, scope)
+      col.type = expr.type
+      col.isAgg = expr.isAgg
+      this.analyzeComputedFieldExpr(col.exprNode, expr)
+    })
+    table.joins.forEach(join => {
+      join.table = this.lookupTable(join.targetNode!)
+      if (!join.table || !join.onExpr) return
+      let joinTarget = {name: join.alias, table: join.table, alias: join.alias}
+      this.analyzeExpr(join.onExpr, {file, table, alias: table.name, fanoutPath: [], joinTarget})
+    })
   }
 
-  // SELECT clause
-  let selects = simpleNode.getChild('SelectClause')?.getChildren('SelectItem') || []
-  let isDistinct = !!txt(simpleNode.getChild('SelectClause')).toLowerCase().startsWith('select distinct')
+  // Expand non-aggregate columns into query fields.
+  // When table is provided, expands that single table's columns.
+  // When table is null, expands all root-visible query tables (base + ad-hoc joins).
+  private expandColumns(table: Table | null, alias: string, query: Query, scope: Scope, namePrefix = '') {
+    if (!table) {
+      let baseJoin = query.joins.find(join => join.source == 'from')
+      if (!baseJoin?.table) return
+      this.expandColumns(baseJoin.table, baseJoin.alias, query, scope)
+      for (let join of query.joins.filter(join => join.source == 'ad-hoc')) {
+        if (join.table) this.expandColumns(join.table, join.alias, query, scope, join.alias)
+      }
+      return
+    }
 
-  for (let s of selects) {
-    if (s.getChild('Wildcard')) {
-      let pathNodes = s.getChild('Wildcard')!.getChildren('Identifier')
-      if (pathNodes.length == 0) {
-        expandColumns(null, '', query, scope)
+    let file = this.fileForPath(table.filePath)
+    for (let col of table.columns) {
+      let outName = namePrefix ? `${namePrefix}_${col.name}` : col.name
+      if (col.exprNode) {
+        // Determine if aggregate (without query context to avoid side-effect diagnostics), then skip measures
+        if (col.isAgg == null) col.isAgg = this.analyzeExpr(col.exprNode, {file, table, alias, fanoutPath: scope.fanoutPath}).isAgg
+        if (col.isAgg) continue
+        let expr = this.analyzeExpr(col.exprNode, {file, query: scope.query, table, alias, otherTables: scope.otherTables, fanoutPath: scope.fanoutPath})
+        if (isScalarType(expr.type, 'interval') && expr.interval?.form == 'scaled') this.diag(col.exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
+        query.fields.push({
+          name: outName,
+          sql: expr.sql,
+          type: expr.type,
+          metadata: col.metadata,
+          fanout: expr.fanout,
+          definitionLocation: col.location,
+        })
+      } else {
+        query.fields.push({
+          name: outName,
+          sql: `${alias}.${col.name}`,
+          type: col.type,
+          metadata: col.metadata,
+          fanout: normalizeExprFanout({path: scope.fanoutPath}),
+          definitionLocation: col.location,
+        })
+      }
+    }
+  }
+
+  // Main query analysis - analyzes and returns a Query with computed SQL
+  analyzeQuery(queryNode: SyntaxNode, outerCtes?: Table[]): Query | void {
+    if (queryNode.name == 'QueryStatement') queryNode = queryNode.getChild('QueryExpression')!
+    return this.analyzeQueryExpression(queryNode.getChild('QueryExpression') || queryNode, getFile(queryNode), outerCtes)
+  }
+
+  private analyzeQueryExpression(queryNode: SyntaxNode, file: FileInfo, outerCtes?: Table[]): Query | void {
+    let ctes = new Map<string, CteTable>()
+    let otherTables = [...(outerCtes || [])]
+    let scope: Scope = {file, alias: '', fanoutPath: [], otherTables}
+
+    // WITH clause - analyze each CTE. Store them on Scope, as they're accessible to later CTEs, and valid tables for the query to from/join
+    let withClauses = queryNode.getChild('WithClause')?.getChildren('CteDef') || []
+    for (let cteDef of withClauses) {
+      let name = txt(cteDef.getChild('Alias'))
+      let query = this.analyzeQuery(cteDef.getChild('QueryExpression')!, scope.otherTables)
+      if (!query) return
+      let columns = query.fields.map(field => ({name: field.name, type: field.type, metadata: field.metadata}) as Column)
+      let cte: CteTable = {name, type: 'cte', tablePath: name, filePath: file.path, columns, joins: [], query}
+      ctes.set(name, cte)
+      scope.otherTables!.push(cte)
+    }
+
+    if (queryNode.getChildren('SetOperator').length) return this.analyzeSetQuery(queryNode, scope, ctes)
+    return this.analyzeSimpleQuery(queryNode.getChild('SimpleQuery')!, queryNode, scope, ctes)
+  }
+
+  private analyzeSimpleQuery(simpleNode: SyntaxNode, queryNode: SyntaxNode, parentScope: Scope, ctes: Map<string, CteTable>): Query | void {
+    let query: Query = {sql: '', fields: [], joins: [], filters: [], groupBy: [], orderBy: []}
+    let scope: Scope = {...parentScope, query}
+    let isAgg = false
+    let fanoutExprs: {node: SyntaxNode; expr: Expr}[] = []
+
+    // FROM / JOIN
+    // We represent both as `joins` on the query, since they're conceptually similar for most of analysis
+    let fromClause = simpleNode.getChild('FromClause')
+    let sources: SyntaxNode[] = fromClause ? [fromClause, ...fromClause.getChildren('JoinClause')] : []
+    for (let sourceNode of sources) {
+      let isJoin = sourceNode.name == 'JoinClause'
+      let unnestSource = sourceNode.getChild('UnnestSource')
+      let tablePrimary = unnestSource ? undefined : sourceNode.getChild('TablePrimary')
+      if (!tablePrimary && !unnestSource) return this.diag(sourceNode, `Invalid ${isJoin ? 'JOIN' : 'FROM'} source`)
+      let alias = txt((unnestSource || tablePrimary)!.getChild('Alias'))
+      let table: Table | undefined
+
+      // This might be referring to a table by name
+      let refNode = tablePrimary?.getChild('Ref') || undefined
+      if (refNode) {
+        table = this.lookupTable(refNode, scope)
+        if (!table) return
+        alias ||= txt(refNode.getChildren('Identifier').at(-1))
+      }
+
+      // or it could be a subquery
+      if (tablePrimary?.getChild('SubqueryExpression')) {
+        let subquery = this.analyzeQuery(tablePrimary.getChild('SubqueryExpression')!.getChild('QueryExpression')!, scope.otherTables)
+        if (!subquery) return
+        let columns = subquery.fields.map(field => ({name: field.name, type: field.type, metadata: field.metadata}) as Column)
+        table = {name: 'subquery', type: 'subquery', tablePath: alias, filePath: scope.file.path, columns, joins: [], query: subquery}
+        alias ||= 'subquery'
+      }
+
+      let joinType: JoinType | undefined = isJoin ? 'inner' : undefined
+      let firstKw = txt(sourceNode.getChildren('Kw')[0]).toLowerCase()
+      if (firstKw == 'left' || firstKw == 'right' || firstKw == 'full' || firstKw == 'cross') joinType = firstKw
+
+      if (unnestSource) {
+        if (!isJoin) return this.diag(unnestSource, 'UNNEST requires a preceding FROM table')
+        if (firstKw == 'join') return this.diag(unnestSource, 'Bare JOIN UNNEST is not supported; use CROSS JOIN UNNEST')
+        if (joinType != 'cross') return this.diag(unnestSource, `${joinType!.toUpperCase()} JOIN UNNEST is not supported`)
+        let exprNode = unnestSource.firstChild?.nextSibling || undefined
+        if (!exprNode) return this.diag(unnestSource, 'UNNEST requires an array expression')
+        let expr = this.analyzeExpr(exprNode, {file: scope.file, query, alias: '', otherTables: scope.otherTables})
+        if (!isArrayType(expr.type)) return this.diag(exprNode, `UNNEST requires an array expression, got ${formatType(expr.type)}`)
+        let onExpr = sourceNode.getChild('Expression') || undefined
+        if (onExpr) return this.diag(sourceNode, 'UNNEST join does not support an ON clause')
+        if (query.joins.find(join => join.alias == alias)) return this.diag(unnestSource, `Query already has table called "${alias}"`)
+        query.joins.push({alias, source: 'ad-hoc', joinType, fanoutPath: extendFanoutPath(undefined, alias), unnestExpr: expr})
         continue
       }
-      let targetScope = followJoins(pathNodes, scope)
-      if (!targetScope) continue
-      if (!targetScope.table) continue
-      expandColumns(targetScope.table, targetScope.alias, query, targetScope)
-    } else {
-      let exprNode = s.getChild('Expression')!
-      let aliasNode = s.getChild('Alias')
-      let expr = analyzeExpr(exprNode, scope)
-      if (isScalarType(expr.type, 'interval') && expr.interval?.form == 'scaled') diag(exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
-      let name = aliasNode ? txt(aliasNode) : inferName(exprNode, scope)
-      isAgg ||= !!expr.isAgg
-      query.fields.push({
-        name,
-        sql: expr.sql,
-        type: expr.type,
-        isAgg: expr.isAgg,
-        fanout: expr.fanout,
-        definitionLocation: locationForNode(aliasNode || exprNode),
-      })
-      fanoutExprs.push({node: exprNode, expr})
+
+      // Now that we have all the bits, construct the join for it.
+      if (query.joins.find(join => join.alias == alias)) return this.diag(tablePrimary!, `Query already has table called "${alias}"`)
+      let onExpr = sourceNode.getChild('Expression') || undefined
+      let qj: QueryJoin = {alias, source: isJoin ? 'ad-hoc' : 'from', table, joinType, fanoutPath: [], onExpr}
+      query.joins.push(qj)
+
+      // If this is a JOIN, analyze the ON expr
+      // It's important we do this _after_ adding the join to the query, since analyzing the expression looks at the query
+      if (joinType == 'cross' && onExpr) return this.diag(sourceNode, 'CROSS JOIN cannot have an ON clause')
+      if (isJoin && !onExpr && joinType != 'cross') return this.diag(sourceNode, `${joinType!.toUpperCase()} JOIN requires an ON clause`)
+      qj.onClause = onExpr && this.analyzeExpr(onExpr, {file: scope.file, query, alias: '', otherTables: scope.otherTables}).sql
     }
-  }
 
-  // WHERE / HAVING - we allow aggregate filters in WHERE (moved to HAVING automatically)
-  let whereNode = simpleNode.getChild('WhereClause')?.getChild('Expression')
-  let havingNode = simpleNode.getChild('HavingClause')?.getChild('Expression')
-  for (let node of [whereNode, havingNode]) {
-    if (!node) continue
-    for (let expr of unpackAnds(node, scope)) {
-      query.filters.push({sql: expr.sql, isAgg: expr.isAgg})
-      fanoutExprs.push({node, expr})
-    }
-  }
+    // SELECT clause
+    let selects = simpleNode.getChild('SelectClause')?.getChildren('SelectItem') || []
+    let isDistinct = !!txt(simpleNode.getChild('SelectClause')).toLowerCase().startsWith('select distinct')
 
-  // GROUP BY - adds fields if not already selected
-  let groupBys = simpleNode.getChild('GroupByClause')?.getChildren('SelectItem') || []
-  for (let g of groupBys) {
-    let exprNode = g.getChild('Expression')!
-    let alias = txt(g.getChild('Alias'))
-
-    // Positional GROUP BY (e.g. `group by 2, 1`) references the current SELECT list.
-    if (exprNode.name == 'Number' && !alias) {
-      let f = query.fields[Number(txt(exprNode)) - 1]
-      if (!f) diag(g, 'No field at index ' + txt(exprNode))
-      query.groupBy.push(f?.name)
-    } else {
-      // Otherwise, we can assume this is an expression (possibly with an alias)
-      // If that expression is already in the selected fields, it's just a reference.
-      let expr = analyzeExpr(exprNode, scope)
-      if (expr.isAgg) diag(g, 'Cannot group by aggregate expressions')
-      let name = g.getChild('Alias') ? txt(g.getChild('Alias')) : inferName(exprNode, scope)
-      query.groupBy.push(name)
-
-      // If it's not in there, add it to the select.
-      if (!query.fields.find(f => f.name == name)) {
-        query.fields.unshift({name, sql: expr.sql, type: expr.type, fanout: expr.fanout, definitionLocation: locationForNode(g.getChild('Alias') || exprNode)})
+    for (let select of selects) {
+      if (select.getChild('Wildcard')) {
+        let pathNodes = select.getChild('Wildcard')!.getChildren('Identifier')
+        if (pathNodes.length == 0) {
+          this.expandColumns(null, '', query, scope)
+          continue
+        }
+        let targetScope = this.followJoins(pathNodes, scope)
+        if (!targetScope?.table) continue
+        this.expandColumns(targetScope.table, targetScope.alias, query, targetScope)
+      } else {
+        let exprNode = select.getChild('Expression')!
+        let aliasNode = select.getChild('Alias')
+        let expr = this.analyzeExpr(exprNode, scope)
+        if (isScalarType(expr.type, 'interval') && expr.interval?.form == 'scaled') this.diag(exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
+        let name = aliasNode ? txt(aliasNode) : this.inferName(exprNode, scope)
+        isAgg ||= !!expr.isAgg
+        query.fields.push({
+          name,
+          sql: expr.sql,
+          type: expr.type,
+          isAgg: expr.isAgg,
+          fanout: expr.fanout,
+          definitionLocation: this.locationForNode(aliasNode || exprNode),
+        })
+        fanoutExprs.push({node: exprNode, expr})
       }
-      fanoutExprs.push({node: g.getChild('Expression')!, expr})
     }
-  }
 
-  // If there are agg fields but no groupBy, automatically group by all non-agg fields
-  let nonAggFields = query.fields.filter(f => !f.isAgg)
-  if (query.groupBy.length == 0 && (isDistinct || nonAggFields.length < query.fields.length)) {
-    query.groupBy = nonAggFields.map(f => f.name)
-  }
-
-  // ORDER BY
-  let {orderBy, limit} = analyzeOrderAndLimit(queryNode, query)
-
-  // Implicit `select *` if nothing selected (only when we have a base table)
-  let baseJoin = query.joins.find(j => j.source == 'from')
-  if (query.fields.length == 0 && baseJoin?.table) {
-    let hasAdHoc = query.joins.some(j => j.source == 'ad-hoc')
-    expandColumns(hasAdHoc ? null : baseJoin.table, baseJoin.alias, query, scope)
-  }
-
-  // Default ORDER BY for aggregate queries
-  if (orderBy.length == 0 && query.groupBy.length > 0) {
-    let firstAggIdx = query.fields.findIndex(f => f.isAgg)
-    if (firstAggIdx >= 0) {
-      orderBy.push({idx: firstAggIdx + 1, desc: true})
-    } else {
-      orderBy.push({idx: 1, desc: false}) // SELECT DISTINCT
+    // WHERE / HAVING - we allow aggregate filters in WHERE (moved to HAVING automatically)
+    let whereNode = simpleNode.getChild('WhereClause')?.getChild('Expression')
+    let havingNode = simpleNode.getChild('HavingClause')?.getChild('Expression')
+    for (let node of [whereNode, havingNode]) {
+      if (!node) continue
+      for (let expr of this.unpackAnds(node, scope)) {
+        query.filters.push({sql: expr.sql, isAgg: expr.isAgg})
+        fanoutExprs.push({node, expr})
+      }
     }
-  }
-  query.orderBy = orderBy
-  query.limit = limit
-  if (isAgg) {
-    fanoutExprs.forEach(({node, expr}) => analyzeAggregateQueryExpr(node, expr))
-    analyzeAggregateQueryFanout(fanoutExprs)
-  }
-  query.sql = buildSql(query, ctes)
-  return query
-}
 
-function analyzeSetQuery(queryNode: SyntaxNode, scope: Scope, ctes: Map<string, CteTable>): Query | void {
-  let branches = [
-    {query: analyzeSimpleQuery(queryNode.getChild('SimpleQuery')!, queryNode.getChild('SimpleQuery')!, scope, new Map()), parenthesized: false},
-    ...queryNode.getChildren('SetOperand').map(node => analyzeSetOperand(node, scope)),
-  ]
+    // GROUP BY - adds fields if not already selected
+    let groupBys = simpleNode.getChild('GroupByClause')?.getChildren('SelectItem') || []
+    for (let groupBy of groupBys) {
+      let exprNode = groupBy.getChild('Expression')!
+      let alias = txt(groupBy.getChild('Alias'))
 
-  let first = branches[0].query
-  if (!first) return
-  for (let branch of branches.slice(1)) {
-    if (!branch.query) return
-    if (branch.query.fields.length != first.fields.length) return diag(queryNode, 'Set operation branches must return the same number of columns')
-  }
+      // Positional GROUP BY (e.g. `group by 2, 1`) references the current SELECT list.
+      if (exprNode.name == 'Number' && !alias) {
+        let field = query.fields[Number(txt(exprNode)) - 1]
+        if (!field) this.diag(groupBy, 'No field at index ' + txt(exprNode))
+        query.groupBy.push(field?.name)
+      } else {
+        // Otherwise, we can assume this is an expression (possibly with an alias)
+        // If that expression is already in the selected fields, it's just a reference.
+        let expr = this.analyzeExpr(exprNode, scope)
+        if (expr.isAgg) this.diag(groupBy, 'Cannot group by aggregate expressions')
+        let name = groupBy.getChild('Alias') ? txt(groupBy.getChild('Alias')) : this.inferName(exprNode, scope)
+        query.groupBy.push(name)
 
-  let setOps = queryNode.getChildren('SetOperator')
-  let fields = first.fields.map((field, idx) => {
-    let next = {...field}
-    let matches = branches.slice(1).every(branch => sameFieldMetadata(branch.query?.fields[idx]?.type, field.type))
-    if (!matches) next.type = withTypeMetadata(next.type, undefined)
-    return next
-  })
+        // If it's not in there, add it to the select.
+        if (!query.fields.find(field => field.name == name)) {
+          query.fields.unshift({name, sql: expr.sql, type: expr.type, fanout: expr.fanout, definitionLocation: this.locationForNode(groupBy.getChild('Alias') || exprNode)})
+        }
+        fanoutExprs.push({node: groupBy.getChild('Expression')!, expr})
+      }
+    }
 
-  let query: Query = {
-    sql: '',
-    fields,
-    joins: [],
-    filters: [],
-    groupBy: [],
-    orderBy: [],
-    setOp: txt(setOps[0]).toLowerCase() as Query['setOp'],
-    branches: branches as {query: Query; parenthesized?: boolean}[],
-  }
+    // If there are agg fields but no groupBy, automatically group by all non-agg fields
+    let nonAggFields = query.fields.filter(field => !field.isAgg)
+    if (query.groupBy.length == 0 && (isDistinct || nonAggFields.length < query.fields.length)) {
+      query.groupBy = nonAggFields.map(field => field.name)
+    }
 
-  for (let opNode of setOps.slice(1)) {
-    let op = txt(opNode).toLowerCase()
-    if (op != query.setOp) return diag(opNode, 'Mixed set operators require parentheses')
-  }
+    // ORDER BY
+    let {orderBy, limit} = this.analyzeOrderAndLimit(queryNode, query)
 
-  let {orderBy, limit} = analyzeOrderAndLimit(queryNode, query)
-  query.orderBy = orderBy
-  query.limit = limit
-  query.sql = buildSql(query, ctes)
-  return query
-}
+    // Implicit `select *` if nothing selected (only when we have a base table)
+    let baseJoin = query.joins.find(join => join.source == 'from')
+    if (query.fields.length == 0 && baseJoin?.table) {
+      let hasAdHoc = query.joins.some(join => join.source == 'ad-hoc')
+      this.expandColumns(hasAdHoc ? null : baseJoin.table, baseJoin.alias, query, scope)
+    }
 
-function analyzeSetOperand(node: SyntaxNode, scope: Scope) {
-  let subqueryNode = node.getChild('SubqueryExpression')
-  if (subqueryNode) return {query: analyzeQuery(subqueryNode.getChild('QueryExpression')!, scope.otherTables), parenthesized: true}
-  return {query: analyzeSimpleQuery(node.getChild('SimpleQuery')!, node.getChild('SimpleQuery')!, scope, new Map()), parenthesized: false}
-}
+    // Default ORDER BY for aggregate queries
+    if (orderBy.length == 0 && query.groupBy.length > 0) {
+      let firstAggIdx = query.fields.findIndex(field => field.isAgg)
+      if (firstAggIdx >= 0) orderBy.push({idx: firstAggIdx + 1, desc: true})
+      else orderBy.push({idx: 1, desc: false}) // SELECT DISTINCT
+    }
 
-function analyzeOrderAndLimit(queryNode: SyntaxNode, query: Query) {
-  let orderBys = queryNode.getChild('OrderByClause')?.getChildren('OrderItem') || []
-  let orderBy: {idx: number; desc: boolean}[] = []
-  for (let o of orderBys) {
-    let fieldRef = txt(o.getChild('Identifier')) || txt(o.getChild('Number'))
-    let desc = txt(o.getChild('Kw')).toLowerCase() == 'desc'
-    let idx = Number(fieldRef) || query.fields.findIndex(f => f.name == fieldRef) + 1
-    if (idx > 0) orderBy.push({idx, desc})
-    else if (fieldRef && isNaN(Number(fieldRef))) diag(o, `Unknown field in ORDER BY: ${fieldRef}`)
+    query.orderBy = orderBy
+    query.limit = limit
+    if (isAgg) {
+      fanoutExprs.forEach(({node, expr}) => this.analyzeAggregateQueryExpr(node, expr))
+      this.analyzeAggregateQueryFanout(fanoutExprs)
+    }
+    query.sql = this.buildSql(query, ctes)
+    return query
   }
 
-  let limitNodes = queryNode.getChild('LimitClause')?.getChildren('Number') || []
-  let limit = limitNodes[0] ? Number(txt(limitNodes[0])) : undefined
-  if (limitNodes[1]) diag(limitNodes[1], 'OFFSET is not supported')
-  return {orderBy, limit}
-}
+  private analyzeSetQuery(queryNode: SyntaxNode, scope: Scope, ctes: Map<string, CteTable>): Query | void {
+    let branches = [
+      {query: this.analyzeSimpleQuery(queryNode.getChild('SimpleQuery')!, queryNode.getChild('SimpleQuery')!, scope, new Map()), parenthesized: false},
+      ...queryNode.getChildren('SetOperand').map(node => this.analyzeSetOperand(node, scope)),
+    ]
 
-// Assemble query parts into final SQL
-// Format a table path for the current dialect
-function formatTablePath(path: string): string {
-  if (config.dialect === 'bigquery') return `\`${path}\``
-  if (config.dialect === 'snowflake') return path.toUpperCase()
-  return path
-}
+    let first = branches[0].query
+    if (!first) return
+    for (let branch of branches.slice(1)) {
+      if (!branch.query) return
+      if (branch.query.fields.length != first.fields.length) return this.diag(queryNode, 'Set operation branches must return the same number of columns')
+    }
 
-function renderUnnestValueSql(alias: string): string {
-  return config.dialect == 'snowflake' ? `${alias}.value` : alias
-}
-
-function renderUnnestJoinClause(join: QueryJoin): string {
-  if (!join.unnestExpr || !join.joinType) return ''
-  let exprSql = join.unnestExpr.sql
-  if (config.dialect == 'bigquery') return `CROSS JOIN UNNEST(${exprSql}) AS ${join.alias}`
-  if (config.dialect == 'snowflake') return `, TABLE(FLATTEN(INPUT => ${exprSql})) AS ${join.alias}`
-  return `CROSS JOIN unnest(${exprSql}) AS ${join.alias}(${join.alias})`
-}
-
-function buildSql(query: Query, cteMap: Map<string, CteTable>): string {
-  let ctes: string[] = [...cteMap.values()].map(c => `${c.name} as ( ${c.query.sql} )`)
-
-  if (query.setOp) {
-    let branches = (query.branches || []).map(branch => {
-      let sql = branch.query.sql
-      return branch.parenthesized ? `( ${sql} )` : sql
+    let setOps = queryNode.getChildren('SetOperator')
+    let fields = first.fields.map((field, idx) => {
+      let next = {...field}
+      let matches = branches.slice(1).every(branch => this.sameFieldMetadata(branch.query?.fields[idx]?.type, field.type))
+      if (!matches) next.type = withTypeMetadata(next.type, undefined)
+      return next
     })
-    let op = query.setOp!.toUpperCase()
-    let sql = branches.join(` ${op} `)
+
+    let query: Query = {
+      sql: '',
+      fields,
+      joins: [],
+      filters: [],
+      groupBy: [],
+      orderBy: [],
+      setOp: txt(setOps[0]).toLowerCase() as Query['setOp'],
+      branches: branches as {query: Query; parenthesized?: boolean}[],
+    }
+
+    for (let opNode of setOps.slice(1)) {
+      let op = txt(opNode).toLowerCase()
+      if (op != query.setOp) return this.diag(opNode, 'Mixed set operators require parentheses')
+    }
+
+    let {orderBy, limit} = this.analyzeOrderAndLimit(queryNode, query)
+    query.orderBy = orderBy
+    query.limit = limit
+    query.sql = this.buildSql(query, ctes)
+    return query
+  }
+
+  private analyzeSetOperand(node: SyntaxNode, scope: Scope) {
+    let subqueryNode = node.getChild('SubqueryExpression')
+    if (subqueryNode) return {query: this.analyzeQuery(subqueryNode.getChild('QueryExpression')!, scope.otherTables), parenthesized: true}
+    return {query: this.analyzeSimpleQuery(node.getChild('SimpleQuery')!, node.getChild('SimpleQuery')!, scope, new Map()), parenthesized: false}
+  }
+
+  private analyzeOrderAndLimit(queryNode: SyntaxNode, query: Query) {
+    let orderBys = queryNode.getChild('OrderByClause')?.getChildren('OrderItem') || []
+    let orderBy: {idx: number; desc: boolean}[] = []
+    for (let orderItem of orderBys) {
+      let fieldRef = txt(orderItem.getChild('Identifier')) || txt(orderItem.getChild('Number'))
+      let desc = txt(orderItem.getChild('Kw')).toLowerCase() == 'desc'
+      let idx = Number(fieldRef) || query.fields.findIndex(field => field.name == fieldRef) + 1
+      if (idx > 0) orderBy.push({idx, desc})
+      else if (fieldRef && isNaN(Number(fieldRef))) this.diag(orderItem, `Unknown field in ORDER BY: ${fieldRef}`)
+    }
+
+    let limitNodes = queryNode.getChild('LimitClause')?.getChildren('Number') || []
+    let limit = limitNodes[0] ? Number(txt(limitNodes[0])) : undefined
+    if (limitNodes[1]) this.diag(limitNodes[1], 'OFFSET is not supported')
+    return {orderBy, limit}
+  }
+
+  // Assemble query parts into final SQL
+  // Format a table path for the current dialect
+  private formatTablePath(path: string): string {
+    if (this.config.dialect === 'bigquery') return `\`${path}\``
+    if (this.config.dialect === 'snowflake') return path.toUpperCase()
+    return path
+  }
+
+  private renderUnnestValueSql(alias: string): string {
+    return this.config.dialect == 'snowflake' ? `${alias}.value` : alias
+  }
+
+  private renderUnnestJoinClause(join: QueryJoin): string {
+    if (!join.unnestExpr || !join.joinType) return ''
+    let exprSql = join.unnestExpr.sql
+    if (this.config.dialect == 'bigquery') return `CROSS JOIN UNNEST(${exprSql}) AS ${join.alias}`
+    if (this.config.dialect == 'snowflake') return `, TABLE(FLATTEN(INPUT => ${exprSql})) AS ${join.alias}`
+    return `CROSS JOIN unnest(${exprSql}) AS ${join.alias}(${join.alias})`
+  }
+
+  private buildSql(query: Query, cteMap: Map<string, CteTable>): string {
+    let ctes: string[] = [...cteMap.values()].map(cte => `${cte.name} as ( ${cte.query.sql} )`)
+
+    if (query.setOp) {
+      let branches = (query.branches || []).map(branch => {
+        let sql = branch.query.sql
+        return branch.parenthesized ? `( ${sql} )` : sql
+      })
+      let op = query.setOp.toUpperCase()
+      let sql = branches.join(` ${op} `)
+      if (query.orderBy.length) {
+        let parts = query.orderBy.map(order => `${order.idx} ${order.desc ? 'desc' : 'asc'} NULLS LAST`)
+        sql += ` ORDER BY ${parts.join(',')}`
+      }
+      if (query.limit) sql += ` LIMIT ${query.limit}`
+      if (ctes.length) sql = `WITH ${ctes.join(', ')} ${sql}`
+      return sql
+    }
+
+    let selectParts = query.fields.map(field => `${field.sql} as ${field.name}`)
+    let baseJoin = query.joins.find(join => join.source == 'from')
+
+    // No FROM clause (e.g. `select 1`)
+    if (!baseJoin?.table) return `SELECT ${selectParts.join(', ')}`
+
+    let renderTableRef = (table: Table): string => {
+      if (table.type === 'view') {
+        if (!ctes.some(cte => cte.startsWith(table.name + ' '))) ctes.push(`${table.name} as ( ${table.query.sql} )`)
+        return table.name
+      }
+      if (table.type === 'subquery') return `( ${table.query.sql} )`
+      return this.formatTablePath(table.tablePath)
+    }
+
+    let fromTable = renderTableRef(baseJoin.table)
+    let joinClauses = query.joins
+      .filter(join => join.source != 'from')
+      .map(join => {
+        if (join.unnestExpr) return this.renderUnnestJoinClause(join)
+        if (!join.table || !join.joinType) return ''
+        let tablePath = renderTableRef(join.table)
+        let keyword = join.joinType.toUpperCase() + ' JOIN'
+        if (join.joinType == 'cross') return `${keyword} ${tablePath} as ${join.alias}`
+        return `${keyword} ${tablePath} as ${join.alias} ON ${join.onClause}`
+      })
+      .filter(Boolean)
+
+    let whereFilters = query.filters.filter(filter => !filter.isAgg).map(filter => filter.sql)
+    let havingFilters = query.filters.filter(filter => filter.isAgg).map(filter => filter.sql)
+    let groupByIndices = query.groupBy.map(group => query.fields.findIndex(field => field.name == group) + 1)
+
+    let sql = `SELECT ${selectParts.join(', ')} FROM ${fromTable} as ${baseJoin.alias}`
+    if (joinClauses.length) sql += ' ' + joinClauses.join(' ')
+    if (whereFilters.length) sql += ` WHERE ${whereFilters.join(' AND ')}`
+    if (groupByIndices.length) sql += ` GROUP BY ${groupByIndices.join(',')}`
+    if (havingFilters.length) sql += ` HAVING ${havingFilters.join(' AND ')}`
     if (query.orderBy.length) {
-      let parts = query.orderBy.map(o => `${o.idx} ${o.desc ? 'desc' : 'asc'} NULLS LAST`)
+      let parts = query.orderBy.map(order => `${order.idx} ${order.desc ? 'desc' : 'asc'} NULLS LAST`)
       sql += ` ORDER BY ${parts.join(',')}`
     }
     if (query.limit) sql += ` LIMIT ${query.limit}`
@@ -559,822 +697,731 @@ function buildSql(query: Query, cteMap: Map<string, CteTable>): string {
     return sql
   }
 
-  let selectParts = query.fields.map(f => `${f.sql} as ${f.name}`)
-  let baseJoin = query.joins.find(j => j.source == 'from')
+  // Analyze an expression node and return SQL + type info
+  analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
+    if (node.type.isError) return this.diag(node, 'Invalid expression', {sql: 'NULL', type: scalarType('error')})
 
-  // No FROM clause (e.g. `select 1`)
-  if (!baseJoin?.table) return `SELECT ${selectParts.join(', ')}`
+    switch (node.name) {
+      case 'Number':
+        return {sql: txt(node), type: scalarType('number')}
+      case 'Boolean':
+        return {sql: txt(node).toLowerCase(), type: scalarType('boolean')}
+      case 'Null':
+        return {sql: 'NULL', type: scalarType('null')}
+      case 'String':
+        return {sql: `'${txt(node).slice(1, -1).replace(/'/g, "''")}'`, type: scalarType('string')}
+      case 'Param':
+        return {sql: txt(node), type: scalarType('string')} // $param - type inferred later
 
-  function renderTableRef(table: Table): string {
-    if (table.type === 'view') {
-      if (!ctes.some(c => c.startsWith(table.name + ' '))) {
-        ctes.push(`${table.name} as ( ${table.query.sql} )`)
-      }
-      return table.name
-    }
-    if (table.type === 'subquery') return `( ${table.query.sql} )`
-    return formatTablePath(table.tablePath)
-  }
+      case 'Ref': {
+        let pathNodes = node.getChildren('Identifier')
+        let fieldNode = pathNodes.pop()!
+        let fieldName = txt(fieldNode)
 
-  let fromTable = renderTableRef(baseJoin.table)
-  let joinClauses = query.joins
-    .filter(j => j.source != 'from')
-    .map(j => {
-      if (j.unnestExpr) return renderUnnestJoinClause(j)
-      if (!j.table || !j.joinType) return ''
-      let tablePath = renderTableRef(j.table)
-      let keyword = j.joinType.toUpperCase() + ' JOIN'
-      if (j.joinType == 'cross') return `${keyword} ${tablePath} as ${j.alias}`
-      return `${keyword} ${tablePath} as ${j.alias} ON ${j.onClause}`
-    })
-    .filter(Boolean)
-
-  let whereFilters = query.filters.filter(f => !f.isAgg).map(f => f.sql)
-  let havingFilters = query.filters.filter(f => f.isAgg).map(f => f.sql)
-  let groupByIndices = query.groupBy.map(g => query.fields.findIndex(f => f.name == g) + 1)
-
-  let sql = `SELECT ${selectParts.join(', ')} FROM ${fromTable} as ${baseJoin.alias}`
-  if (joinClauses.length) sql += ' ' + joinClauses.join(' ')
-  if (whereFilters.length) sql += ` WHERE ${whereFilters.join(' AND ')}`
-  if (groupByIndices.length) sql += ` GROUP BY ${groupByIndices.join(',')}`
-  if (havingFilters.length) sql += ` HAVING ${havingFilters.join(' AND ')}`
-  if (query.orderBy.length) {
-    let parts = query.orderBy.map(o => `${o.idx} ${o.desc ? 'desc' : 'asc'} NULLS LAST`)
-    sql += ` ORDER BY ${parts.join(',')}`
-  }
-  if (query.limit) sql += ` LIMIT ${query.limit}`
-  if (ctes.length) sql = `WITH ${ctes.join(', ')} ${sql}`
-  return sql
-}
-
-// Analyze an expression node and return SQL + type info
-export function analyzeExpr(node: SyntaxNode, scope: Scope): Expr {
-  if (node.type.isError) return diag(node, 'Invalid expression', {sql: 'NULL', type: scalarType('error')})
-
-  switch (node.name) {
-    case 'Number':
-      return {sql: txt(node), type: scalarType('number')}
-    case 'Boolean':
-      return {sql: txt(node).toLowerCase(), type: scalarType('boolean')}
-    case 'Null':
-      return {sql: 'NULL', type: scalarType('null')}
-    case 'String':
-      return {sql: `'${txt(node).slice(1, -1).replace(/'/g, "''")}'`, type: scalarType('string')}
-    case 'Param':
-      return {sql: txt(node), type: scalarType('string')} // $param - type inferred later
-
-    case 'Ref': {
-      let pathNodes = node.getChildren('Identifier')
-      let fieldNode = pathNodes.pop()!
-      let fieldName = txt(fieldNode)
-
-      // Check output fields first when we're at the query root (e.g. HAVING/post-agg filters).
-      // Don't do this while resolving table expressions, or we can accidentally bind to sibling
-      // SELECT aliases instead of the table's computed columns.
-      if (scope.query && !scope.table && pathNodes.length == 0) {
-        let outField = scope.query.fields.find(f => f.name == fieldName)
-        if (outField) return {sql: outField.sql, type: outField.type, isAgg: outField.isAgg, fanout: outField.fanout}
-      }
-
-      // Follow any dot path (e.g., `users.orders` in `users.orders.amount`), then find the field
-      let targetScope = followJoins(pathNodes, scope)
-      if (!targetScope) return {sql: 'NULL', type: scalarType('error')}
-
-      // Build the list of tables to search: if followJoins landed on a specific table, just that one.
-      // Otherwise, search all tables either in FROM or explicitly JOINed (but not implicitly joined).
-      let possibleJoins = targetScope.table
-        ? [{table: targetScope.table, alias: targetScope.alias, fanoutPath: targetScope.fanoutPath}]
-        : scope.query?.joins.filter(j => j.source != 'implicit' && j.table).map(j => ({table: j.table!, alias: j.alias, fanoutPath: j.fanoutPath})) || []
-      let unnestMatches = !targetScope.table && pathNodes.length == 0 ? scope.query?.joins.filter(j => j.unnestExpr && j.alias == fieldName) || [] : []
-
-      // Expect just one of the possibleJoins to have the named column. Otherwise, it's an error.
-      let matches = possibleJoins.filter(j => j.table.columns.some(c => c.name == fieldName))
-      if (matches.length + unnestMatches.length > 1) {
-        return diag(fieldNode, `Ambiguous field "${fieldName}"`, {sql: 'NULL', type: scalarType('error')})
-      }
-
-      if (unnestMatches.length == 1) {
-        let join = unnestMatches[0]
-        let elementType = isArrayType(join.unnestExpr!.type) ? join.unnestExpr!.type.elementType : scalarType('error')
-        return {sql: renderUnnestValueSql(join.alias), type: elementType, fanout: normalizeExprFanout({path: join.fanoutPath})}
-      }
-
-      if (matches.length == 0) {
-        if (possibleJoins.some(j => j.table.joins.some(jj => jj.alias == fieldName))) {
-          return diag(fieldNode, `"${fieldName}" is a join, not a column`, {sql: 'NULL', type: scalarType('error')})
+        // Check output fields first when we're at the query root (e.g. HAVING/post-agg filters).
+        // Don't do this while resolving table expressions, or we can accidentally bind to sibling
+        // SELECT aliases instead of the table's computed columns.
+        if (scope.query && !scope.table && pathNodes.length == 0) {
+          let outField = scope.query.fields.find(field => field.name == fieldName)
+          if (outField) return {sql: outField.sql, type: outField.type, isAgg: outField.isAgg, fanout: outField.fanout}
         }
-        let on = possibleJoins.length == 1 ? ` on ${possibleJoins[0].table.name}` : ''
-        return diag(fieldNode, `Unknown field "${fieldName}"${on}`, {sql: 'NULL', type: scalarType('error')})
+
+        // Follow any dot path (e.g., `users.orders` in `users.orders.amount`), then find the field
+        let targetScope = this.followJoins(pathNodes, scope)
+        if (!targetScope) return {sql: 'NULL', type: scalarType('error')}
+
+        // Build the list of tables to search: if followJoins landed on a specific table, just that one.
+        // Otherwise, search all tables either in FROM or explicitly JOINed (but not implicitly joined).
+        let possibleJoins = targetScope.table
+          ? [{table: targetScope.table, alias: targetScope.alias, fanoutPath: targetScope.fanoutPath}]
+          : scope.query?.joins.filter(join => join.source != 'implicit' && join.table).map(join => ({table: join.table!, alias: join.alias, fanoutPath: join.fanoutPath})) || []
+        let unnestMatches = !targetScope.table && pathNodes.length == 0 ? scope.query?.joins.filter(join => join.unnestExpr && join.alias == fieldName) || [] : []
+
+        // Expect just one of the possibleJoins to have the named column. Otherwise, it's an error.
+        let matches = possibleJoins.filter(join => join.table.columns.some(col => col.name == fieldName))
+        if (matches.length + unnestMatches.length > 1) {
+          return this.diag(fieldNode, `Ambiguous field "${fieldName}"`, {sql: 'NULL', type: scalarType('error')})
+        }
+
+        if (unnestMatches.length == 1) {
+          let join = unnestMatches[0]
+          let elementType = isArrayType(join.unnestExpr!.type) ? join.unnestExpr!.type.elementType : scalarType('error')
+          return {sql: this.renderUnnestValueSql(join.alias), type: elementType, fanout: normalizeExprFanout({path: join.fanoutPath})}
+        }
+
+        if (matches.length == 0) {
+          if (possibleJoins.some(join => join.table.joins.some(next => next.alias == fieldName))) {
+            return this.diag(fieldNode, `"${fieldName}" is a join, not a column`, {sql: 'NULL', type: scalarType('error')})
+          }
+          let on = possibleJoins.length == 1 ? ` on ${possibleJoins[0].table.name}` : ''
+          return this.diag(fieldNode, `Unknown field "${fieldName}"${on}`, {sql: 'NULL', type: scalarType('error')})
+        }
+
+        let {table, alias} = matches[0]
+        let col = table.columns.find(column => column.name == fieldName)!
+        this.addReference('column', fieldNode, col.symbolId)
+
+        // Simple case: this is just a regular column on a table
+        if (!col.exprNode) return {sql: `${alias}.${col.name}`, type: col.type, fanout: normalizeExprFanout({path: matches[0].fanoutPath})}
+
+        // Computed column: analyze its expression in the matched table's scope
+        if (this.computedColumnStack.has(col)) return this.diag(col.exprNode, 'Cycles are not allowed between computed columns', {sql: 'NULL', type: scalarType('error')})
+        this.computedColumnStack.add(col)
+        let expr = this.analyzeExpr(col.exprNode, {file: this.fileForPath(table.filePath), query: scope.query, table, alias, otherTables: scope.otherTables, fanoutPath: matches[0].fanoutPath})
+        this.computedColumnStack.delete(col)
+        return {sql: `(${expr.sql})`, type: expr.type, isAgg: expr.isAgg, fanout: expr.fanout}
       }
 
-      let {table, alias} = matches[0]
-      let col = table.columns.find(c => c.name == fieldName)!
-      NODE_ENTITY_MAP.set(fieldNode, {entityType: 'field', field: col, table})
-      addReference('column', fieldNode, col.symbolId)
+      case 'FunctionCall':
+        return analyzeFunction(this, node, scope)
 
-      // Simple case: this is just a regular column on a table
-      if (!col.exprNode) return {sql: `${alias}.${col.name}`, type: col.type, fanout: normalizeExprFanout({path: matches[0].fanoutPath})}
-
-      // Computed column: analyze its expression in the matched table's scope
-      if (analysisStack.has(col)) return diag(col.exprNode, 'Cycles are not allowed between computed columns', {sql: 'NULL', type: scalarType('error')})
-      analysisStack.add(col)
-      let expr = analyzeExpr(col.exprNode, {query: scope.query, table, alias, otherTables: scope.otherTables, fanoutPath: matches[0].fanoutPath})
-      analysisStack.delete(col)
-      return {
-        sql: `(${expr.sql})`,
-        type: expr.type,
-        isAgg: expr.isAgg,
-        fanout: expr.fanout,
+      case 'WindowExpression': {
+        let baseNode = node.getChild('FunctionCall') || node.getChild('Count')
+        if (!baseNode) return this.diag(node, 'Window expressions require a function call', {sql: 'NULL', type: scalarType('error')})
+        let isPercentile = this.isPercentileFunctionCall(baseNode)
+        if (isPercentile && !this.isPercentileWindowSpecSupported(node.getChild('OverClause')!)) {
+          return this.diag(node.getChild('OverClause')!, 'pXX window form currently supports PARTITION BY only', {sql: 'NULL', type: scalarType('error')})
+        }
+        let base = baseNode.name == 'FunctionCall' ? analyzeFunction(this, baseNode, scope, {isWindow: true}) : this.analyzeExpr(baseNode, scope)
+        if (isScalarType(base.type, 'error')) return base
+        if (!base.canWindow) return this.diag(baseNode, 'Only aggregate or window functions can use OVER', {sql: 'NULL', type: scalarType('error')})
+        let over = this.renderOverClause(node.getChild('OverClause')!, scope)
+        return {sql: `${base.sql} OVER (${over})`, type: base.type, isAgg: false}
       }
-    }
 
-    case 'FunctionCall':
-      return analyzeFunction(node, scope, analyzeExpr)
-
-    case 'WindowExpression': {
-      let baseNode = node.getChild('FunctionCall') || node.getChild('Count')
-      if (!baseNode) return diag(node, 'Window expressions require a function call', {sql: 'NULL', type: scalarType('error')})
-      let isPercentile = isPercentileFunctionCall(baseNode)
-      if (isPercentile && !isPercentileWindowSpecSupported(node.getChild('OverClause')!)) {
-        return diag(node.getChild('OverClause')!, 'pXX window form currently supports PARTITION BY only', {sql: 'NULL', type: scalarType('error')})
+      case 'Parenthetical': {
+        let inner = this.analyzeExpr(node.getChild('Expression')!, scope)
+        return {...inner, sql: `(${inner.sql})`}
       }
-      let base = baseNode.name == 'FunctionCall' ? analyzeFunction(baseNode, scope, analyzeExpr, {isWindow: true}) : analyzeExpr(baseNode, scope)
-      if (isScalarType(base.type, 'error')) return base
-      if (!base.canWindow) return diag(baseNode, 'Only aggregate or window functions can use OVER', {sql: 'NULL', type: scalarType('error')})
-      let over = renderOverClause(node.getChild('OverClause')!, scope)
-      return {sql: `${base.sql} OVER (${over})`, type: base.type, isAgg: false}
-    }
 
-    case 'Parenthetical': {
-      let inner = analyzeExpr(node.getChild('Expression')!, scope)
-      return {...inner, sql: `(${inner.sql})`}
-    }
-
-    case 'Count': {
-      let inner = node.getChild('Expression')
-      if (inner) {
-        let e = analyzeExpr(inner, scope)
+      case 'Count': {
+        let inner = node.getChild('Expression')
+        if (inner) {
+          let expr = this.analyzeExpr(inner, scope)
+          return {
+            sql: `count(distinct ${expr.sql})`,
+            type: scalarType('number'),
+            isAgg: true,
+            canWindow: true,
+            fanout: normalizeExprFanout({sensitivePaths: mergeSensitiveFanouts(expr.fanout?.sensitivePaths), conflict: expr.fanout?.conflict}),
+          }
+        }
         return {
-          sql: `count(distinct ${e.sql})`,
+          sql: 'count(1)',
           type: scalarType('number'),
           isAgg: true,
           canWindow: true,
-          fanout: normalizeExprFanout({
-            sensitivePaths: mergeSensitiveFanouts(e.fanout?.sensitivePaths),
-            conflict: e.fanout?.conflict,
-          }),
-        }
-      }
-      return {
-        sql: 'count(1)',
-        type: scalarType('number'),
-        isAgg: true,
-        canWindow: true,
-        fanout: normalizeExprFanout({sensitivePaths: [extendFanoutPath(scope.fanoutPath)]}),
-      }
-    }
-
-    case 'BinaryExpression':
-    case 'OrExpression':
-    case 'AndExpression':
-    case 'ComparisonExpression':
-    case 'AddExpression':
-    case 'MultiplyExpression': {
-      let left = analyzeExpr(node.firstChild!, scope)
-      let right = analyzeExpr(node.lastChild!, scope)
-      let op = txt(node.firstChild?.nextSibling).toLowerCase()
-
-      // Type coercion for dates
-      if ((isScalarType(left.type, 'date') || isScalarType(left.type, 'timestamp')) && isScalarType(right.type, 'string')) {
-        right = coerceToTemporal(right, left.type, node.lastChild!)
-      }
-      if ((isScalarType(right.type, 'date') || isScalarType(right.type, 'timestamp')) && isScalarType(left.type, 'string')) {
-        left = coerceToTemporal(left, right.type, node.firstChild!)
-      }
-
-      // Date arithmetic
-      if (op == '+' || op == '-') {
-        if (isScalarType(left.type, 'date') || isScalarType(left.type, 'timestamp') || isScalarType(left.type, 'interval') || isScalarType(right.type, 'interval')) {
-          return analyzeDateArithmetic(op, left, right, node)
+          fanout: normalizeExprFanout({sensitivePaths: [extendFanoutPath(scope.fanoutPath)]}),
         }
       }
 
-      // Type checking for operators
-      if (op == '*') {
-        let multiplied = analyzeIntervalMultiplication(left, right, node)
-        if (multiplied) return multiplied
-      }
-      if (op == '*' || op == '/' || op == '%') {
-        checkTypes(left, ['number'], node.firstChild!)
-        checkTypes(right, ['number'], node.lastChild!)
-      }
-      if (op == 'like' || op == 'ilike') {
-        checkTypes(left, ['string'], node.firstChild!)
-        checkTypes(right, ['string'], node.lastChild!)
-      }
-      if (op == '||') {
-        checkTypes(left, ['string'], node.firstChild!)
-        checkTypes(right, ['string'], node.lastChild!)
-      }
+      case 'BinaryExpression':
+      case 'OrExpression':
+      case 'AndExpression':
+      case 'ComparisonExpression':
+      case 'AddExpression':
+      case 'MultiplyExpression': {
+        let left = this.analyzeExpr(node.firstChild!, scope)
+        let right = this.analyzeExpr(node.lastChild!, scope)
+        let op = txt(node.firstChild?.nextSibling).toLowerCase()
 
-      let resultType = left.type
-      if (['and', 'or', '<', '<=', '>', '>=', '=', '!=', '<>', 'like', 'ilike'].includes(op)) resultType = scalarType('boolean')
-      if (op == '||') resultType = scalarType('string')
-      if (op == '<>') op = '!='
+        // Type coercion for dates
+        if ((isScalarType(left.type, 'date') || isScalarType(left.type, 'timestamp')) && isScalarType(right.type, 'string')) {
+          right = this.coerceToTemporal(right, left.type, node.lastChild!)
+        }
+        if ((isScalarType(right.type, 'date') || isScalarType(right.type, 'timestamp')) && isScalarType(left.type, 'string')) {
+          left = this.coerceToTemporal(left, right.type, node.firstChild!)
+        }
 
-      // ILIKE handling for BigQuery
-      let sql: string
-      if (op == 'ilike' && config.dialect == 'bigquery') {
-        sql = `LOWER(${left.sql}) LIKE LOWER(${right.sql})`
-      } else if (op == 'and' || op == 'or') {
-        sql = `(${left.sql} ${op.toUpperCase()} ${right.sql})`
-      } else if (op == 'like' || op == 'ilike') {
-        sql = `${left.sql} ${op.toUpperCase()} ${right.sql}`
-      } else {
-        sql = `${left.sql}${op}${right.sql}`
-      }
+        // Date arithmetic
+        if (op == '+' || op == '-') {
+          if (isScalarType(left.type, 'date') || isScalarType(left.type, 'timestamp') || isScalarType(left.type, 'interval') || isScalarType(right.type, 'interval')) {
+            return this.analyzeDateArithmetic(op, left, right, node)
+          }
+        }
 
-      return mergeExprAnalysis([left, right], sql, resultType, left.isAgg || right.isAgg)
-    }
+        // Type checking for operators
+        if (op == '*') {
+          let multiplied = this.analyzeIntervalMultiplication(left, right, node)
+          if (multiplied) return multiplied
+        }
+        if (op == '*' || op == '/' || op == '%') {
+          this.checkTypes(left, ['number'], node.firstChild!)
+          this.checkTypes(right, ['number'], node.lastChild!)
+        }
+        if (op == 'like' || op == 'ilike') {
+          this.checkTypes(left, ['string'], node.firstChild!)
+          this.checkTypes(right, ['string'], node.lastChild!)
+        }
+        if (op == '||') {
+          this.checkTypes(left, ['string'], node.firstChild!)
+          this.checkTypes(right, ['string'], node.lastChild!)
+        }
 
-    case 'UnaryExpression': {
-      let op = txt(node.firstChild).toLowerCase()
-      let child = analyzeExpr(node.lastChild!, scope)
-      if (op == 'not') return {sql: `NOT (${child.sql})`, type: scalarType('boolean'), isAgg: child.isAgg, fanout: child.fanout}
-      if (op == '-') return {sql: `-(${child.sql})`, type: child.type, isAgg: child.isAgg, fanout: child.fanout}
-      if (op == '+') return {sql: `(${child.sql})`, type: child.type, isAgg: child.isAgg, fanout: child.fanout}
-      return diag(node, `Unknown unary operator: ${op}`, {sql: 'NULL', type: scalarType('error')})
-    }
+        let resultType = left.type
+        if (['and', 'or', '<', '<=', '>', '>=', '=', '!=', '<>', 'like', 'ilike'].includes(op)) resultType = scalarType('boolean')
+        if (op == '||') resultType = scalarType('string')
+        if (op == '<>') op = '!='
 
-    case 'NullTestExpression': {
-      let isNot = !!node.getChildren('Kw').find(n => txt(n).toLowerCase() == 'not')
-      let e = analyzeExpr(node.firstChild!, scope)
-      return {sql: `${e.sql} IS ${isNot ? 'NOT ' : ''}NULL`, type: scalarType('boolean'), isAgg: e.isAgg, fanout: e.fanout}
-    }
+        // ILIKE handling for BigQuery
+        let sql: string
+        if (op == 'ilike' && this.config.dialect == 'bigquery') {
+          sql = `LOWER(${left.sql}) LIKE LOWER(${right.sql})`
+        } else if (op == 'and' || op == 'or') {
+          sql = `(${left.sql} ${op.toUpperCase()} ${right.sql})`
+        } else if (op == 'like' || op == 'ilike') {
+          sql = `${left.sql} ${op.toUpperCase()} ${right.sql}`
+        } else {
+          sql = `${left.sql}${op}${right.sql}`
+        }
 
-    case 'CaseExpression': {
-      let parts = ['CASE']
-      let isAgg = false
-      let fanoutExprs: Expr[] = []
-      let caseValue = node.getChild('Expression')
-      if (caseValue) {
-        let e = analyzeExpr(caseValue, scope)
-        parts.push(e.sql)
-        isAgg ||= !!e.isAgg
-        fanoutExprs.push(e)
+        return this.mergeExprAnalysis([left, right], sql, resultType, left.isAgg || right.isAgg)
       }
 
-      let resultType: FieldType = scalarType('string')
-      for (let w of node.getChildren('WhenClause')) {
-        let exprs = w.getChildren('Expression')
-        let when = analyzeExpr(exprs[0], scope)
-        let then = analyzeExpr(exprs[1], scope)
-        resultType = then.type
-        isAgg ||= !!when.isAgg || !!then.isAgg
-        fanoutExprs.push(when, then)
-        parts.push(`WHEN (${when.sql}) THEN ${then.sql}`)
+      case 'UnaryExpression': {
+        let op = txt(node.firstChild).toLowerCase()
+        let child = this.analyzeExpr(node.lastChild!, scope)
+        if (op == 'not') return {sql: `NOT (${child.sql})`, type: scalarType('boolean'), isAgg: child.isAgg, fanout: child.fanout}
+        if (op == '-') return {sql: `-(${child.sql})`, type: child.type, isAgg: child.isAgg, fanout: child.fanout}
+        if (op == '+') return {sql: `(${child.sql})`, type: child.type, isAgg: child.isAgg, fanout: child.fanout}
+        return this.diag(node, `Unknown unary operator: ${op}`, {sql: 'NULL', type: scalarType('error')})
       }
 
-      let elseClause = node.getChild('ElseClause')
-      if (elseClause) {
-        let elseExpr = analyzeExpr(elseClause.getChild('Expression')!, scope)
-        parts.push(`ELSE ${elseExpr.sql}`)
-        isAgg ||= !!elseExpr.isAgg
-        fanoutExprs.push(elseExpr)
+      case 'NullTestExpression': {
+        let isNot = !!node.getChildren('Kw').find(next => txt(next).toLowerCase() == 'not')
+        let expr = this.analyzeExpr(node.firstChild!, scope)
+        return {sql: `${expr.sql} IS ${isNot ? 'NOT ' : ''}NULL`, type: scalarType('boolean'), isAgg: expr.isAgg, fanout: expr.fanout}
       }
-      parts.push('END')
-      return mergeExprAnalysis(fanoutExprs, parts.join(' '), resultType, isAgg || undefined)
-    }
 
-    case 'InExpression': {
-      let not = txt(node.getChild('Kw')).toLowerCase() == 'not'
-      let e = analyzeExpr(node.firstChild!, scope)
-      let valueList = node.getChild('InValueList')
-      let subqueryNode = node.getChild('QueryExpression')
-      if (subqueryNode) {
-        let subquery = analyzeQuery(subqueryNode, scope.otherTables)
+      case 'CaseExpression': {
+        let parts = ['CASE']
+        let isAgg = false
+        let fanoutExprs: Expr[] = []
+        let caseValue = node.getChild('Expression')
+        if (caseValue) {
+          let expr = this.analyzeExpr(caseValue, scope)
+          parts.push(expr.sql)
+          isAgg ||= !!expr.isAgg
+          fanoutExprs.push(expr)
+        }
+
+        let resultType: FieldType = scalarType('string')
+        for (let when of node.getChildren('WhenClause')) {
+          let exprs = when.getChildren('Expression')
+          let whenExpr = this.analyzeExpr(exprs[0], scope)
+          let thenExpr = this.analyzeExpr(exprs[1], scope)
+          resultType = thenExpr.type
+          isAgg ||= !!whenExpr.isAgg || !!thenExpr.isAgg
+          fanoutExprs.push(whenExpr, thenExpr)
+          parts.push(`WHEN (${whenExpr.sql}) THEN ${thenExpr.sql}`)
+        }
+
+        let elseClause = node.getChild('ElseClause')
+        if (elseClause) {
+          let elseExpr = this.analyzeExpr(elseClause.getChild('Expression')!, scope)
+          parts.push(`ELSE ${elseExpr.sql}`)
+          isAgg ||= !!elseExpr.isAgg
+          fanoutExprs.push(elseExpr)
+        }
+        parts.push('END')
+        return this.mergeExprAnalysis(fanoutExprs, parts.join(' '), resultType, isAgg || undefined)
+      }
+
+      case 'InExpression': {
+        let not = txt(node.getChild('Kw')).toLowerCase() == 'not'
+        let expr = this.analyzeExpr(node.firstChild!, scope)
+        let valueList = node.getChild('InValueList')
+        let subqueryNode = node.getChild('QueryExpression')
+        if (subqueryNode) {
+          let subquery = this.analyzeQuery(subqueryNode, scope.otherTables)
+          if (!subquery) return {sql: 'NULL', type: scalarType('error')}
+          if (subquery.fields.length != 1) return this.diag(subqueryNode, 'Subquery in IN must return exactly one column', {sql: 'NULL', type: scalarType('error')})
+          return {sql: `${expr.sql} ${not ? 'NOT IN' : 'IN'} (${subquery.sql})`, type: scalarType('boolean'), isAgg: expr.isAgg, fanout: expr.fanout}
+        }
+        if (!valueList) return this.diag(node, 'IN expression must provide either values or a subquery', {sql: 'NULL', type: scalarType('error')})
+        let values = valueList.getChildren('Expression').map(valueNode => {
+          let value = this.analyzeExpr(valueNode, scope)
+          // Coerce string literals to temporal types if needed
+          if ((isScalarType(expr.type, 'date') || isScalarType(expr.type, 'timestamp')) && isScalarType(value.type, 'string')) {
+            value = this.coerceToTemporal(value, expr.type, valueNode)
+          }
+          return value.sql
+        })
+        return {sql: `${expr.sql} ${not ? 'NOT IN' : 'IN'} (${values.join(',')})`, type: scalarType('boolean'), isAgg: expr.isAgg, fanout: expr.fanout}
+      }
+
+      case 'BetweenExpression': {
+        let not = !!node
+          .getChildren('Kw')
+          .map(next => txt(next).toLowerCase())
+          .find(next => next == 'not')
+        let [exprNode, lowNode, highNode] = node.getChildren('Expression')
+        let [expr, low, high] = [exprNode, lowNode, highNode].map(next => this.analyzeExpr(next, scope))
+
+        if (isScalarType(expr.type, 'date') || isScalarType(expr.type, 'timestamp')) {
+          low = this.coerceToTemporal(low, expr.type, lowNode)
+          high = this.coerceToTemporal(high, expr.type, highNode)
+        }
+
+        let sql = `${expr.sql} ${not ? 'NOT BETWEEN' : 'BETWEEN'} ${low.sql} AND ${high.sql}`
+        return this.mergeExprAnalysis([expr, low, high], sql, scalarType('boolean'), expr.isAgg || low.isAgg || high.isAgg)
+      }
+
+      case 'SubqueryExpression': {
+        let subquery = this.analyzeQuery(node.getChild('QueryExpression')!, scope.otherTables)
         if (!subquery) return {sql: 'NULL', type: scalarType('error')}
-        if (subquery.fields.length != 1) return diag(subqueryNode, 'Subquery in IN must return exactly one column', {sql: 'NULL', type: scalarType('error')})
-        return {sql: `${e.sql} ${not ? 'NOT IN' : 'IN'} (${subquery.sql})`, type: scalarType('boolean'), isAgg: e.isAgg, fanout: e.fanout}
+        if (subquery.fields.length != 1) return this.diag(node, 'Subquery expression must return exactly one column', {sql: 'NULL', type: scalarType('error')})
+        return {sql: `(${subquery.sql})`, type: subquery.fields[0].type}
       }
-      if (!valueList) {
-        return diag(node, 'IN expression must provide either values or a subquery', {sql: 'NULL', type: scalarType('error')})
+
+      case 'CastExpression':
+      case 'TypeCastExpression': {
+        let inner = node.getChild('Expression') || node.firstChild!
+        let expr = this.analyzeExpr(inner, scope)
+        let typeNode = node.getChild('CastType')!
+        let targetType = txt(typeNode).toUpperCase()
+        let parsed = parseGsqlFieldType(targetType)
+        if (parsed.error) return this.diag(typeNode, parsed.error, {sql: 'NULL', type: scalarType('error')})
+        if (!parsed.type) return this.diag(typeNode, `Unsupported cast type: ${targetType.toLowerCase()}`, {sql: 'NULL', type: scalarType('error')})
+        let resultType = parsed.type
+        return {...expr, sql: `CAST(${expr.sql} AS ${targetType})`, type: this.preserveTemporalMetadataThroughCast(expr, resultType)}
       }
-      let values = valueList.getChildren('Expression').map(v => {
-        let val = analyzeExpr(v, scope)
-        // Coerce string literals to temporal types if needed
-        if ((isScalarType(e.type, 'date') || isScalarType(e.type, 'timestamp')) && isScalarType(val.type, 'string')) {
-          val = coerceToTemporal(val, e.type, v)
+
+      case 'ExtractExpression': {
+        let extractInner = node.getChild('Expression')!
+        let expr = this.analyzeExpr(extractInner, scope)
+        this.checkTypes(expr, ['date', 'timestamp'], extractInner)
+        let unit = txt(node.getChild('ExtractUnit')!)
+          .replace(/^['"]|['"]$/g, '')
+          .toLowerCase()
+        return {sql: `EXTRACT(${unit} FROM ${expr.sql})`, type: scalarType('number'), isAgg: expr.isAgg, fanout: expr.fanout}
+      }
+
+      case 'IntervalExpression': {
+        let stringNode = node.getChild('String')
+        if (stringNode) {
+          let parsed = parseIntervalLiteral(txt(stringNode).slice(1, -1))
+          if (!parsed) return this.diag(stringNode, 'Could not parse interval', {sql: 'NULL', type: scalarType('error')})
+          return {
+            sql: `interval ${parsed.quantity} ${parsed.unit}`,
+            type: scalarType('interval'),
+            interval: {quantitySql: String(parsed.quantity), unit: parsed.unit, form: 'constant'},
+          }
         }
-        return val.sql
-      })
-      return {sql: `${e.sql} ${not ? 'NOT IN' : 'IN'} (${values.join(',')})`, type: scalarType('boolean'), isAgg: e.isAgg, fanout: e.fanout}
-    }
-
-    case 'BetweenExpression': {
-      let not = !!node
-        .getChildren('Kw')
-        .map(n => txt(n).toLowerCase())
-        .find(k => k == 'not')
-      let [eNode, lowNode, highNode] = node.getChildren('Expression')
-      let [e, low, high] = [eNode, lowNode, highNode].map(n => analyzeExpr(n, scope))
-
-      if (isScalarType(e.type, 'date') || isScalarType(e.type, 'timestamp')) {
-        low = coerceToTemporal(low, e.type, lowNode)
-        high = coerceToTemporal(high, e.type, highNode)
-      }
-
-      let sql = `${e.sql} ${not ? 'NOT BETWEEN' : 'BETWEEN'} ${low.sql} AND ${high.sql}`
-      return mergeExprAnalysis([e, low, high], sql, scalarType('boolean'), e.isAgg || low.isAgg || high.isAgg)
-    }
-
-    case 'SubqueryExpression': {
-      let subquery = analyzeQuery(node.getChild('QueryExpression')!, scope.otherTables)
-      if (!subquery) return {sql: 'NULL', type: scalarType('error')}
-      if (subquery.fields.length != 1) return diag(node, 'Subquery expression must return exactly one column', {sql: 'NULL', type: scalarType('error')})
-      return {sql: `(${subquery.sql})`, type: subquery.fields[0].type}
-    }
-
-    case 'CastExpression':
-    case 'TypeCastExpression': {
-      let inner = node.getChild('Expression') || node.firstChild!
-      let e = analyzeExpr(inner, scope)
-      let typeNode = node.getChild('CastType')!
-      let targetType = txt(typeNode).toUpperCase()
-      let parsed = parseGsqlFieldType(targetType)
-      if (parsed.error) return diag(typeNode, parsed.error, {sql: 'NULL', type: scalarType('error')})
-      if (!parsed.type) return diag(typeNode, `Unsupported cast type: ${targetType.toLowerCase()}`, {sql: 'NULL', type: scalarType('error')})
-      let resultType = parsed.type
-      return {...e, sql: `CAST(${e.sql} AS ${targetType})`, type: preserveTemporalMetadataThroughCast(e, resultType)}
-    }
-
-    case 'ExtractExpression': {
-      let extractInner = node.getChild('Expression')!
-      let e = analyzeExpr(extractInner, scope)
-      checkTypes(e, ['date', 'timestamp'], extractInner)
-      let unit = txt(node.getChild('ExtractUnit')!)
-        .replace(/^['"]|['"]$/g, '')
-        .toLowerCase()
-      return {sql: `EXTRACT(${unit} FROM ${e.sql})`, type: scalarType('number'), isAgg: e.isAgg, fanout: e.fanout}
-    }
-
-    case 'IntervalExpression': {
-      let stringNode = node.getChild('String')
-      if (stringNode) {
-        let parsed = parseIntervalLiteral(txt(stringNode).slice(1, -1))
-        if (!parsed) return diag(stringNode, 'Could not parse interval', {sql: 'NULL', type: scalarType('error')})
+        let quantityNode = node.getChild('Number') || node.getChild('Ref')
+        if (!quantityNode) return this.diag(node, 'Interval requires a quantity before the unit', {sql: 'NULL', type: scalarType('error')})
+        let quantity = this.analyzeExpr(quantityNode, scope)
+        this.checkTypes(quantity, ['number'], quantityNode)
+        let unit = parseIntervalUnit(txt(node.getChild('IntervalUnit')!).toLowerCase())
+        if (!unit) return this.diag(node, 'Invalid interval unit', {sql: 'NULL', type: scalarType('error')})
         return {
-          sql: `interval ${parsed.quantity} ${parsed.unit}`,
+          ...quantity,
+          sql: `INTERVAL ${quantity.sql} ${unit}`,
           type: scalarType('interval'),
-          interval: {quantitySql: String(parsed.quantity), unit: parsed.unit, form: 'constant'},
+          interval: {quantitySql: quantity.sql, unit, form: quantityNode.name == 'Number' ? 'constant' : 'dynamic'},
         }
       }
-      let quantityNode = node.getChild('Number') || node.getChild('Ref')
-      if (!quantityNode) return diag(node, 'Interval requires a quantity before the unit', {sql: 'NULL', type: scalarType('error')})
-      let quantity = analyzeExpr(quantityNode, scope)
-      checkTypes(quantity, ['number'], quantityNode)
-      let unit = parseIntervalUnit(txt(node.getChild('IntervalUnit')!).toLowerCase())
-      if (!unit) return diag(node, 'Invalid interval unit', {sql: 'NULL', type: scalarType('error')})
-      return {
-        ...quantity,
-        sql: `INTERVAL ${quantity.sql} ${unit}`,
-        type: scalarType('interval'),
-        interval: {quantitySql: quantity.sql, unit, form: quantityNode.name == 'Number' ? 'constant' : 'dynamic'},
+
+      case 'DateExpression':
+      case 'TimestampExpression': {
+        let isDate = node.name == 'DateExpression'
+        let lit = txt(node.getChild('String')!).slice(1, -1)
+        let parsed = parseTemporalLiteral(lit, isDate ? 'date' : 'timestamp')
+        if (!parsed) return this.diag(node, `Invalid ${isDate ? 'date' : 'timestamp'}`, {sql: 'NULL', type: scalarType('error')})
+        return {sql: `${isDate ? 'DATE' : 'TIMESTAMP'} '${parsed.literal}'`, type: isDate ? scalarType('date') : scalarType('timestamp')}
       }
-    }
 
-    case 'DateExpression':
-    case 'TimestampExpression': {
-      let isDate = node.name == 'DateExpression'
-      let lit = txt(node.getChild('String')!).slice(1, -1)
-      let parsed = parseTemporalLiteral(lit, isDate ? 'date' : 'timestamp')
-      if (!parsed) return diag(node, `Invalid ${isDate ? 'date' : 'timestamp'}`, {sql: 'NULL', type: scalarType('error')})
-      return {sql: `${isDate ? 'DATE' : 'TIMESTAMP'} '${parsed.literal}'`, type: isDate ? scalarType('date') : scalarType('timestamp')}
-    }
-
-    default:
-      return diag(node, `Unsupported expression: ${node.name}`, {sql: 'NULL', type: scalarType('error')})
-  }
-}
-
-function analyzeDateArithmetic(op: '+' | '-', left: Expr, right: Expr, node: SyntaxNode): Expr {
-  let merged = mergeExprAnalysis([left, right], '', scalarType('number'), left.isAgg || right.isAgg)
-
-  // date - date = interval
-  if ((isScalarType(left.type, 'date') || isScalarType(left.type, 'timestamp')) && (isScalarType(right.type, 'date') || isScalarType(right.type, 'timestamp'))) {
-    if (op != '-') return diag(node, 'Can only subtract dates', {sql: 'NULL', type: scalarType('error')})
-    let unit = isScalarType(left.type, 'timestamp') ? 'SECOND' : 'DAY'
-    if (config.dialect == 'bigquery') {
-      return {...merged, sql: `TIMESTAMP_DIFF(${left.sql}, ${right.sql}, ${unit})`, type: scalarType('number')}
-    }
-    if (config.dialect == 'snowflake') {
-      return {...merged, sql: `TIMESTAMPDIFF(${unit}, ${right.sql}, ${left.sql})`, type: scalarType('number')}
-    }
-    return {...merged, sql: `DATE_DIFF('${unit.toLowerCase()}', ${right.sql}, ${left.sql})`, type: scalarType('number')}
-  }
-
-  // date +/- interval
-  if ((isScalarType(left.type, 'date') || isScalarType(left.type, 'timestamp')) && isScalarType(right.type, 'interval')) {
-    if (!right.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: scalarType('error')})
-    return {...merged, sql: renderTemporalArithmetic(config.dialect, left.sql, left.type.kind, op, right.interval), type: left.type}
-  }
-
-  // interval + date (normalize to date + interval)
-  if (isScalarType(left.type, 'interval') && (isScalarType(right.type, 'date') || isScalarType(right.type, 'timestamp'))) {
-    if (op == '-') return diag(node, 'Cannot subtract date from interval', {sql: 'NULL', type: scalarType('error')})
-    if (!left.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: scalarType('error')})
-    return {...merged, sql: renderTemporalArithmetic(config.dialect, right.sql, right.type.kind, '+', left.interval), type: right.type}
-  }
-
-  return diag(node, 'Invalid date arithmetic', {sql: 'NULL', type: scalarType('error')})
-}
-
-function analyzeIntervalMultiplication(left: Expr, right: Expr, node: SyntaxNode): Expr | null {
-  if (isScalarType(left.type, 'number') && isScalarType(right.type, 'interval')) {
-    return scaleInterval(left, right, node.lastChild!)
-  }
-  if (isScalarType(left.type, 'interval') && isScalarType(right.type, 'number')) {
-    return scaleInterval(right, left, node.firstChild!)
-  }
-  return null
-}
-
-function scaleInterval(multiplier: Expr, intervalExpr: Expr, node: SyntaxNode): Expr {
-  if (!intervalExpr.interval) return diag(node, 'Invalid interval expression', {sql: 'NULL', type: scalarType('error')})
-  if (intervalExpr.interval.form != 'constant') return diag(node, 'Only literal intervals can be multiplied', {sql: 'NULL', type: scalarType('error')})
-  let quantitySql = intervalExpr.interval.quantitySql == '1' ? multiplier.sql : `${multiplier.sql}*${intervalExpr.interval.quantitySql}`
-  return {
-    sql: renderStandaloneInterval(config.dialect, {quantitySql, unit: intervalExpr.interval.unit, form: 'scaled'}),
-    type: scalarType('interval'),
-    isAgg: multiplier.isAgg || intervalExpr.isAgg,
-    interval: {quantitySql, unit: intervalExpr.interval.unit, form: 'scaled'},
-  }
-}
-
-function coerceToTemporal(expr: Expr, targetType: FieldType, node: SyntaxNode): Expr {
-  if (!isScalarType(targetType, 'date') && !isScalarType(targetType, 'timestamp')) return expr
-  // Extract the string literal value (remove quotes)
-  let match = expr.sql.match(/^'(.+)'$/)
-  if (!match) return expr
-  let parsed = parseTemporalLiteral(match[1], targetType.kind)
-  if (!parsed) {
-    diag(node, `Cannot parse as ${targetType.kind}: ${expr.sql}`)
-    return expr
-  }
-  return {...expr, sql: `${targetType.kind.toUpperCase()} '${parsed.literal}'`, type: scalarType(targetType.kind)}
-}
-
-function preserveTemporalMetadataThroughCast(expr: Expr, resultType: FieldType) {
-  let metadata = expr.type.metadata
-  if (!metadata?.temporal) return resultType
-  if (!isScalarType(resultType, 'date') && !isScalarType(resultType, 'timestamp')) return resultType
-  return withTypeMetadata(resultType, metadata)
-}
-
-function sameFieldMetadata(left?: FieldType, right?: FieldType) {
-  let leftMetadata = left?.metadata
-  let rightMetadata = right?.metadata
-  if (!leftMetadata && !rightMetadata) return true
-  if (!leftMetadata || !rightMetadata) return false
-  return sameTemporalMetadata(leftMetadata.temporal, rightMetadata.temporal)
-}
-
-function sameTemporalMetadata(left?: TemporalFieldMetadata, right?: TemporalFieldMetadata) {
-  if (!left && !right) return true
-  if (!left || !right) return false
-  return left.grain == right.grain
-}
-
-function isPercentileFunctionCall(node: SyntaxNode): boolean {
-  if (node.name != 'FunctionCall') return false
-  let name = txt(node.getChild('Identifier')).toLowerCase()
-  return /^p\d+$/.test(name)
-}
-
-function isPercentileWindowSpecSupported(overClause: SyntaxNode): boolean {
-  let spec = overClause.getChild('WindowSpec')
-  if (!spec) return true
-  if (spec.getChild('WindowOrderByClause')) return false
-  if (spec.getChild('WindowFrameClause')) return false
-  return true
-}
-
-function renderOverClause(overClause: SyntaxNode, scope: Scope): string {
-  let spec = overClause.getChild('WindowSpec')
-  if (!spec) return ''
-  let parts: string[] = []
-
-  let partition = spec.getChild('WindowPartitionClause')
-  if (partition) {
-    let exprs = partition.getChildren('Expression').map(e => analyzeExpr(e, scope).sql)
-    parts.push(`PARTITION BY ${exprs.join(', ')}`)
-  }
-
-  let orderBy = spec.getChild('WindowOrderByClause')
-  if (orderBy) {
-    let items = orderBy.getChildren('WindowOrderItem').map(item => {
-      let expr = analyzeExpr(item.getChild('Expression')!, scope).sql
-      let desc = txt(item.getChild('Kw')).toLowerCase() == 'desc'
-      return `${expr} ${desc ? 'DESC' : 'ASC'}`
-    })
-    parts.push(`ORDER BY ${items.join(', ')}`)
-  }
-
-  let frame = spec.getChild('WindowFrameClause')
-  if (frame) parts.push(renderWindowFrame(frame, scope))
-
-  return parts.join(' ')
-}
-
-function renderWindowFrame(frame: SyntaxNode, scope: Scope): string {
-  let mode = txt(frame.getChildren('Kw')[0]).toUpperCase()
-  let between = frame.getChild('WindowFrameBetween')
-  if (between) {
-    let bounds = between.getChildren('WindowFrameBound').map(b => renderWindowBound(b, scope))
-    return `${mode} BETWEEN ${bounds[0]} AND ${bounds[1]}`
-  }
-  let start = frame.getChild('WindowFrameStart')!.getChild('WindowFrameBound')!
-  return `${mode} ${renderWindowBound(start, scope)}`
-}
-
-function renderWindowBound(bound: SyntaxNode, scope: Scope): string {
-  let kws = bound.getChildren('Kw').map(k => txt(k).toLowerCase())
-  if (kws.includes('unbounded')) {
-    return `UNBOUNDED ${kws.includes('following') ? 'FOLLOWING' : 'PRECEDING'}`
-  }
-  if (kws.includes('current')) return 'CURRENT ROW'
-  let expr = analyzeExpr(bound.getChild('Expression')!, scope).sql
-  return `${expr} ${kws.includes('following') ? 'FOLLOWING' : 'PRECEDING'}`
-}
-
-// Traverse a join path (like `tableA.tableB.`), returning a new scope pointing to the target table. Adds implied joins to the query as it goes
-function followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
-  let part = pathNodes[0]
-  let name = txt(part)
-
-  if (pathNodes.length == 0) return scope
-
-  // If we're analyzing an ON clause, any path nodes must point at the source or target table
-  if (scope.joinTarget) {
-    let pointsAtSource = !!scope.table && name == scope.alias
-    let pointsAtTarget = name == scope.joinTarget.alias || name == scope.joinTarget.name
-    if (!pointsAtSource && !pointsAtTarget) return diag(pathNodes[0], 'Joins must point at either the source or target table', null)
-
-    let table = pointsAtTarget ? scope.joinTarget.table : scope.table!
-    let alias = pointsAtTarget ? scope.joinTarget.alias : scope.alias
-    NODE_ENTITY_MAP.set(pathNodes[0], {entityType: 'table', table})
-    addReference('table', pathNodes[0], table.symbolId)
-    return {query: scope.query, table, alias, fanoutPath: scope.fanoutPath, otherTables: scope.otherTables}
-  }
-
-  // If scope is at the root of the table (ie scope.table == null), then the first part of the path could point at
-  // the alias of any table in the FROM or JOIN clauses of a query.
-  // But it could also refer to a join _on_ one of those tables (assuming the name is unique).
-  if (!scope.table) {
-    // This could be a ref to an existing FROM/JOIN alias
-    let existing = scope.query!.joins.find(j => j.alias == name)
-    if (existing) {
-      if (!existing.table) return diag(part, `"${name}" is an unnested value, not a table`, null)
-      NODE_ENTITY_MAP.set(part, {entityType: 'table', table: existing.table})
-      addReference('table', part, existing.table?.symbolId)
-      scope = {...scope, table: existing.table!, alias: existing.alias, fanoutPath: existing.fanoutPath}
-      pathNodes.shift() // remove, since we're updating scope
-    } else {
-      // otherwise, this might be referring to a join _on_ one of those FROM/JOIN tables
-      let matches = scope.query!.joins.filter(j => j.table && j.table.joins.some(jj => jj.alias == name))
-      if (matches.length > 1) return diag(part, `"${name}" matches multiple possible joins in this query`, null)
-      if (matches.length == 0) return diag(part, `Could not find "${name}" on query`, null)
-      scope = {...scope, table: matches[0].table!, alias: matches[0].alias, fanoutPath: matches[0].fanoutPath}
+      default:
+        return this.diag(node, `Unsupported expression: ${node.name}`, {sql: 'NULL', type: scalarType('error')})
     }
   }
 
-  // At this point we're guaranteed to have a scope.table, and from here it's easy. Each part of the path must be
-  // the name of a join on scope.table, and we just need to walk through each one updating our scope, and adding an implicit join to the query
-  for (let part of pathNodes) {
+  private analyzeDateArithmetic(op: '+' | '-', left: Expr, right: Expr, node: SyntaxNode): Expr {
+    let merged = this.mergeExprAnalysis([left, right], '', scalarType('number'), left.isAgg || right.isAgg)
+
+    // date - date = interval
+    if ((isScalarType(left.type, 'date') || isScalarType(left.type, 'timestamp')) && (isScalarType(right.type, 'date') || isScalarType(right.type, 'timestamp'))) {
+      if (op != '-') return this.diag(node, 'Can only subtract dates', {sql: 'NULL', type: scalarType('error')})
+      let unit = isScalarType(left.type, 'timestamp') ? 'SECOND' : 'DAY'
+      if (this.config.dialect == 'bigquery') return {...merged, sql: `TIMESTAMP_DIFF(${left.sql}, ${right.sql}, ${unit})`, type: scalarType('number')}
+      if (this.config.dialect == 'snowflake') return {...merged, sql: `TIMESTAMPDIFF(${unit}, ${right.sql}, ${left.sql})`, type: scalarType('number')}
+      return {...merged, sql: `DATE_DIFF('${unit.toLowerCase()}', ${right.sql}, ${left.sql})`, type: scalarType('number')}
+    }
+
+    // date +/- interval
+    if ((isScalarType(left.type, 'date') || isScalarType(left.type, 'timestamp')) && isScalarType(right.type, 'interval')) {
+      if (!right.interval) return this.diag(node, 'Invalid interval expression', {sql: 'NULL', type: scalarType('error')})
+      return {...merged, sql: renderTemporalArithmetic(this.config.dialect, left.sql, left.type.kind, op, right.interval), type: left.type}
+    }
+
+    // interval + date (normalize to date + interval)
+    if (isScalarType(left.type, 'interval') && (isScalarType(right.type, 'date') || isScalarType(right.type, 'timestamp'))) {
+      if (op == '-') return this.diag(node, 'Cannot subtract date from interval', {sql: 'NULL', type: scalarType('error')})
+      if (!left.interval) return this.diag(node, 'Invalid interval expression', {sql: 'NULL', type: scalarType('error')})
+      return {...merged, sql: renderTemporalArithmetic(this.config.dialect, right.sql, right.type.kind, '+', left.interval), type: right.type}
+    }
+
+    return this.diag(node, 'Invalid date arithmetic', {sql: 'NULL', type: scalarType('error')})
+  }
+
+  private analyzeIntervalMultiplication(left: Expr, right: Expr, node: SyntaxNode): Expr | null {
+    if (isScalarType(left.type, 'number') && isScalarType(right.type, 'interval')) return this.scaleInterval(left, right, node.lastChild!)
+    if (isScalarType(left.type, 'interval') && isScalarType(right.type, 'number')) return this.scaleInterval(right, left, node.firstChild!)
+    return null
+  }
+
+  private scaleInterval(multiplier: Expr, intervalExpr: Expr, node: SyntaxNode): Expr {
+    if (!intervalExpr.interval) return this.diag(node, 'Invalid interval expression', {sql: 'NULL', type: scalarType('error')})
+    if (intervalExpr.interval.form != 'constant') return this.diag(node, 'Only literal intervals can be multiplied', {sql: 'NULL', type: scalarType('error')})
+    let quantitySql = intervalExpr.interval.quantitySql == '1' ? multiplier.sql : `${multiplier.sql}*${intervalExpr.interval.quantitySql}`
+    return {
+      sql: renderStandaloneInterval(this.config.dialect, {quantitySql, unit: intervalExpr.interval.unit, form: 'scaled'}),
+      type: scalarType('interval'),
+      isAgg: multiplier.isAgg || intervalExpr.isAgg,
+      interval: {quantitySql, unit: intervalExpr.interval.unit, form: 'scaled'},
+    }
+  }
+
+  private coerceToTemporal(expr: Expr, targetType: FieldType, node: SyntaxNode): Expr {
+    if (!isScalarType(targetType, 'date') && !isScalarType(targetType, 'timestamp')) return expr
+    // Extract the string literal value (remove quotes)
+    let match = expr.sql.match(/^'(.+)'$/)
+    if (!match) return expr
+    let parsed = parseTemporalLiteral(match[1], targetType.kind)
+    if (!parsed) {
+      this.diag(node, `Cannot parse as ${targetType.kind}: ${expr.sql}`)
+      return expr
+    }
+    return {...expr, sql: `${targetType.kind.toUpperCase()} '${parsed.literal}'`, type: scalarType(targetType.kind)}
+  }
+
+  private preserveTemporalMetadataThroughCast(expr: Expr, resultType: FieldType) {
+    let metadata = expr.type.metadata
+    if (!metadata?.temporal) return resultType
+    if (!isScalarType(resultType, 'date') && !isScalarType(resultType, 'timestamp')) return resultType
+    return withTypeMetadata(resultType, metadata)
+  }
+
+  private sameFieldMetadata(left?: FieldType, right?: FieldType) {
+    let leftMetadata = left?.metadata
+    let rightMetadata = right?.metadata
+    if (!leftMetadata && !rightMetadata) return true
+    if (!leftMetadata || !rightMetadata) return false
+    return this.sameTemporalMetadata(leftMetadata.temporal, rightMetadata.temporal)
+  }
+
+  private sameTemporalMetadata(left?: TemporalFieldMetadata, right?: TemporalFieldMetadata) {
+    if (!left && !right) return true
+    if (!left || !right) return false
+    return left.grain == right.grain
+  }
+
+  private isPercentileFunctionCall(node: SyntaxNode): boolean {
+    if (node.name != 'FunctionCall') return false
+    let name = txt(node.getChild('Identifier')).toLowerCase()
+    return /^p\d+$/.test(name)
+  }
+
+  private isPercentileWindowSpecSupported(overClause: SyntaxNode): boolean {
+    let spec = overClause.getChild('WindowSpec')
+    if (!spec) return true
+    if (spec.getChild('WindowOrderByClause')) return false
+    if (spec.getChild('WindowFrameClause')) return false
+    return true
+  }
+
+  private renderOverClause(overClause: SyntaxNode, scope: Scope): string {
+    let spec = overClause.getChild('WindowSpec')
+    if (!spec) return ''
+    let parts: string[] = []
+
+    let partition = spec.getChild('WindowPartitionClause')
+    if (partition) {
+      let exprs = partition.getChildren('Expression').map(expr => this.analyzeExpr(expr, scope).sql)
+      parts.push(`PARTITION BY ${exprs.join(', ')}`)
+    }
+
+    let orderBy = spec.getChild('WindowOrderByClause')
+    if (orderBy) {
+      let items = orderBy.getChildren('WindowOrderItem').map(item => {
+        let expr = this.analyzeExpr(item.getChild('Expression')!, scope).sql
+        let desc = txt(item.getChild('Kw')).toLowerCase() == 'desc'
+        return `${expr} ${desc ? 'DESC' : 'ASC'}`
+      })
+      parts.push(`ORDER BY ${items.join(', ')}`)
+    }
+
+    let frame = spec.getChild('WindowFrameClause')
+    if (frame) parts.push(this.renderWindowFrame(frame, scope))
+    return parts.join(' ')
+  }
+
+  private renderWindowFrame(frame: SyntaxNode, scope: Scope): string {
+    let mode = txt(frame.getChildren('Kw')[0]).toUpperCase()
+    let between = frame.getChild('WindowFrameBetween')
+    if (between) {
+      let bounds = between.getChildren('WindowFrameBound').map(bound => this.renderWindowBound(bound, scope))
+      return `${mode} BETWEEN ${bounds[0]} AND ${bounds[1]}`
+    }
+    let start = frame.getChild('WindowFrameStart')!.getChild('WindowFrameBound')!
+    return `${mode} ${this.renderWindowBound(start, scope)}`
+  }
+
+  private renderWindowBound(bound: SyntaxNode, scope: Scope): string {
+    let kws = bound.getChildren('Kw').map(keyword => txt(keyword).toLowerCase())
+    if (kws.includes('unbounded')) return `UNBOUNDED ${kws.includes('following') ? 'FOLLOWING' : 'PRECEDING'}`
+    if (kws.includes('current')) return 'CURRENT ROW'
+    let expr = this.analyzeExpr(bound.getChild('Expression')!, scope).sql
+    return `${expr} ${kws.includes('following') ? 'FOLLOWING' : 'PRECEDING'}`
+  }
+
+  // Traverse a join path (like `tableA.tableB.`), returning a new scope pointing to the target table. Adds implied joins to the query as it goes
+  private followJoins(pathNodes: SyntaxNode[], scope: Scope): Scope | null {
+    let part = pathNodes[0]
     let name = txt(part)
-    if (name == scope.alias || name == scope.table!.name) continue
+    if (pathNodes.length == 0) return scope
 
-    let table = scope.table!
-    let alias = scope.alias
-    let next = table.joins.find(j => j.alias == name)
-    if (!next) return diag(part, `Unknown join "${name}" on ${table.name}`, null)
+    // If we're analyzing an ON clause, any path nodes must point at the source or target table
+    if (scope.joinTarget) {
+      let pointsAtSource = !!scope.table && name == scope.alias
+      let pointsAtTarget = name == scope.joinTarget.alias || name == scope.joinTarget.name
+      if (!pointsAtSource && !pointsAtTarget) return this.diag(pathNodes[0], 'Joins must point at either the source or target table', null)
 
-    next.table = lookupTable(next.targetNode!)
-    if (!next.table) return null
-
-    // Construct a new implied join and attache it to the query
-    let fromAlias = scope.query?.joins.find(j => j.source == 'from')?.alias
-    let newAlias = alias == fromAlias ? name : `${alias}_${name}`
-    let fanoutPath = next.cardinality == 'many' ? extendFanoutPath(scope.fanoutPath, name) : extendFanoutPath(scope.fanoutPath)
-    if (scope.query && !scope.query.joins.find(j => j.alias == newAlias)) {
-      let joinTarget = {name: next.alias, table: next.table, alias: newAlias}
-      let onClause = analyzeExpr(next.onExpr!, {table, alias, fanoutPath: scope.fanoutPath, joinTarget}).sql
-      scope.query.joins.push({alias: newAlias, targetTable: next.targetTable, table: next.table, source: 'implicit', cardinality: next.cardinality, fanoutPath, joinType: 'left', onClause})
+      let table = pointsAtTarget ? scope.joinTarget.table : scope.table!
+      let alias = pointsAtTarget ? scope.joinTarget.alias : scope.alias
+      this.addReference('table', pathNodes[0], table.symbolId)
+      return {file: this.fileForPath(table.filePath), query: scope.query, table, alias, fanoutPath: scope.fanoutPath, otherTables: scope.otherTables}
     }
 
-    NODE_ENTITY_MAP.set(part, {entityType: 'table', table: next.table})
-    addReference('table', part, next.table.symbolId)
-    scope = {...scope, table: next.table, alias: newAlias, fanoutPath}
-  }
-
-  return scope
-}
-
-function mergeExprAnalysis(exprs: Expr[], sql: string, type: FieldType, isAgg?: boolean): Expr {
-  let rowFanout = mergeFanoutPaths(exprs.map(expr => expr.fanout?.path))
-  return {
-    sql,
-    type,
-    isAgg,
-    fanout: normalizeExprFanout({
-      path: isAgg ? undefined : rowFanout.path,
-      sensitivePaths: mergeSensitiveFanouts(...exprs.map(expr => expr.fanout?.sensitivePaths)),
-      conflict: rowFanout.conflict || exprs.some(expr => expr.fanout?.conflict),
-    }),
-  }
-}
-
-function analyzeComputedFieldExpr(node: SyntaxNode, expr: Expr) {
-  if (expr.fanout?.conflict) diag(node, 'Join graph creates a chasm trap')
-  if (!expr.isAgg && !isBaseFanoutPath(expr.fanout?.path)) diag(node, fanoutMessage(expr.fanout?.path, 'aggregate it first'))
-  let paths = uniqueFanoutPaths(expr.fanout?.sensitivePaths || [])
-  if (paths.length > 1) {
-    diag(node, multiGrainMessage(paths))
-  }
-}
-
-function analyzeAggregateQueryExpr(node: SyntaxNode, expr: Expr) {
-  if (expr.fanout?.conflict) diag(node, 'Join graph creates a chasm trap')
-}
-
-// Aggregate-query fanout diagnostics have to look at the query as a whole: first ensure
-// any non-aggregate dimensions stay at the same grain as the aggregates, then classify the
-// aggregate grains into the more specific cases we can explain clearly (chasm trap, a base
-// aggregate fanned out by one join, an ancestor aggregate fanned out by a descendant join,
-// or the generic join-graph fanout fallback).
-function analyzeAggregateQueryFanout(exprs: {node: SyntaxNode; expr: Expr}[]) {
-  let aggExprs = exprs.filter(entry => entry.expr.isAgg)
-  let paths = uniqueFanoutPaths(aggExprs.flatMap(entry => entry.expr.fanout?.sensitivePaths || []))
-  if (paths.length == 0) return
-
-  let pathKeys = new Set(paths.map(path => fanoutPathKey(path)))
-
-  // Non-aggregate dimensions are allowed only when they stay at the same grain
-  // as every aggregate in the query. Otherwise, either the dimension is fanning
-  // out a base-grain aggregate or it is grouping by the wrong join-many path.
-  for (let entry of exprs) {
-    if (entry.expr.isAgg || isBaseFanoutPath(entry.expr.fanout?.path)) continue
-
-    let exprPathKey = fanoutPathKey(entry.expr.fanout?.path)
-    if (pathKeys.size == 1 && pathKeys.has(exprPathKey)) continue
-
-    // A join-many dimension can fan out an aggregate that otherwise lives at base grain.
-    if (paths.length == 1 && isBaseFanoutPath(paths[0])) {
-      for (let aggEntry of aggExprs) {
-        let entryPaths = uniqueFanoutPaths(aggEntry.expr.fanout?.sensitivePaths || [])
-        if (!entryPaths.some(path => isBaseFanoutPath(path))) continue
-        diag(aggEntry.node, aggregateFanoutMessage(txt(aggEntry.node), entry.expr.fanout?.path))
+    // If scope is at the root of the table (ie scope.table == null), then the first part of the path could point at
+    // the alias of any table in the FROM or JOIN clauses of a query.
+    // But it could also refer to a join _on_ one of those tables (assuming the name is unique).
+    if (!scope.table) {
+      // This could be a ref to an existing FROM/JOIN alias
+      let existing = scope.query!.joins.find(join => join.alias == name)
+      if (existing) {
+        if (!existing.table) return this.diag(part, `"${name}" is an unnested value, not a table`, null)
+        this.addReference('table', part, existing.table.symbolId)
+        scope = {...scope, file: this.fileForPath(existing.table.filePath), table: existing.table, alias: existing.alias, fanoutPath: existing.fanoutPath}
+        pathNodes.shift()
+      } else {
+        // otherwise, this might be referring to a join _on_ one of those FROM/JOIN tables
+        let matches = scope.query!.joins.filter(join => join.table && join.table.joins.some(next => next.alias == name))
+        if (matches.length > 1) return this.diag(part, `"${name}" matches multiple possible joins in this query`, null)
+        if (matches.length == 0) return this.diag(part, `Could not find "${name}" on query`, null)
+        scope = {...scope, file: this.fileForPath(matches[0].table!.filePath), table: matches[0].table!, alias: matches[0].alias, fanoutPath: matches[0].fanoutPath}
       }
-      continue
     }
 
-    let targetPath = paths.length == 1 && isPrefix(entry.expr.fanout!.path!, paths[0]) ? paths[0] : entry.expr.fanout?.path
-    diag(entry.node, fanoutMessage(targetPath, 'aggregate queries cannot group by it directly'))
+    // At this point we're guaranteed to have a scope.table, and from here it's easy. Each part of the path must be
+    // the name of a join on scope.table, and we just need to walk through each one updating our scope, and adding an implicit join to the query
+    for (let part of pathNodes) {
+      let name = txt(part)
+      if (name == scope.alias || name == scope.table!.name) continue
+
+      let table = scope.table!
+      let alias = scope.alias
+      let next = table.joins.find(join => join.alias == name)
+      if (!next) return this.diag(part, `Unknown join "${name}" on ${table.name}`, null)
+
+      next.table = this.lookupTable(next.targetNode!)
+      if (!next.table) return null
+
+      // Construct a new implied join and attache it to the query
+      let fromAlias = scope.query?.joins.find(join => join.source == 'from')?.alias
+      let newAlias = alias == fromAlias ? name : `${alias}_${name}`
+      let fanoutPath = next.cardinality == 'many' ? extendFanoutPath(scope.fanoutPath, name) : extendFanoutPath(scope.fanoutPath)
+      if (scope.query && !scope.query.joins.find(join => join.alias == newAlias)) {
+        let joinTarget = {name: next.alias, table: next.table, alias: newAlias}
+        let onClause = this.analyzeExpr(next.onExpr!, {file: scope.file, table, alias, fanoutPath: scope.fanoutPath, joinTarget}).sql
+        scope.query.joins.push({alias: newAlias, targetTable: next.targetTable, table: next.table, source: 'implicit', cardinality: next.cardinality, fanoutPath, joinType: 'left', onClause})
+      }
+
+      this.addReference('table', part, next.table.symbolId)
+      scope = {...scope, file: this.fileForPath(next.table.filePath), table: next.table, alias: newAlias, fanoutPath}
+    }
+
+    return scope
   }
 
-  if (paths.length <= 1) return
-
-  let joinedPaths = paths.filter(path => !isBaseFanoutPath(path))
-
-  // Sibling join-many branches produce a classic chasm trap.
-  if (joinedPaths.length > 1 && isChasmTrap(joinedPaths)) {
-    let message = multiGrainMessage(joinedPaths)
-    for (let entry of aggExprs) {
-      let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
-      if (entryPaths.length == 0) continue
-      diag(entry.node, message)
+  private mergeExprAnalysis(exprs: Expr[], sql: string, type: FieldType, isAgg?: boolean): Expr {
+    let rowFanout = mergeFanoutPaths(exprs.map(expr => expr.fanout?.path))
+    return {
+      sql,
+      type,
+      isAgg,
+      fanout: normalizeExprFanout({
+        path: isAgg ? undefined : rowFanout.path,
+        sensitivePaths: mergeSensitiveFanouts(...exprs.map(expr => expr.fanout?.sensitivePaths)),
+        conflict: rowFanout.conflict || exprs.some(expr => expr.fanout?.conflict),
+      }),
     }
-    return
   }
 
-  // One base-grain aggregate plus one joined grain means the base aggregate is fanned out.
-  if (paths.length == 2 && joinedPaths.length == 1) {
-    for (let entry of aggExprs) {
-      let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
-      if (!entryPaths.some(path => isBaseFanoutPath(path))) continue
-      diag(entry.node, aggregateFanoutMessage(txt(entry.node), joinedPaths[0]))
-    }
-    return
+  private analyzeComputedFieldExpr(node: SyntaxNode, expr: Expr) {
+    if (expr.fanout?.conflict) this.diag(node, 'Join graph creates a chasm trap')
+    if (!expr.isAgg && !isBaseFanoutPath(expr.fanout?.path)) this.diag(node, fanoutMessage(expr.fanout?.path, 'aggregate it first'))
+    let paths = uniqueFanoutPaths(expr.fanout?.sensitivePaths || [])
+    if (paths.length > 1) this.diag(node, multiGrainMessage(paths))
   }
 
-  // Ancestor/descendant join-many paths mean the shallower aggregate is fanned out by the deeper join.
-  if (paths.length == 2 && joinedPaths.length == 2) {
-    let [pathA, pathB] = joinedPaths
-    let ancestor: typeof pathA | undefined
-    let descendant: typeof pathA | undefined
+  private analyzeAggregateQueryExpr(node: SyntaxNode, expr: Expr) {
+    if (expr.fanout?.conflict) this.diag(node, 'Join graph creates a chasm trap')
+  }
 
-    if (isPrefix(pathA, pathB)) {
-      ancestor = pathA
-      descendant = pathB
-    } else if (isPrefix(pathB, pathA)) {
-      ancestor = pathB
-      descendant = pathA
+  // Aggregate-query fanout diagnostics have to look at the query as a whole: first ensure
+  // any non-aggregate dimensions stay at the same grain as the aggregates, then classify the
+  // aggregate grains into the more specific cases we can explain clearly (chasm trap, a base
+  // aggregate fanned out by one join, an ancestor aggregate fanned out by a descendant join,
+  // or the generic join-graph fanout fallback).
+  private analyzeAggregateQueryFanout(exprs: {node: SyntaxNode; expr: Expr}[]) {
+    let aggExprs = exprs.filter(entry => entry.expr.isAgg)
+    let paths = uniqueFanoutPaths(aggExprs.flatMap(entry => entry.expr.fanout?.sensitivePaths || []))
+    if (paths.length == 0) return
+
+    let pathKeys = new Set(paths.map(path => fanoutPathKey(path)))
+
+    // Non-aggregate dimensions are allowed only when they stay at the same grain
+    // as every aggregate in the query. Otherwise, either the dimension is fanning
+    // out a base-grain aggregate or it is grouping by the wrong join-many path.
+    for (let entry of exprs) {
+      if (entry.expr.isAgg || isBaseFanoutPath(entry.expr.fanout?.path)) continue
+
+      let exprPathKey = fanoutPathKey(entry.expr.fanout?.path)
+      if (pathKeys.size == 1 && pathKeys.has(exprPathKey)) continue
+
+      // A join-many dimension can fan out an aggregate that otherwise lives at base grain.
+      if (paths.length == 1 && isBaseFanoutPath(paths[0])) {
+        for (let aggEntry of aggExprs) {
+          let entryPaths = uniqueFanoutPaths(aggEntry.expr.fanout?.sensitivePaths || [])
+          if (!entryPaths.some(path => isBaseFanoutPath(path))) continue
+          this.diag(aggEntry.node, aggregateFanoutMessage(txt(aggEntry.node), entry.expr.fanout?.path))
+        }
+        continue
+      }
+
+      let targetPath = paths.length == 1 && isPrefix(entry.expr.fanout!.path!, paths[0]) ? paths[0] : entry.expr.fanout?.path
+      this.diag(entry.node, fanoutMessage(targetPath, 'aggregate queries cannot group by it directly'))
     }
 
-    if (ancestor && descendant) {
-      let ancestorKey = fanoutPathKey(ancestor)
-      let descendantKey = fanoutPathKey(descendant)
+    if (paths.length <= 1) return
 
+    let joinedPaths = paths.filter(path => !isBaseFanoutPath(path))
+
+    // Sibling join-many branches produce a classic chasm trap.
+    if (joinedPaths.length > 1 && isChasmTrap(joinedPaths)) {
+      let message = multiGrainMessage(joinedPaths)
       for (let entry of aggExprs) {
         let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
-        if (!entryPaths.some(path => fanoutPathKey(path) == ancestorKey) || entryPaths.some(path => fanoutPathKey(path) == descendantKey)) continue
-        diag(entry.node, aggregateFanoutMessage(txt(entry.node), descendant))
+        if (entryPaths.length == 0) continue
+        this.diag(entry.node, message)
       }
       return
     }
-  }
 
-  // Anything more complex falls back to the generic join-graph fanout diagnostic.
-  let message = multiGrainMessage(paths)
-  for (let entry of aggExprs) {
-    let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
-    if (entryPaths.length == 0) continue
-    diag(entry.node, message)
-  }
-}
+    // One base-grain aggregate plus one joined grain means the base aggregate is fanned out.
+    if (paths.length == 2 && joinedPaths.length == 1) {
+      for (let entry of aggExprs) {
+        let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
+        if (!entryPaths.some(path => isBaseFanoutPath(path))) continue
+        this.diag(entry.node, aggregateFanoutMessage(txt(entry.node), joinedPaths[0]))
+      }
+      return
+    }
 
-// Find a table by Ref node, failing if it doesn't exist
-function lookupTable(node: SyntaxNode, scope?: Scope): Table | undefined {
-  let name = txt(node)
-  let table: Table | undefined
+    // Ancestor/descendant join-many paths mean the shallower aggregate is fanned out by the deeper join.
+    if (paths.length == 2 && joinedPaths.length == 2) {
+      let [pathA, pathB] = joinedPaths
+      let ancestor: typeof pathA | undefined
+      let descendant: typeof pathA | undefined
 
-  for (let scopeTable of scope?.otherTables || []) {
-    if (scopeTable.name == name) table = scopeTable
-  }
-  let currentUri = getFile(node).path
-  for (let file of Object.values(FILE_MAP)) {
-    if (table) break
-    if (file.path.endsWith('.gsql') || file.path == currentUri) {
-      let match = file.tables.find(t => t.name == name)
-      if (match) table = match
+      if (isPrefix(pathA, pathB)) {
+        ancestor = pathA
+        descendant = pathB
+      } else if (isPrefix(pathB, pathA)) {
+        ancestor = pathB
+        descendant = pathA
+      }
+
+      if (ancestor && descendant) {
+        let ancestorKey = fanoutPathKey(ancestor)
+        let descendantKey = fanoutPathKey(descendant)
+        for (let entry of aggExprs) {
+          let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
+          if (!entryPaths.some(path => fanoutPathKey(path) == ancestorKey) || entryPaths.some(path => fanoutPathKey(path) == descendantKey)) continue
+          this.diag(entry.node, aggregateFanoutMessage(txt(entry.node), descendant))
+        }
+        return
+      }
+    }
+
+    // Anything more complex falls back to the generic join-graph fanout diagnostic.
+    let message = multiGrainMessage(paths)
+    for (let entry of aggExprs) {
+      let entryPaths = uniqueFanoutPaths(entry.expr.fanout?.sensitivePaths || [])
+      if (entryPaths.length == 0) continue
+      this.diag(entry.node, message)
     }
   }
-  if (!table) return diag(node, `Unknown table "${name}"`)
-  analyzeView(table)
-  if (table.type == 'view' && !table.query) return
-  addReference('table', node, table.symbolId)
-  return table
-}
 
-function inferName(exprNode: SyntaxNode, scope: Scope): string {
-  if (exprNode.name == 'Ref') {
-    return exprNode
-      .getChildren('Identifier')
-      .map(i => txt(i))
-      .join('_')
-  }
-  return `col_${scope.query?.fields.length || 0}`
-}
+  // Find a table by Ref node, failing if it doesn't exist
+  private lookupTable(node: SyntaxNode, scope?: Scope): Table | undefined {
+    let name = txt(node)
+    let table: Table | undefined
 
-// TODO: do we still need this?
-function unpackAnds(node: SyntaxNode, scope: Scope): Expr[] {
-  if (node.name == 'BinaryExpression') {
-    let op = txt(node.firstChild?.nextSibling).toLowerCase()
-    if (op == 'and') {
-      return [...unpackAnds(node.firstChild!, scope), ...unpackAnds(node.lastChild!, scope)]
+    for (let scopeTable of scope?.otherTables || []) {
+      if (scopeTable.name == name) table = scopeTable
     }
+    let currentUri = getFile(node).path
+    for (let file of this.files) {
+      if (table) break
+      if (file.path.endsWith('.gsql') || file.path == currentUri) {
+        let match = file.tables.find(next => next.name == name)
+        if (match) table = match
+      }
+    }
+    if (!table) return this.diag(node, `Unknown table "${name}"`)
+    this.analyzeView(table)
+    if (table.type == 'view' && !table.query) return
+    this.addReference('table', node, table.symbolId)
+    return table
   }
-  return [analyzeExpr(node, scope)]
-}
 
-export function clearWorkspace() {
-  Object.keys(FILE_MAP).forEach(k => delete FILE_MAP[k])
-  diagnostics = []
-}
+  private inferName(exprNode: SyntaxNode, scope: Scope): string {
+    if (exprNode.name == 'Ref')
+      return exprNode
+        .getChildren('Identifier')
+        .map(i => txt(i))
+        .join('_')
+    return `col_${scope.query?.fields.length || 0}`
+  }
 
-export function clearDiagnostics() {
-  diagnostics = []
-}
-export function getNodeEntity(node: SyntaxNode) {
-  return NODE_ENTITY_MAP.get(node)
-}
+  // TODO: do we still need this?
+  private unpackAnds(node: SyntaxNode, scope: Scope): Expr[] {
+    if (node.name == 'BinaryExpression') {
+      let op = txt(node.firstChild?.nextSibling).toLowerCase()
+      if (op == 'and') return [...this.unpackAnds(node.firstChild!, scope), ...this.unpackAnds(node.lastChild!, scope)]
+    }
+    return [this.analyzeExpr(node, scope)]
+  }
 
-export function recordSyntaxErrors(fi: FileInfo) {
-  fi.tree!.topNode.cursor().iterate(n => {
-    if (n.type.isError) diag(n.node, 'Syntax error')
-  })
-}
+  private recordSyntaxErrors(fi: FileInfo) {
+    fi.tree!.topNode.cursor().iterate(node => {
+      if (node.type.isError) this.diag(node.node, 'Syntax error')
+    })
+  }
 
-export function diag<T>(node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T {
-  let file = getFile(node)
-  let from = getPosition(node.from, file)
-  let to = getPosition(node.to, file)
-  diagnostics.push({severity: 'error', message, file: toRelativePath(file.path), from, to, frame: buildFrame(from, to)})
-  return defaultReturn as T
-}
+  diag<T>(node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T {
+    let file = getFile(node)
+    let from = getPosition(node.from, file)
+    let to = getPosition(node.to, file)
+    this.diagnostics.push({severity: 'error', message, file: toRelativePath(file.path), from, to, frame: buildFrame(from, to)})
+    return defaultReturn as T
+  }
 
-export function checkTypes(expr: Expr, expected: TypeKind[], node: SyntaxNode) {
-  if (isScalarType(expr.type, 'error') || isScalarType(expr.type, 'null')) return
-  if (expected.some(kind => (kind == 'array' ? isArrayType(expr.type) : isScalarType(expr.type, kind)))) return
-  diag(node, `Expected ${expected.join(' or ')}, got ${formatType(expr.type)}`)
+  checkTypes(expr: Expr, expected: TypeKind[], node: SyntaxNode) {
+    if (isScalarType(expr.type, 'error') || isScalarType(expr.type, 'null')) return
+    if (expected.some(kind => (kind == 'array' ? isArrayType(expr.type) : isScalarType(expr.type, kind)))) return
+    this.diag(node, `Expected ${expected.join(' or ')}, got ${formatType(expr.type)}`)
+  }
 }

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -27,49 +27,49 @@ export async function loadWorkspace(dir: string, includeMd: boolean, ignoredFile
   return files
 }
 
-export function getTable(result: AnalysisResult, name: string) {
-  return result.files.flatMap(file => file.tables).find(table => table.name == name)
+export function getTable(analysis: AnalysisResult, name: string) {
+  return analysis.files.flatMap(file => file.tables).find(table => table.name == name)
 }
 
-export function getFile(result: AnalysisResult, name: string) {
-  return result.files.find(file => file.path == name)
+export function getFile(analysis: AnalysisResult, name: string) {
+  return analysis.files.find(file => file.path == name)
 }
 
-export function getFiles(result: AnalysisResult) {
-  return result.files
+export function getFiles(analysis: AnalysisResult) {
+  return analysis.files
 }
 
-export function getDiagnostics(result: AnalysisResult): GrapheneError[] {
-  return result.diagnostics
+export function getDiagnostics(analysis: AnalysisResult): GrapheneError[] {
+  return analysis.diagnostics
 }
 
-export function getHover(result: AnalysisResult, path: string, line: number, col: number): string {
-  let symbol = getNavigationTarget(result, path, line, col)
+export function getHover(analysis: AnalysisResult, path: string, line: number, col: number): string {
+  let symbol = getNavigationTarget(analysis, path, line, col)
   return symbol?.hover || ''
 }
 
-export function getDefinition(result: AnalysisResult, path: string, line: number, col: number): Location | null {
-  let symbol = getNavigationTarget(result, path, line, col)
+export function getDefinition(analysis: AnalysisResult, path: string, line: number, col: number): Location | null {
+  let symbol = getNavigationTarget(analysis, path, line, col)
   return symbol?.location || null
 }
 
-export function getReferences(result: AnalysisResult, path: string, line: number, col: number, includeDeclaration = false): Location[] {
-  let symbol = getNavigationTarget(result, path, line, col)
+export function getReferences(analysis: AnalysisResult, path: string, line: number, col: number, includeDeclaration = false): Location[] {
+  let symbol = getNavigationTarget(analysis, path, line, col)
   if (!symbol) return []
 
-  let references = result.files.flatMap(file => file.navigation.references.filter(ref => ref.targetId == symbol.id).map(ref => ref.location))
+  let references = analysis.files.flatMap(file => file.navigation.references.filter(ref => ref.targetId == symbol.id).map(ref => ref.location))
   if (includeDeclaration) return [symbol.location, ...references]
   return references
 }
 
-function getNavigationTarget(result: AnalysisResult, path: string, line: number, col: number) {
-  let file = getFile(result, path)
+function getNavigationTarget(analysis: AnalysisResult, path: string, line: number, col: number) {
+  let file = getFile(analysis, path)
   if (!file) return null
 
   let offset = getSourceOffset(line, col, file)
   let reference = file.navigation.references.find(ref => containsOffset(ref.location, offset))
   if (reference) {
-    return result.files.flatMap(next => next.navigation.symbols).find(symbol => symbol.id == reference.targetId)
+    return analysis.files.flatMap(next => next.navigation.symbols).find(symbol => symbol.id == reference.targetId)
   }
 
   return file.navigation.symbols.find(symbol => containsOffset(symbol.location, offset)) || null

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -2,154 +2,85 @@ import {glob} from 'glob'
 import {readFile} from 'node:fs/promises'
 import path from 'node:path'
 
-import {FILE_MAP, analyzeQuery, findTables, clearWorkspace, diagnostics, clearDiagnostics, getNodeEntity, recordSyntaxErrors, analyzeTableFully, applyExtends} from './analyze.ts'
-import {config, loadConfig} from './config.ts'
-import {parseMarkdown} from './markdown.ts'
+import {analyzeWorkspace} from './analyze.ts'
 import {fillInParams} from './params.ts'
-import {parser} from './parser.js'
-import {type GrapheneError, type Location, type Query} from './types.ts'
-import {getOffset, getSourceOffset} from './util.ts'
+import {type AnalysisResult, type GrapheneError, type Location, type Query, type WorkspaceFileInput} from './types.ts'
+import {getSourceOffset} from './util.ts'
 
-export {clearWorkspace}
-export {config, loadConfig}
-export type {Query, Table, GrapheneError} from './types.ts'
-export function getTable(name: string) {
-  return Object.values(FILE_MAP)
-    .flatMap(f => f.tables)
-    .find(t => t.name == name)
-}
-export function getFile(name: string) {
-  return FILE_MAP[name]
-}
-export function getFiles() {
-  return Object.values(FILE_MAP)
-}
-export function getDiagnostics(): GrapheneError[] {
-  return diagnostics
-}
+export {analyzeWorkspace}
+export type {AnalysisResult, AnalysisWorkspace, FileInfo, GrapheneError, Query, Table, WorkspaceFileInput} from './types.ts'
 
-// Loads and parses all gsql files within a directory
-export async function loadWorkspace(dir: string, includeMd: boolean) {
-  let ignore = ['node_modules/**', '**/.*/**', ...config.ignoredFiles]
-  let files = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore, follow: false})
-  for await (let file of files) {
+export async function loadWorkspace(dir: string, includeMd: boolean, ignoredFiles: string[] = []): Promise<WorkspaceFileInput[]> {
+  let ignore = ['node_modules/**', '**/.*/**', ...ignoredFiles]
+  let paths = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore, follow: false})
+  let files: WorkspaceFileInput[] = []
+
+  for await (let file of paths) {
     try {
       let contents = await readFile(path.join(dir, file), 'utf-8')
-      updateFile(contents, file)
-    } catch (e: any) {
-      console.error('Failed to read file', file, e.message)
+      files.push({path: file, contents})
+    } catch (err: any) {
+      console.error('Failed to read file', file, err.message)
     }
   }
+
+  return files
 }
 
-export function updateFile(contents: string, path: string) {
-  FILE_MAP[path] ||= {path, contents, tree: null, tables: [], queries: [], navigation: {symbols: [], references: []}}
-  FILE_MAP[path].contents = contents
-  FILE_MAP[path].tree = null
-  FILE_MAP[path].navigation = {symbols: [], references: []}
-  return FILE_MAP[path]
+export function getTable(result: AnalysisResult, name: string) {
+  return result.files.flatMap(file => file.tables).find(table => table.name == name)
 }
 
-export function deleteFile(path: string) {
-  delete FILE_MAP[path]
+export function getFile(result: AnalysisResult, name: string) {
+  return result.files.find(file => file.path == name)
 }
 
-// Analyze all files in the workspace. If content is provided, it's added as a virtual 'input' file and its queries are returned.
-export function analyze(contents?: string, contentType?: 'gsql' | 'md'): Query[] {
-  clearDiagnostics()
+export function getFiles(result: AnalysisResult) {
+  return result.files
+}
 
-  delete FILE_MAP['input']
-  if (contents) updateFile(contents, 'input')
+export function getDiagnostics(result: AnalysisResult): GrapheneError[] {
+  return result.diagnostics
+}
 
-  Object.values(FILE_MAP).forEach(fi => {
-    let isMd = fi.path.endsWith('.md') || (fi.path == 'input' && contentType == 'md')
-    fi.navigation = {symbols: [], references: []}
-    fi.tree ||= isMd ? parseMarkdown(fi) : parser.parse(fi.contents)
-    fi.tree!.fileInfo = fi
-    recordSyntaxErrors(fi)
-    findTables(fi)
-  })
-  Object.values(FILE_MAP).forEach(applyExtends)
+export function getHover(result: AnalysisResult, path: string, line: number, col: number): string {
+  let symbol = getNavigationTarget(result, path, line, col)
+  return symbol?.hover || ''
+}
 
-  if (contents) {
-    let fi = FILE_MAP['input']
-    fi.tables.forEach(analyzeTableFully)
-    let nodes = fi.tree!.topNode.getChildren('QueryStatement') || []
-    fi.queries = nodes.map(n => analyzeQuery(n)).filter((q): q is Query => !!q)
-    return fi.queries
+export function getDefinition(result: AnalysisResult, path: string, line: number, col: number): Location | null {
+  let symbol = getNavigationTarget(result, path, line, col)
+  return symbol?.location || null
+}
+
+export function getReferences(result: AnalysisResult, path: string, line: number, col: number, includeDeclaration = false): Location[] {
+  let symbol = getNavigationTarget(result, path, line, col)
+  if (!symbol) return []
+
+  let references = result.files.flatMap(file => file.navigation.references.filter(ref => ref.targetId == symbol.id).map(ref => ref.location))
+  if (includeDeclaration) return [symbol.location, ...references]
+  return references
+}
+
+function getNavigationTarget(result: AnalysisResult, path: string, line: number, col: number) {
+  let file = getFile(result, path)
+  if (!file) return null
+
+  let offset = getSourceOffset(line, col, file)
+  let reference = file.navigation.references.find(ref => containsOffset(ref.location, offset))
+  if (reference) {
+    return result.files.flatMap(next => next.navigation.symbols).find(symbol => symbol.id == reference.targetId)
   }
 
-  Object.values(FILE_MAP)
-    .flatMap(f => f.tables)
-    .forEach(analyzeTableFully)
-  Object.values(FILE_MAP).forEach(fi => {
-    let nodes = fi.tree!.topNode.getChildren('QueryStatement') || []
-    fi.queries = nodes.map(n => analyzeQuery(n)).filter((q): q is Query => !!q)
-  })
-  return []
+  return file.navigation.symbols.find(symbol => containsOffset(symbol.location, offset)) || null
+}
+
+function containsOffset(location: Location, offset: number) {
+  return offset >= location.from.offset && offset <= location.to.offset
 }
 
 export function toSql(query: Query, params: Record<string, any> = {}): string {
   query = structuredClone(query)
   fillInParams(query, params)
   return query.sql
-}
-
-export function getHover(path: string, line: number, col: number): string {
-  let fi = FILE_MAP[path]
-  let offset = getOffset(line, col, fi)
-
-  if (!fi.tree) return ''
-
-  let node = fi.tree!.resolve(offset)
-  let entity = getNodeEntity(node)
-  while (!entity && node.parent) {
-    node = node.parent
-    entity = getNodeEntity(node)
-  }
-
-  if (!entity) return ''
-  if (entity.entityType == 'field') {
-    let desc = entity.field.metadata?.description ? `\n\n${entity.field.metadata.description}` : ''
-    return `#### ${entity.table.name}.${entity.field.name}${desc}`
-  }
-
-  if (entity.entityType == 'table') {
-    let desc = entity.table.metadata?.description ? `\n\n${entity.table.metadata.description}` : ''
-    return `#### ${entity.table.name}${desc}`
-  }
-  return ''
-}
-
-export function getDefinition(path: string, line: number, col: number): Location | null {
-  let symbol = getNavigationTarget(path, line, col)
-  return symbol?.location || null
-}
-
-export function getReferences(path: string, line: number, col: number, includeDeclaration = false): Location[] {
-  let symbol = getNavigationTarget(path, line, col)
-  if (!symbol) return []
-
-  let references = Object.values(FILE_MAP).flatMap(file => file.navigation.references.filter(ref => ref.targetId == symbol.id).map(ref => ref.location))
-  if (includeDeclaration) return [symbol.location, ...references]
-  return references
-}
-
-function getNavigationTarget(path: string, line: number, col: number) {
-  let fi = FILE_MAP[path]
-  if (!fi) return null
-
-  let offset = getSourceOffset(line, col, fi)
-  let reference = fi.navigation.references.find(ref => containsOffset(ref.location, offset))
-  if (reference) {
-    return Object.values(FILE_MAP)
-      .flatMap(file => file.navigation.symbols)
-      .find(symbol => symbol.id == reference.targetId)
-  }
-
-  return fi.navigation.symbols.find(symbol => containsOffset(symbol.location, offset)) || null
-}
-
-function containsOffset(location: Location, offset: number) {
-  return offset >= location.from.offset && offset <= location.to.offset
 }

--- a/lang/features.test.ts
+++ b/lang/features.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'vitest'
 
 /// <reference types="vitest/globals" />
-import {analyze, getDefinition, getHover, getReferences, clearWorkspace, updateFile} from './core.ts'
+import {analyze, getDefinition, getHover, getReferences, clearWorkspace, updateFile} from './testHelpers.ts'
 
 function simple(location: ReturnType<typeof getDefinition>) {
   if (!location) return null

--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -1,10 +1,9 @@
 import {type SyntaxNode} from '@lezer/common'
 
+import type {Analyzer} from './analyze.ts'
 import type {FunctionDef, ArgDef} from './functionTypes.ts'
 
-import {diag, checkTypes} from './analyze.ts'
 import {bigQueryFunctions} from './bigQueryFunctions.ts'
-import {config} from './config.ts'
 import {duckDbFunctions} from './duckDbFunctions.ts'
 import {extendFanoutPath, mergeFanoutPaths, mergeSensitiveFanouts, normalizeExprFanout} from './fanout.ts'
 import {snowflakeFunctions} from './snowflakeFunctions.ts'
@@ -113,22 +112,20 @@ function findOverloads(name: string, dialect: string): Overload[] {
 // Function Call Analysis
 // ============================================================================
 
-type AnalyzeExprFn = (node: SyntaxNode, scope: Scope) => Expr
-
-export function analyzeFunction(node: SyntaxNode, scope: Scope, analyzeExpr: AnalyzeExprFn, opts: {isWindow?: boolean} = {}): Expr {
+export function analyzeFunction(analyzer: Analyzer, node: SyntaxNode, scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
   let name = txt(node.getChild('Identifier')).toLowerCase()
   let argNodes = node.getChildren('Expression')
 
   // Check for percentile functions (p50, p90, etc.) before overload lookup
   let percentileMatch = /^p(\d+)$/.exec(name)
   if (percentileMatch) {
-    let args = argNodes.map(n => analyzeExpr(n, scope))
-    if (args[0]) checkTypes(args[0], ['number'], argNodes[0])
-    return analyzePercentile(node, args, percentileMatch[1], scope, opts)
+    let args = argNodes.map(n => analyzer.analyzeExpr(n, scope))
+    if (args[0]) analyzer.checkTypes(args[0], ['number'], argNodes[0])
+    return analyzePercentile(analyzer, node, args, percentileMatch[1], scope, opts)
   }
 
   // Find matching overload
-  let overloads = findOverloads(name, config.dialect)
+  let overloads = findOverloads(name, analyzer.config.dialect)
   let overload = overloads.find(o => {
     if (o.params.length == argNodes.length) return true
     if (!o.params.some(p => p.isVariadic)) return false
@@ -147,16 +144,16 @@ export function analyzeFunction(node: SyntaxNode, scope: Scope, analyzeExpr: Ana
     if (firstType?.type == 'sql native' && firstType?.rawType === 'kw') {
       return {sql: txt(argNode), type: scalarType('sql native')}
     }
-    let arg = analyzeExpr(argNode, scope)
+    let arg = analyzer.analyzeExpr(argNode, scope)
     let allowed = overload?.params[paramIdx]?.allowedTypes.map(t => t.type)
-    if (allowed) checkTypes(arg, allowed, argNode)
+    if (allowed) analyzer.checkTypes(arg, allowed, argNode)
     return arg
   })
 
   if (!overload) {
-    if (overloads.length === 0) return diag(node, `Unknown function: ${name}`, {sql: 'NULL', type: scalarType('error')})
+    if (overloads.length === 0) return analyzer.diag(node, `Unknown function: ${name}`, {sql: 'NULL', type: scalarType('error')})
     let expected = [...new Set(overloads.map(o => o.params.length))].sort().join(' or ')
-    return diag(node, `Wrong number of arguments for ${name}: expected ${expected}, got ${argNodes.length}`, {sql: 'NULL', type: scalarType('error')})
+    return analyzer.diag(node, `Wrong number of arguments for ${name}: expected ${expected}, got ${argNodes.length}`, {sql: 'NULL', type: scalarType('error')})
   }
 
   let returnType: FieldType = overload.returnType.type as FieldType
@@ -184,15 +181,15 @@ export function analyzeFunction(node: SyntaxNode, scope: Scope, analyzeExpr: Ana
   }
 }
 
-function analyzePercentile(node: SyntaxNode, args: Expr[], digits: string, scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
+function analyzePercentile(analyzer: Analyzer, node: SyntaxNode, args: Expr[], digits: string, scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
   let frac = Number(`0.${digits}`)
-  if (Number(digits) == 100) return diag(node, 'p100 is not allowed', {sql: 'NULL', type: scalarType('error')})
-  if (Number(digits) == 0) return diag(node, 'p0 is not allowed', {sql: 'NULL', type: scalarType('error')})
-  if (config.dialect == 'bigquery' && frac > 0.99) return diag(node, 'BigQuery only supports up to p99', {sql: 'NULL', type: scalarType('error')})
+  if (Number(digits) == 100) return analyzer.diag(node, 'p100 is not allowed', {sql: 'NULL', type: scalarType('error')})
+  if (Number(digits) == 0) return analyzer.diag(node, 'p0 is not allowed', {sql: 'NULL', type: scalarType('error')})
+  if (analyzer.config.dialect == 'bigquery' && frac > 0.99) return analyzer.diag(node, 'BigQuery only supports up to p99', {sql: 'NULL', type: scalarType('error')})
 
   let inner = args[0]?.sql || 'NULL'
   let sql: string
-  switch (config.dialect) {
+  switch (analyzer.config.dialect) {
     case 'duckdb':
       sql = `quantile_cont(${inner}, ${frac})`
       break
@@ -207,7 +204,7 @@ function analyzePercentile(node: SyntaxNode, args: Expr[], digits: string, scope
       sql = `PERCENTILE_CONT(${frac}) WITHIN GROUP (ORDER BY ${inner})`
       break
     default:
-      return diag(node, `Percentile not supported for ${config.dialect}`, {sql: 'NULL', type: scalarType('error')})
+      return analyzer.diag(node, `Percentile not supported for ${analyzer.config.dialect}`, {sql: 'NULL', type: scalarType('error')})
   }
   return {
     sql,

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -5,8 +5,8 @@ import {expect} from 'vitest'
 
 /// <reference types="vitest/globals" />
 import {setConfig} from './config.ts'
-import {clearWorkspace, getTable, analyze, toSql, getDiagnostics, updateFile, loadWorkspace, getFile} from './core.ts'
-import {prepareEcommerceTables} from './testHelpers.ts'
+import {toSql} from './core.ts'
+import {prepareEcommerceTables, clearWorkspace, getTable, analyze, getDiagnostics, updateFile, loadWorkspace, getFile} from './testHelpers.ts'
 import {formatType} from './types.ts'
 import {trimIndentation} from './util.ts'
 

--- a/lang/markdown.ts
+++ b/lang/markdown.ts
@@ -1,4 +1,4 @@
-import type {FileInfo} from './types.ts'
+import type {ParsedFileArtifacts, WorkspaceFileInput} from './types.ts'
 
 import {parser} from './parser.js'
 
@@ -45,8 +45,8 @@ interface AttrMatch {
   start: number
 }
 
-export function parseMarkdown(fi: FileInfo) {
-  let source = fi.contents
+export function parseMarkdown(file: WorkspaceFileInput): ParsedFileArtifacts {
+  let source = file.contents
   let fences = collectFences(source)
   let components = collectComponents(source, fences)
   let events = [...fences, ...components].sort((a, b) => a.start - b.start)
@@ -159,9 +159,11 @@ export function parseMarkdown(fi: FileInfo) {
   appendWhitespace(cursor, source.length)
 
   let doc = virtual.join('')
-  fi.virtualContents = doc
-  fi.virtualToMarkdownOffset = [...mapping, source.length]
-  return parser.parse(doc)
+  return {
+    tree: parser.parse(doc),
+    virtualContents: doc,
+    virtualToMarkdownOffset: [...mapping, source.length],
+  }
 }
 
 function collectFences(source: string): FenceMatch[] {

--- a/lang/testHelpers.ts
+++ b/lang/testHelpers.ts
@@ -83,7 +83,7 @@ function formatDiagnostics(_source: string, diagnostics: GrapheneError[]): strin
 
 let conn: DuckDBConnection
 let files: WorkspaceFileInput[] = []
-let lastResult: AnalysisResult = {files: [], diagnostics: []}
+let lastAnalysis: AnalysisResult = {files: [], diagnostics: []}
 
 export async function prepareEcommerceTables() {
   let db = await DuckDBInstance.create(':memory:')
@@ -93,7 +93,7 @@ export async function prepareEcommerceTables() {
 
 export function clearWorkspace() {
   files = []
-  lastResult = {files: [], diagnostics: []}
+  lastAnalysis = {files: [], diagnostics: []}
 }
 
 export function updateFile(contents: string, path: string, kind?: 'gsql' | 'md') {
@@ -105,17 +105,17 @@ export function updateFile(contents: string, path: string, kind?: 'gsql' | 'md')
 
 export async function loadWorkspace(dir: string, includeMd: boolean) {
   files = await loadWorkspaceFiles(dir, includeMd, config.ignoredFiles)
-  lastResult = {files: [], diagnostics: []}
+  lastAnalysis = {files: [], diagnostics: []}
 }
 
 export function analyze(contents?: string, contentType?: 'gsql' | 'md') {
   if (contents) {
-    lastResult = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents, kind: contentType})}, 'input')
+    lastAnalysis = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents, kind: contentType})}, 'input')
   } else {
-    lastResult = analyzeWorkspace({config, files})
+    lastAnalysis = analyzeWorkspace({config, files})
   }
   files = files.map(file => {
-    let analyzed = getFileFromResult(lastResult, file.path)
+    let analyzed = getFileFromResult(lastAnalysis, file.path)
     if (!analyzed) return file
     return {
       ...file,
@@ -126,31 +126,31 @@ export function analyze(contents?: string, contentType?: 'gsql' | 'md') {
       },
     }
   })
-  return getFileFromResult(lastResult, 'input')?.queries || []
+  return getFileFromResult(lastAnalysis, 'input')?.queries || []
 }
 
 export function getDiagnostics() {
-  return getDiagnosticsFromResult(lastResult)
+  return getDiagnosticsFromResult(lastAnalysis)
 }
 
 export function getTable(name: string) {
-  return getTableFromResult(lastResult, name)
+  return getTableFromResult(lastAnalysis, name)
 }
 
 export function getFile(name: string) {
-  return getFileFromResult(lastResult, name) || files.find(file => file.path == name)
+  return getFileFromResult(lastAnalysis, name) || files.find(file => file.path == name)
 }
 
 export function getHover(path: string, line: number, col: number) {
-  return getHoverFromResult(lastResult, path, line, col)
+  return getHoverFromResult(lastAnalysis, path, line, col)
 }
 
 export function getDefinition(path: string, line: number, col: number) {
-  return getDefinitionFromResult(lastResult, path, line, col)
+  return getDefinitionFromResult(lastAnalysis, path, line, col)
 }
 
 export function getReferences(path: string, line: number, col: number, includeDeclaration = false) {
-  return getReferencesFromResult(lastResult, path, line, col, includeDeclaration)
+  return getReferencesFromResult(lastAnalysis, path, line, col, includeDeclaration)
 }
 
 // small delay to allow debugger to attach, since vitest doesn't support --inspect-wait

--- a/lang/testHelpers.ts
+++ b/lang/testHelpers.ts
@@ -1,7 +1,19 @@
 import {type DuckDBConnection, DuckDBInstance} from '@duckdb/node-api'
 import {expect as vitestExpect} from 'vitest'
 
-import {toSql, analyze, getDiagnostics, type GrapheneError} from './core.ts'
+import {config} from './config.ts'
+import {
+  analyzeWorkspace,
+  getDefinition as getDefinitionFromResult,
+  getDiagnostics as getDiagnosticsFromResult,
+  getFile as getFileFromResult,
+  getHover as getHoverFromResult,
+  getReferences as getReferencesFromResult,
+  getTable as getTableFromResult,
+  loadWorkspace as loadWorkspaceFiles,
+  toSql,
+} from './core.ts'
+import {type AnalysisResult, type GrapheneError, type WorkspaceFileInput} from './types.ts'
 import {trimIndentation} from './util.ts'
 
 const ECOMM_SETUP = `
@@ -70,11 +82,75 @@ function formatDiagnostics(_source: string, diagnostics: GrapheneError[]): strin
 }
 
 let conn: DuckDBConnection
+let files: WorkspaceFileInput[] = []
+let lastResult: AnalysisResult = {files: [], diagnostics: []}
 
 export async function prepareEcommerceTables() {
   let db = await DuckDBInstance.create(':memory:')
   conn = await db.connect()
   await conn.run(ECOMM_SETUP)
+}
+
+export function clearWorkspace() {
+  files = []
+  lastResult = {files: [], diagnostics: []}
+}
+
+export function updateFile(contents: string, path: string, kind?: 'gsql' | 'md') {
+  let next = {path, contents, kind}
+  let idx = files.findIndex(file => file.path == path)
+  if (idx >= 0) files[idx] = next
+  else files.push(next)
+}
+
+export async function loadWorkspace(dir: string, includeMd: boolean) {
+  files = await loadWorkspaceFiles(dir, includeMd, config.ignoredFiles)
+  lastResult = {files: [], diagnostics: []}
+}
+
+export function analyze(contents?: string, contentType?: 'gsql' | 'md') {
+  if (contents) {
+    lastResult = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents, kind: contentType})}, 'input')
+  } else {
+    lastResult = analyzeWorkspace({config, files})
+  }
+  files = files.map(file => {
+    let analyzed = getFileFromResult(lastResult, file.path)
+    if (!analyzed) return file
+    return {
+      ...file,
+      parsed: {
+        tree: analyzed.tree!,
+        virtualContents: analyzed.virtualContents,
+        virtualToMarkdownOffset: analyzed.virtualToMarkdownOffset,
+      },
+    }
+  })
+  return getFileFromResult(lastResult, 'input')?.queries || []
+}
+
+export function getDiagnostics() {
+  return getDiagnosticsFromResult(lastResult)
+}
+
+export function getTable(name: string) {
+  return getTableFromResult(lastResult, name)
+}
+
+export function getFile(name: string) {
+  return getFileFromResult(lastResult, name) || files.find(file => file.path == name)
+}
+
+export function getHover(path: string, line: number, col: number) {
+  return getHoverFromResult(lastResult, path, line, col)
+}
+
+export function getDefinition(path: string, line: number, col: number) {
+  return getDefinitionFromResult(lastResult, path, line, col)
+}
+
+export function getReferences(path: string, line: number, col: number, includeDeclaration = false) {
+  return getReferencesFromResult(lastResult, path, line, col, includeDeclaration)
 }
 
 // small delay to allow debugger to attach, since vitest doesn't support --inspect-wait

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -5,8 +5,38 @@ import type {TimestampUnit} from './temporal.ts'
 
 declare module '@lezer/common' {
   interface Tree {
-    fileInfo: FileInfo
+    fileInfo?: FileInfo
   }
+}
+
+export interface AnalysisWorkspace {
+  config: AnalysisConfig
+  files: WorkspaceFileInput[]
+}
+
+export interface AnalysisResult {
+  files: FileInfo[]
+  diagnostics: GrapheneError[]
+}
+
+export interface AnalysisConfig {
+  dialect: string
+  defaultNamespace?: string
+}
+
+export interface WorkspaceFileInput {
+  path: string
+  contents: string
+  kind?: FileKind
+  parsed?: ParsedFileArtifacts
+}
+
+export type FileKind = 'gsql' | 'md'
+
+export interface ParsedFileArtifacts {
+  tree: Tree
+  virtualContents?: string
+  virtualToMarkdownOffset?: number[]
 }
 
 export type ScalarTypeKind = 'string' | 'number' | 'boolean' | 'date' | 'timestamp' | 'json' | 'sql native' | 'error' | 'null' | 'interval' | 'record'
@@ -188,6 +218,7 @@ export interface IntervalExpr {
 
 // Context for analyzing expressions - table/alias change as we traverse joins, but query is shared
 export interface Scope {
+  file: FileInfo
   query?: Query // null when analyzing table definitions (not in a query context)
   table?: Table
   alias: string // current alias for this table context (e.g., "users", "orders", "users_orders")
@@ -243,6 +274,7 @@ export interface Column {
 interface TableBase {
   name: string
   tablePath: string
+  filePath: string
   columns: Column[]
   joins: QueryJoin[]
   metadata?: Record<string, string>
@@ -303,6 +335,7 @@ export interface NavigationSymbol {
   name: string
   location: Location
   tableId?: string
+  hover?: string
 }
 
 export interface NavigationReference {

--- a/lang/util.ts
+++ b/lang/util.ts
@@ -61,7 +61,7 @@ export function getFile(node: SyntaxNode | SyntaxNodeRef): FileInfo {
   if (node.node) node = node.node
   let top: SyntaxNode = node as SyntaxNode
   while (top.parent) top = top.parent
-  return top!.tree!.fileInfo
+  return top!.tree!.fileInfo!
 }
 
 export function txt(node: SyntaxNode | null | undefined) {

--- a/language-server/src/service.ts
+++ b/language-server/src/service.ts
@@ -14,8 +14,9 @@ import {
 } from 'vscode-languageserver-protocol'
 import {URI, Utils as URIs} from 'vscode-uri'
 
-import {deleteFile, updateFile, analyze, getDefinition, getDiagnostics, getFiles, getHover, getReferences, loadConfig, loadWorkspace} from '../../lang/core.ts'
-import {type GrapheneError, type Location as GrapheneLocation} from '../../lang/types.ts'
+import {config, loadConfig} from '../../lang/config.ts'
+import {analyzeWorkspace, getDefinition, getDiagnostics, getFiles, getHover, getReferences, loadWorkspace} from '../../lang/core.ts'
+import {type AnalysisResult, type GrapheneError, type Location as GrapheneLocation, type WorkspaceFileInput} from '../../lang/types.ts'
 
 export function createGrapheneService(server: ReturnType<typeof createServer>): LanguageServicePlugin {
   return {
@@ -31,10 +32,14 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
     },
     create(context): LanguageServicePluginInstance {
       let [workspace] = context.env.workspaceFolders
+      let workspaceFiles: WorkspaceFileInput[] = []
+      let analysisResult: AnalysisResult = {files: [], diagnostics: []}
       let analysis = createWorkspaceAnalysis({
         load: () => {
           loadConfig(workspace.fsPath)
-          return loadWorkspace(workspace.fsPath, true)
+          return loadWorkspace(workspace.fsPath, true, config.ignoredFiles).then(files => {
+            workspaceFiles = files
+          })
         },
         analyze: tryAnalyze,
         delay: 200,
@@ -52,20 +57,20 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
           await analysis.pending
 
           let path = workspacePath(document.uri)
-          return path ? {contents: getHover(path, position.line, position.character)} : null
+          return path ? {contents: getHover(analysisResult, path, position.line, position.character)} : null
         },
         async provideDefinition(document, position, _token) {
           await analysis.pending
 
           let path = workspacePath(document.uri)
-          let location = path ? getDefinition(path, position.line, position.character) : null
+          let location = path ? getDefinition(analysisResult, path, position.line, position.character) : null
           return location ? [toLocationLink(workspace, location)] : []
         },
         async provideReferences(document, position, context, _token) {
           await analysis.pending
 
           let path = workspacePath(document.uri)
-          return path ? getReferences(path, position.line, position.character, context.includeDeclaration).map(location => toLocation(workspace, location)) : []
+          return path ? getReferences(analysisResult, path, position.line, position.character, context.includeDeclaration).map(location => toLocation(workspace, location)) : []
         },
         async provideDiagnostics(document) {
           await analysis.pending
@@ -75,18 +80,14 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         },
         async provideWorkspaceDiagnostics() {
           await analysis.pending
-
           return workspaceDiagnostics()
         },
       }
 
       function workspacePath(uri: DocumentUri): string | null {
         let parsed = URI.parse(uri)
-        if (parsed.scheme === 'file') {
-          return relativePath(workspace.fsPath, parsed.fsPath)
-        } else {
-          return null
-        }
+        if (parsed.scheme !== 'file') return null
+        return relativePath(workspace.fsPath, parsed.fsPath)
       }
 
       function watchWorkspace(): Disposable {
@@ -104,12 +105,10 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
             if (!path) continue
 
             if (change.type === FileChangeType.Deleted) {
-              deleteFile(path)
+              workspaceFiles = workspaceFiles.filter(file => file.path != path)
             } else {
               let document = server.documents.get(URI.parse(change.uri))
-              if (document) {
-                updateFile(document.getText(), path)
-              }
+              if (document) workspaceFiles = upsertFile(workspaceFiles, {path, contents: document.getText()})
             }
           }
 
@@ -118,10 +117,9 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
 
         changeContent = server.documents.onDidChangeContent(({document}) => {
           let path = workspacePath(document.uri)
-          if (path) {
-            updateFile(document.getText(), path)
-            analysis.invalidate()
-          }
+          if (!path) return
+          workspaceFiles = upsertFile(workspaceFiles, {path, contents: document.getText()})
+          analysis.invalidate()
         })
 
         return {
@@ -135,7 +133,8 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
 
       async function tryAnalyze() {
         try {
-          analyze()
+          analysisResult = analyzeWorkspace({config, files: workspaceFiles})
+          workspaceFiles = updateParsedFiles(workspaceFiles, analysisResult)
           await server.languageFeatures.requestRefresh(false)
         } catch (err) {
           let message = err instanceof Error ? err.stack || err.message : String(err)
@@ -144,13 +143,13 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
       }
 
       function diagnosticsFor(path: string) {
-        return getDiagnostics()
+        return getDiagnostics(analysisResult)
           .filter(diagnostic => diagnostic.file === path)
           .map(toDiagnostic)
       }
 
       function workspaceDiagnostics() {
-        return getFiles().map(file => {
+        return getFiles(analysisResult).map(file => {
           return {
             kind: DocumentDiagnosticReportKind.Full,
             uri: URIs.joinPath(workspace, file.path).toString(),
@@ -161,6 +160,27 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
       }
     },
   }
+}
+
+function upsertFile(files: WorkspaceFileInput[], next: WorkspaceFileInput) {
+  let idx = files.findIndex(file => file.path == next.path)
+  if (idx < 0) return [...files, next]
+  return files.map((file, fileIdx) => (fileIdx == idx ? next : file))
+}
+
+function updateParsedFiles(files: WorkspaceFileInput[], result: AnalysisResult) {
+  return files.map(file => {
+    let analyzed = result.files.find(next => next.path == file.path)
+    if (!analyzed) return file
+    return {
+      ...file,
+      parsed: {
+        tree: analyzed.tree!,
+        virtualContents: analyzed.virtualContents,
+        virtualToMarkdownOffset: analyzed.virtualToMarkdownOffset,
+      },
+    }
+  })
 }
 
 // Coordinates workspace analysis: load once, run the initial analysis immediately,

--- a/language-server/src/service.ts
+++ b/language-server/src/service.ts
@@ -168,9 +168,9 @@ function upsertFile(files: WorkspaceFileInput[], next: WorkspaceFileInput) {
   return files.map((file, fileIdx) => (fileIdx == idx ? next : file))
 }
 
-function updateParsedFiles(files: WorkspaceFileInput[], result: AnalysisResult) {
+function updateParsedFiles(files: WorkspaceFileInput[], analysis: AnalysisResult) {
   return files.map(file => {
-    let analyzed = result.files.find(next => next.path == file.path)
+    let analyzed = analysis.files.find(next => next.path == file.path)
     if (!analyzed) return file
     return {
       ...file,

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -1,8 +1,8 @@
 import stripAnsi from 'strip-ansi'
 
 import {check} from '../../cli/check.ts'
+import {mockFileMap} from '../../cli/mockFiles.ts'
 import {runMdFile} from '../../cli/run.ts'
-import {updateFile} from '../../lang/core.ts'
 import {trimIndentation} from '../../lang/util.ts'
 import {test, expect} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
@@ -21,17 +21,15 @@ function outputLines() {
 
 test.beforeEach(() => {
   logs = ''
+  Object.keys(mockFileMap).forEach(key => delete mockFileMap[key])
 })
 
 test('check defaults to analyzing the whole workspace', async () => {
-  updateFile(
-    `
+  mockFileMap['tmp_bad.gsql'] = `
     table tmp_bad as (
       from flights select not_a_function()
     )
-  `,
-    'tmp_bad.gsql',
-  )
+  `
 
   await check({log})
   expect(outputLines()).toEqual(

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -6,8 +6,7 @@ import {test as base, onTestFinished} from 'vitest'
 
 import {mockFileMap} from '../../cli/mockFiles.ts'
 import {serve2} from '../../cli/serve2.ts'
-import {type Config, config, setConfig} from '../../lang/config.ts'
-import {clearWorkspace, loadWorkspace} from '../../lang/core.ts'
+import {type Config, setConfig} from '../../lang/config.ts'
 import {trackBrowserConsole} from './logWatcher.ts'
 import {playwrightExpect as expect} from './matchers.ts'
 
@@ -100,7 +99,6 @@ export const test = base.extend<{browser: Browser; page: Page; sharedPage: Page;
       let server = await serve2()
 
       function cleanup() {
-        clearWorkspace()
         Object.keys(mockFileMap).forEach(key => delete mockFileMap[key])
 
         // Vite caches our mocked files, so we need to clear them out after each test.
@@ -118,7 +116,6 @@ export const test = base.extend<{browser: Browser; page: Page; sharedPage: Page;
       await use({
         url: (options: Partial<Config> = {}) => {
           setConfig({...options, root: options.root || viteRoot, port} as any)
-          loadWorkspace(config.root, false)
           onTestFinished(cleanup)
           return `http://localhost:${port}`
         },
@@ -205,7 +202,6 @@ export const test = base.extend<{browser: Browser; page: Page; sharedPage: Page;
 test.beforeEach(() => {
   let root = path.join(fileURLToPath(import.meta.url), '../../../examples/flights')
   setConfig({root})
-  clearWorkspace()
 })
 
 async function getAvailablePort(): Promise<number> {


### PR DESCRIPTION
This PR refactors the core analysis logic to decouple it from workspace state handling. The design I landed on breaks down essentially as:

1. `AnalysisWorkspace` represents only the inputs to analysis: Configuration (mostly `dialect`) as well as workspace files (including parsed artifacts to reuse). This differs slightly from [this](https://graphenedata.slack.com/archives/C0AJE9DA2QL/p1774893946511029?thread_ts=1774471757.852819&cid=C0AJE9DA2QL) `Workspace` shape which included `diagnostics` and `tables` to be populated. Instead these are returned explicitly in the `AnalysisResult` which I think is clearer.
2. Per-analysis state (like `computedColumnStack` to detect computed column cycles) is encapsulated in an analyzer object and the various `analyzeXYZ` functions are generally methods on the analyzer. It also has instance state for the `AnalysisResult` it is building up. (And it is passed to the analysis functions in `functions.ts` so that they can use it to analyze expressions and report diagnostics).
3. Handling of any kind of cross-analysis workspace state is pushed entirely out of `lang/`. Specifically LSP and the serve task are the only callers that keep this kind of state and they just handle it themselves

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #239 
- <kbd>&nbsp;2&nbsp;</kbd> #233 
- <kbd>&nbsp;1&nbsp;</kbd> #232 👈 
<!-- GitButler Footer Boundary Bottom -->

