### PR TITLE
support multiple graphene projects in LSP

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -25,7 +25,7 @@ const pkgPath = fs.existsSync(path.join(__dirname, 'package.json')) ? path.join(
 const libPkg = fs.readJsonSync(pkgPath)
 program.name('graphene').description('Graphene CLI').version(libPkg.version, '-v, --version')
 
-loadConfig(process.cwd(), envFiles => {
+await loadConfig(process.cwd(), envFiles => {
   dotenv.config({quiet: true, path: envFiles || '.env'})
 })
 

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs'
+import {readFile} from 'node:fs/promises'
 import path from 'path'
 
 export interface Config {
@@ -62,9 +62,9 @@ export function normalizeConfig(input: ConfigInput, defaultRoot = process.cwd())
   } as Config
 }
 
-export function readConfigInput(dir: string): ConfigInput | null {
+export async function readConfigInput(dir: string): Promise<ConfigInput | null> {
   try {
-    let txt = fs.readFileSync(path.join(dir, 'package.json'), 'utf8')
+    let txt = await readFile(path.join(dir, 'package.json'), 'utf8')
     let graphene = JSON.parse(txt).graphene
     if (!graphene || typeof graphene != 'object' || Array.isArray(graphene)) return null
     return graphene
@@ -73,15 +73,15 @@ export function readConfigInput(dir: string): ConfigInput | null {
   }
 }
 
-export function readConfig(dir: string, envLoader?: (envFiles: string[] | string) => void, defaultRoot = dir): Config {
-  let packageJsonObject = readConfigInput(dir) || ({} as ConfigInput)
+export async function readConfig(dir: string, envLoader?: (envFiles: string[] | string) => void, defaultRoot = dir): Promise<Config> {
+  let packageJsonObject = (await readConfigInput(dir)) || ({} as ConfigInput)
   if (envLoader) envLoader(packageJsonObject.envFile || ['.env'])
   return normalizeConfig({...packageJsonObject, root: packageJsonObject.root || defaultRoot}, defaultRoot)
 }
 
 // Read graphene config out of package.json
-export function loadConfig(dir: string, envLoader?: (envFiles: string[] | string) => void) {
+export async function loadConfig(dir: string, envLoader?: (envFiles: string[] | string) => void) {
   if (config.root) return
   Object.keys(config).forEach(key => delete config[key])
-  Object.assign(config, readConfig(dir, envLoader, process.cwd()))
+  Object.assign(config, await readConfig(dir, envLoader, process.cwd()))
 }

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -36,32 +36,52 @@ export type ConfigInput = Omit<Config, 'dialect' | 'ignoredFiles' | 'envFile'> &
 export let config: Config = {dialect: 'duckdb', root: ''} as Config
 
 export function setConfig(cfg: ConfigInput) {
+  Object.keys(config).forEach(key => delete config[key])
+  Object.assign(config, normalizeConfig(cfg))
+}
+
+export function normalizeConfig(input: ConfigInput, defaultRoot = process.cwd()): Config {
+  let cfg = {...input}
   if (cfg.namespace && !cfg.defaultNamespace) cfg.defaultNamespace = cfg.namespace
+
   let dialect = cfg.dialect || 'duckdb'
   if (cfg.bigquery) dialect = 'bigquery'
   else if (cfg.snowflake) dialect = 'snowflake'
   else if (cfg.duckdb) dialect = 'duckdb'
-  Object.keys(config).forEach(key => delete config[key])
-  Object.assign(config, cfg)
-  config.dialect = dialect
-  config.root ||= process.cwd()
-  config.port ||= Number(process.env.GRAPHENE_PORT) || 4000
-  config.ignoredFiles ||= ['agents.md', 'claude.md']
+  let envFile = ['.env']
+  if (Array.isArray(cfg.envFile)) envFile = cfg.envFile
+  else if (cfg.envFile) envFile = [cfg.envFile]
+
+  return {
+    ...cfg,
+    dialect,
+    root: cfg.root || defaultRoot,
+    port: cfg.port || Number(process.env.GRAPHENE_PORT) || 4000,
+    ignoredFiles: cfg.ignoredFiles || ['agents.md', 'claude.md'],
+    envFile,
+  } as Config
+}
+
+export function readConfigInput(dir: string): ConfigInput | null {
+  try {
+    let txt = fs.readFileSync(path.join(dir, 'package.json'), 'utf8')
+    let graphene = JSON.parse(txt).graphene
+    if (!graphene || typeof graphene != 'object' || Array.isArray(graphene)) return null
+    return graphene
+  } catch {
+    return null
+  }
+}
+
+export function readConfig(dir: string, envLoader?: (envFiles: string[] | string) => void, defaultRoot = dir): Config {
+  let packageJsonObject = readConfigInput(dir) || ({} as ConfigInput)
+  if (envLoader) envLoader(packageJsonObject.envFile || ['.env'])
+  return normalizeConfig({...packageJsonObject, root: packageJsonObject.root || defaultRoot}, defaultRoot)
 }
 
 // Read graphene config out of package.json
 export function loadConfig(dir: string, envLoader?: (envFiles: string[] | string) => void) {
   if (config.root) return
-
-  let packageJsonObject = {} as any
-  try {
-    let txt = fs.readFileSync(path.join(dir, 'package.json'), 'utf8')
-    packageJsonObject = JSON.parse(txt).graphene || {}
-  } catch {
-    console.warn('No package.json found in current directory')
-  }
-
-  if (envLoader) envLoader(packageJsonObject.envFile || ['.env'])
-
-  setConfig({...packageJsonObject, root: packageJsonObject.root || process.cwd()})
+  Object.keys(config).forEach(key => delete config[key])
+  Object.assign(config, readConfig(dir, envLoader, process.cwd()))
 }

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -7,6 +7,7 @@
     "@volar/language-core": "^2.4.28",
     "@volar/language-server": "^2.4.28",
     "@volar/language-service": "^2.4.28",
+    "glob": "^13.0.1",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-uri": "^3.1.0"
   }

--- a/language-server/src/service.test.ts
+++ b/language-server/src/service.test.ts
@@ -1,0 +1,85 @@
+/// <reference types="vitest/globals" />
+import {mkdtemp, mkdir, rm, writeFile} from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {expect} from 'vitest'
+import {URI} from 'vscode-uri'
+
+import {discoverGrapheneProjects, findOwningProjectRoot} from './service.ts'
+
+describe('Graphene project discovery', () => {
+  it('finds package.json files with a top-level graphene config and ignores other packages', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-lsp-'))
+
+    try {
+      await mkdir(path.join(root, 'app'), {recursive: true})
+      await mkdir(path.join(root, 'nested', 'child'), {recursive: true})
+      await mkdir(path.join(root, 'scripts-only'), {recursive: true})
+      await mkdir(path.join(root, 'node_modules', 'dep'), {recursive: true})
+      await mkdir(path.join(root, '.cache', 'hidden'), {recursive: true})
+
+      await writeFile(
+        path.join(root, 'app', 'package.json'),
+        JSON.stringify({
+          name: 'app',
+          graphene: {defaultNamespace: 'analytics'},
+        }),
+      )
+
+      await writeFile(
+        path.join(root, 'nested', 'child', 'package.json'),
+        JSON.stringify({
+          name: 'child',
+          graphene: {snowflake: {account: 'acct', username: 'user', privateKeyPath: './snowflake.pem'}},
+        }),
+      )
+
+      await writeFile(
+        path.join(root, 'scripts-only', 'package.json'),
+        JSON.stringify({
+          name: 'scripts-only',
+          scripts: {graphene: 'node cli.js'},
+        }),
+      )
+
+      await writeFile(
+        path.join(root, 'node_modules', 'dep', 'package.json'),
+        JSON.stringify({
+          name: 'dep',
+          graphene: {defaultNamespace: 'ignored'},
+        }),
+      )
+
+      await writeFile(
+        path.join(root, '.cache', 'hidden', 'package.json'),
+        JSON.stringify({
+          name: 'hidden',
+          graphene: {defaultNamespace: 'ignored'},
+        }),
+      )
+
+      let projects = await discoverGrapheneProjects([URI.file(root)])
+
+      expect(projects.map(project => project.root)).toEqual([path.join(root, 'app'), path.join(root, 'nested', 'child')])
+      expect(projects[0].config.root).toBe(path.join(root, 'app'))
+      expect(projects[0].config.defaultNamespace).toBe('analytics')
+      expect(projects[0].config.dialect).toBe('duckdb')
+      expect(projects[1].config.root).toBe(path.join(root, 'nested', 'child'))
+      expect(projects[1].config.dialect).toBe('snowflake')
+    } finally {
+      await rm(root, {recursive: true, force: true})
+    }
+  })
+})
+
+describe('project ownership', () => {
+  it('uses the nearest ancestor project root for nested projects', () => {
+    let root = '/repo'
+    let appRoot = path.join(root, 'app')
+    let nestedRoot = path.join(appRoot, 'packages', 'subproject')
+
+    expect(findOwningProjectRoot(path.join(nestedRoot, 'report.md'), [appRoot, nestedRoot])).toBe(nestedRoot)
+    expect(findOwningProjectRoot(path.join(appRoot, 'tables', 'users.gsql'), [appRoot, nestedRoot])).toBe(appRoot)
+    expect(findOwningProjectRoot(path.join(root, 'notes.md'), [appRoot, nestedRoot])).toBeNull()
+  })
+})

--- a/language-server/src/service.ts
+++ b/language-server/src/service.ts
@@ -16,7 +16,7 @@ import {
 } from 'vscode-languageserver-protocol'
 import {URI} from 'vscode-uri'
 
-import {type Config, readConfig, readConfigInput} from '../../lang/config.ts'
+import {type Config, normalizeConfig, readConfigInput} from '../../lang/config.ts'
 import {analyzeWorkspace, getDefinition, getDiagnostics, getFiles, getHover, getReferences, loadWorkspace} from '../../lang/core.ts'
 import {type AnalysisResult, type GrapheneError, type Location as GrapheneLocation, type WorkspaceFileInput} from '../../lang/types.ts'
 
@@ -257,8 +257,9 @@ export async function discoverGrapheneProjects(workspaceFolders: readonly URI[])
 
     for (let packageJsonPath of packageJsonPaths) {
       let root = path.join(workspace.fsPath, path.dirname(packageJsonPath))
-      if (!readConfigInput(root)) continue
-      projects.set(root, {root, config: readConfig(root, undefined, root)})
+      let input = await readConfigInput(root)
+      if (!input) continue
+      projects.set(root, {root, config: normalizeConfig({...input, root: input.root || root}, root)})
     }
   }
 

--- a/language-server/src/service.ts
+++ b/language-server/src/service.ts
@@ -65,29 +65,31 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         async provideHover(document, position) {
           await analysis.pending
 
-          let target = projectDocument(document.uri)
-          return target ? {contents: getHover(target.project.analysis, target.path, position.line, position.character)} : null
+          let target = projectFromUri(document.uri)
+          if (!target) return null
+          return {contents: getHover(target.project.analysis, target.path, position.line, position.character)}
         },
         async provideDefinition(document, position, _token) {
           await analysis.pending
 
-          let target = projectDocument(document.uri)
-          let location = target ? getDefinition(target.project.analysis, target.path, position.line, position.character) : null
-          return target && location ? [toLocationLink(target.project.root, location)] : []
+          let target = projectFromUri(document.uri)
+          if (!target) return []
+          let location = getDefinition(target.project.analysis, target.path, position.line, position.character)
+          return location ? [toLocationLink(target.project.root, location)] : []
         },
         async provideReferences(document, position, context, _token) {
           await analysis.pending
 
-          let target = projectDocument(document.uri)
-          return target
-            ? getReferences(target.project.analysis, target.path, position.line, position.character, context.includeDeclaration).map(location => toLocation(target.project.root, location))
-            : []
+          let target = projectFromUri(document.uri)
+          if (!target) return []
+          return getReferences(target.project.analysis, target.path, position.line, position.character, context.includeDeclaration).map(location => toLocation(target.project.root, location))
         },
         async provideDiagnostics(document) {
           await analysis.pending
 
-          let target = projectDocument(document.uri)
-          return target ? diagnosticsFor(target.project, target.path) : []
+          let target = projectFromUri(document.uri)
+          if (!target) return []
+          return diagnosticsFor(target.project, target.path)
         },
         async provideWorkspaceDiagnostics() {
           await analysis.pending
@@ -125,7 +127,7 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         })
 
         changeContent = server.documents.onDidChangeContent(({document}) => {
-          let target = projectDocument(document.uri)
+          let target = projectFromUri(document.uri)
           if (!target) return
 
           target.project.files = upsertFile(target.project.files, {path: target.path, contents: document.getText()})
@@ -146,7 +148,7 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         let touched = false
 
         for (let change of changes) {
-          let target = projectPath(change.uri)
+          let target = projectFromUri(change.uri)
           if (!target) continue
 
           if (change.type === FileChangeType.Deleted) {
@@ -165,13 +167,7 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         if (touched) analysis.invalidate()
       }
 
-      function projectDocument(uri: DocumentUri) {
-        let target = projectPath(uri)
-        if (!target) return null
-        return {project: target.project, path: target.path}
-      }
-
-      function projectPath(uri: DocumentUri) {
+      function projectFromUri(uri: DocumentUri) {
         let absolutePath = fileUriPath(uri)
         if (!absolutePath) return null
 

--- a/language-server/src/service.ts
+++ b/language-server/src/service.ts
@@ -1,22 +1,38 @@
 import {type createServer} from '@volar/language-server/node.js'
 import {type LanguageServicePlugin, type LanguageServicePluginInstance} from '@volar/language-service'
-import {relative as relativePath} from 'node:path'
+import {glob} from 'glob'
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
 import {
   DiagnosticSeverity,
   DocumentDiagnosticReportKind,
   FileChangeType,
   type Diagnostic,
   type Disposable,
-  type WorkspaceDocumentDiagnosticReport,
   type DocumentUri,
   type Location,
   type LocationLink,
+  type WorkspaceDocumentDiagnosticReport,
 } from 'vscode-languageserver-protocol'
-import {URI, Utils as URIs} from 'vscode-uri'
+import {URI} from 'vscode-uri'
 
-import {config, loadConfig} from '../../lang/config.ts'
+import {type Config, readConfig, readConfigInput} from '../../lang/config.ts'
 import {analyzeWorkspace, getDefinition, getDiagnostics, getFiles, getHover, getReferences, loadWorkspace} from '../../lang/core.ts'
 import {type AnalysisResult, type GrapheneError, type Location as GrapheneLocation, type WorkspaceFileInput} from '../../lang/types.ts'
+
+type ProjectRoot = string
+
+interface ProjectState {
+  root: ProjectRoot
+  config: Config
+  files: WorkspaceFileInput[]
+  analysis: AnalysisResult
+}
+
+export interface DiscoveredGrapheneProject {
+  root: ProjectRoot
+  config: Config
+}
 
 export function createGrapheneService(server: ReturnType<typeof createServer>): LanguageServicePlugin {
   return {
@@ -31,22 +47,15 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
       referencesProvider: true,
     },
     create(context): LanguageServicePluginInstance {
-      let [workspace] = context.env.workspaceFolders
-      let workspaceFiles: WorkspaceFileInput[] = []
-      let analysisResult: AnalysisResult = {files: [], diagnostics: []}
+      let projects = new Map<ProjectRoot, ProjectState>()
+      let dirtyRoots = new Set<ProjectRoot>()
+      let reportedDiagnosticUris = new Set<string>()
       let analysis = createWorkspaceAnalysis({
-        load: () => {
-          loadConfig(workspace.fsPath)
-          return loadWorkspace(workspace.fsPath, true, config.ignoredFiles).then(files => {
-            workspaceFiles = files
-          })
-        },
-        analyze: tryAnalyze,
+        load: loadProjects,
+        analyze: analyzeDirtyProjects,
         delay: 200,
       })
       let workspaceWatcher = watchWorkspace()
-
-      console.log('started Graphene language server', workspace.fsPath)
 
       return {
         dispose() {
@@ -56,27 +65,29 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         async provideHover(document, position) {
           await analysis.pending
 
-          let path = workspacePath(document.uri)
-          return path ? {contents: getHover(analysisResult, path, position.line, position.character)} : null
+          let target = projectDocument(document.uri)
+          return target ? {contents: getHover(target.project.analysis, target.path, position.line, position.character)} : null
         },
         async provideDefinition(document, position, _token) {
           await analysis.pending
 
-          let path = workspacePath(document.uri)
-          let location = path ? getDefinition(analysisResult, path, position.line, position.character) : null
-          return location ? [toLocationLink(workspace, location)] : []
+          let target = projectDocument(document.uri)
+          let location = target ? getDefinition(target.project.analysis, target.path, position.line, position.character) : null
+          return target && location ? [toLocationLink(target.project.root, location)] : []
         },
         async provideReferences(document, position, context, _token) {
           await analysis.pending
 
-          let path = workspacePath(document.uri)
-          return path ? getReferences(analysisResult, path, position.line, position.character, context.includeDeclaration).map(location => toLocation(workspace, location)) : []
+          let target = projectDocument(document.uri)
+          return target
+            ? getReferences(target.project.analysis, target.path, position.line, position.character, context.includeDeclaration).map(location => toLocation(target.project.root, location))
+            : []
         },
         async provideDiagnostics(document) {
           await analysis.pending
 
-          let path = workspacePath(document.uri)
-          return path ? diagnosticsFor(path) : []
+          let target = projectDocument(document.uri)
+          return target ? diagnosticsFor(target.project, target.path) : []
         },
         async provideWorkspaceDiagnostics() {
           await analysis.pending
@@ -84,10 +95,20 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         },
       }
 
-      function workspacePath(uri: DocumentUri): string | null {
-        let parsed = URI.parse(uri)
-        if (parsed.scheme !== 'file') return null
-        return relativePath(workspace.fsPath, parsed.fsPath)
+      async function loadProjects() {
+        let discovered = await discoverGrapheneProjects(context.env.workspaceFolders || [])
+        let next = new Map<ProjectRoot, ProjectState>()
+
+        await Promise.all(
+          discovered.map(async project => {
+            let files = await loadWorkspace(project.root, true, project.config.ignoredFiles)
+            next.set(project.root, {root: project.root, config: project.config, files, analysis: {files: [], diagnostics: []}})
+          }),
+        )
+
+        projects = next
+        dirtyRoots = new Set(next.keys())
+        console.log('started Graphene language server', [...projects.keys()])
       }
 
       function watchWorkspace(): Disposable {
@@ -100,25 +121,15 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         })
 
         changeWatchedFiles = server.fileWatcher.onDidChangeWatchedFiles(({changes}) => {
-          for (let change of changes) {
-            let path = workspacePath(change.uri)
-            if (!path) continue
-
-            if (change.type === FileChangeType.Deleted) {
-              workspaceFiles = workspaceFiles.filter(file => file.path != path)
-            } else {
-              let document = server.documents.get(URI.parse(change.uri))
-              if (document) workspaceFiles = upsertFile(workspaceFiles, {path, contents: document.getText()})
-            }
-          }
-
-          analysis.invalidate()
+          void applyFileChanges(changes)
         })
 
         changeContent = server.documents.onDidChangeContent(({document}) => {
-          let path = workspacePath(document.uri)
-          if (!path) return
-          workspaceFiles = upsertFile(workspaceFiles, {path, contents: document.getText()})
+          let target = projectDocument(document.uri)
+          if (!target) return
+
+          target.project.files = upsertFile(target.project.files, {path: target.path, contents: document.getText()})
+          dirtyRoots.add(target.project.root)
           analysis.invalidate()
         })
 
@@ -131,35 +142,157 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         }
       }
 
-      async function tryAnalyze() {
-        try {
-          analysisResult = analyzeWorkspace({config, files: workspaceFiles})
-          workspaceFiles = updateParsedFiles(workspaceFiles, analysisResult)
-          await server.languageFeatures.requestRefresh(false)
-        } catch (err) {
-          let message = err instanceof Error ? err.stack || err.message : String(err)
-          console.error(`Analyze failed: ${message}`)
+      async function applyFileChanges(changes: {uri: DocumentUri; type: FileChangeType}[]) {
+        let touched = false
+
+        for (let change of changes) {
+          let target = projectPath(change.uri)
+          if (!target) continue
+
+          if (change.type === FileChangeType.Deleted) {
+            target.project.files = target.project.files.filter(file => file.path != target.path)
+          } else {
+            let document = server.documents.get(URI.parse(change.uri))
+            let contents = document?.getText() || (await readWorkspaceFile(target.absolutePath))
+            if (contents == null) continue
+            target.project.files = upsertFile(target.project.files, {path: target.path, contents})
+          }
+
+          dirtyRoots.add(target.project.root)
+          touched = true
+        }
+
+        if (touched) analysis.invalidate()
+      }
+
+      function projectDocument(uri: DocumentUri) {
+        let target = projectPath(uri)
+        if (!target) return null
+        return {project: target.project, path: target.path}
+      }
+
+      function projectPath(uri: DocumentUri) {
+        let absolutePath = fileUriPath(uri)
+        if (!absolutePath) return null
+
+        let root = findOwningProjectRoot(absolutePath, projects.keys())
+        if (!root) return null
+
+        let project = projects.get(root)
+        if (!project) return null
+
+        return {
+          project,
+          absolutePath,
+          path: path.relative(root, absolutePath),
         }
       }
 
-      function diagnosticsFor(path: string) {
-        return getDiagnostics(analysisResult)
-          .filter(diagnostic => diagnostic.file === path)
+      async function analyzeDirtyProjects() {
+        let changed = false
+
+        for (let root of dirtyRoots) {
+          let project = projects.get(root)
+          if (!project) continue
+
+          try {
+            project.analysis = analyzeWorkspace({config: project.config, files: project.files})
+            project.files = updateParsedFiles(project.files, project.analysis)
+            changed = true
+          } catch (err) {
+            let message = err instanceof Error ? err.stack || err.message : String(err)
+            console.error(`Analyze failed for ${root}: ${message}`)
+          }
+        }
+
+        dirtyRoots.clear()
+        if (changed) await server.languageFeatures.requestRefresh(false)
+      }
+
+      function diagnosticsFor(project: ProjectState, filePath: string) {
+        return getDiagnostics(project.analysis)
+          .filter(diagnostic => diagnostic.file === filePath)
           .map(toDiagnostic)
       }
 
       function workspaceDiagnostics() {
-        return getFiles(analysisResult).map(file => {
-          return {
-            kind: DocumentDiagnosticReportKind.Full,
-            uri: URIs.joinPath(workspace, file.path).toString(),
-            version: null,
-            items: diagnosticsFor(file.path),
+        let currentUris = new Set<string>()
+        let reports: WorkspaceDocumentDiagnosticReport[] = []
+
+        for (let project of projects.values()) {
+          for (let file of getFiles(project.analysis)) {
+            let uri = URI.file(path.resolve(project.root, file.path)).toString()
+            currentUris.add(uri)
+            reports.push({
+              kind: DocumentDiagnosticReportKind.Full,
+              uri,
+              version: null,
+              items: diagnosticsFor(project, file.path),
+            })
           }
-        }) satisfies WorkspaceDocumentDiagnosticReport[]
+        }
+
+        for (let uri of reportedDiagnosticUris) {
+          if (currentUris.has(uri)) continue
+          reports.push({
+            kind: DocumentDiagnosticReportKind.Full,
+            uri,
+            version: null,
+            items: [],
+          })
+        }
+
+        reportedDiagnosticUris = currentUris
+        return reports
       }
     },
   }
+}
+
+export async function discoverGrapheneProjects(workspaceFolders: readonly URI[]): Promise<DiscoveredGrapheneProject[]> {
+  let projects = new Map<ProjectRoot, DiscoveredGrapheneProject>()
+
+  for (let workspace of workspaceFolders) {
+    let packageJsonPaths = await glob('**/package.json', {
+      cwd: workspace.fsPath,
+      ignore: ['node_modules/**', '**/.*/**'],
+      follow: false,
+    })
+
+    for (let packageJsonPath of packageJsonPaths) {
+      let root = path.join(workspace.fsPath, path.dirname(packageJsonPath))
+      if (!readConfigInput(root)) continue
+      projects.set(root, {root, config: readConfig(root, undefined, root)})
+    }
+  }
+
+  return [...projects.values()].sort((left, right) => left.root.localeCompare(right.root))
+}
+
+export function findOwningProjectRoot(filePath: string, projectRoots: Iterable<ProjectRoot>): ProjectRoot | null {
+  let matches = [...projectRoots].filter(root => containsPath(root, filePath))
+  if (!matches.length) return null
+  matches.sort((left, right) => right.length - left.length)
+  return matches[0]
+}
+
+function containsPath(root: ProjectRoot, filePath: string) {
+  let relative = path.relative(root, filePath)
+  return relative == '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+async function readWorkspaceFile(filePath: string) {
+  try {
+    return await readFile(filePath, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+function fileUriPath(uri: DocumentUri): string | null {
+  let parsed = URI.parse(uri)
+  if (parsed.scheme !== 'file') return null
+  return parsed.fsPath
 }
 
 function upsertFile(files: WorkspaceFileInput[], next: WorkspaceFileInput) {
@@ -232,9 +365,9 @@ function toDiagnostic(diagnostic: GrapheneError): Diagnostic {
   }
 }
 
-function toLocation(workspace: URI, location: GrapheneLocation): Location {
+function toLocation(root: ProjectRoot, location: GrapheneLocation): Location {
   return {
-    uri: URIs.joinPath(workspace, location.file).toString(),
+    uri: URI.file(path.resolve(root, location.file)).toString(),
     range: {
       start: {line: location.from.line, character: location.from.col},
       end: {line: location.to.line, character: location.to.col},
@@ -242,8 +375,8 @@ function toLocation(workspace: URI, location: GrapheneLocation): Location {
   }
 }
 
-function toLocationLink(workspace: URI, location: GrapheneLocation): LocationLink {
-  let uri = URIs.joinPath(workspace, location.file).toString()
+function toLocationLink(root: ProjectRoot, location: GrapheneLocation): LocationLink {
+  let uri = URI.file(path.resolve(root, location.file)).toString()
   let range = {
     start: {line: location.from.line, character: location.from.col},
     end: {line: location.to.line, character: location.to.col},

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": "^10.0.2",
     "eslint-plugin-prefer-let": "^4.0.1",
     "eslint-plugin-svelte": "^3.14.0",
+    "glob": "^13.0.1",
     "globals": "^16.5.0",
     "oxfmt": "^0.36.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       eslint-plugin-svelte:
         specifier: ^3.14.0
         version: 3.15.0(eslint@10.0.3)(svelte@5.53.7)
+      glob:
+        specifier: ^13.0.1
+        version: 13.0.6
       globals:
         specifier: ^16.5.0
         version: 16.5.0
@@ -244,6 +247,9 @@ importers:
       '@volar/language-service':
         specifier: ^2.4.28
         version: 2.4.28
+      glob:
+        specifier: ^13.0.1
+        version: 13.0.6
       vscode-languageserver-protocol:
         specifier: ^3.17.5
         version: 3.17.5

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,13 @@ export default defineConfig({
           include: ['vscode/**/*.test.ts'],
         },
       },
+      {
+        extends: true,
+        test: {
+          name: 'language-server',
+          include: ['language-server/**/*.test.ts'],
+        },
+      },
     ],
   },
 })


### PR DESCRIPTION
This PR takes advantage of the refactor from #232 to support multiple graphene projects in the LSP, discovered by looking for `package.json` files with graphene configs. (I'm also using it to test GitButler's stacked PR support)

fixes #200

