### PR TITLE
bare niladic function support

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -14,7 +14,7 @@ import {
   multiGrainMessage,
   uniqueFanoutPaths,
 } from './fanout.ts'
-import {analyzeFunction} from './functions.ts'
+import {analyzeBareFunction, analyzeFunction} from './functions.ts'
 import {parseMarkdown} from './markdown.ts'
 import {extractLeadingMetadata} from './metadata.ts'
 import {parser} from './parser.js'
@@ -752,6 +752,10 @@ class AnalysisSession implements Analyzer {
         if (matches.length == 0) {
           if (possibleJoins.some(join => join.table.joins.some(next => next.alias == fieldName))) {
             return this.diag(fieldNode, `"${fieldName}" is a join, not a column`, {sql: 'NULL', type: scalarType('error')})
+          }
+          if (pathNodes.length == 0) {
+            let bareFn = analyzeBareFunction(this, node, fieldName.toLowerCase(), scope)
+            if (bareFn) return bareFn
           }
           let on = possibleJoins.length == 1 ? ` on ${possibleJoins[0].table.name}` : ''
           return this.diag(fieldNode, `Unknown field "${fieldName}"${on}`, {sql: 'NULL', type: scalarType('error')})

--- a/lang/bigQueryFunctions.ts
+++ b/lang/bigQueryFunctions.ts
@@ -1868,6 +1868,7 @@ export const bigQueryFunctions: FunctionDef[] = [
     url: `${bq}/date_functions#current_date`,
     args: [{name: 'time_zone', type: 'string?', description: 'The time zone to use. Defaults to UTC.'}],
     returns: 'date',
+    supportsBareInvocation: true,
   },
   {
     name: 'date',
@@ -2072,6 +2073,7 @@ export const bigQueryFunctions: FunctionDef[] = [
     url: `${bq}/datetime_functions#current_datetime`,
     args: [{name: 'time_zone', type: 'string?', description: 'The time zone to use. Defaults to UTC.'}],
     returns: 'timestamp',
+    supportsBareInvocation: true,
   },
   {
     name: 'local_timestamp',
@@ -2084,6 +2086,7 @@ export const bigQueryFunctions: FunctionDef[] = [
     args: [],
     returns: 'timestamp',
     sqlName: 'CURRENT_DATETIME',
+    supportsBareInvocation: true,
   },
   {
     name: 'datetime',
@@ -2240,6 +2243,7 @@ export const bigQueryFunctions: FunctionDef[] = [
     url: `${bq}/time_functions#current_time`,
     args: [{name: 'time_zone', type: 'string?', description: 'The time zone to use. Defaults to UTC.'}],
     returns: 'timestamp', // Graphene treats TIME as timestamp
+    supportsBareInvocation: true,
   },
   {
     name: 'time',
@@ -2398,6 +2402,7 @@ export const bigQueryFunctions: FunctionDef[] = [
     url: `${bq}/timestamp_functions#current_timestamp`,
     args: [{name: 'time_zone', type: 'string?', description: 'The time zone to use.'}],
     returns: 'timestamp',
+    supportsBareInvocation: true,
   },
   {
     name: 'timestamp',

--- a/lang/duckDbFunctions.ts
+++ b/lang/duckDbFunctions.ts
@@ -2108,6 +2108,7 @@ export const duckDbFunctions: FunctionDef[] = [
     url: `${duck}/date#current_date`,
     args: [],
     returns: 'date',
+    supportsBareInvocation: true,
   },
   {
     name: 'current_time',
@@ -2119,6 +2120,7 @@ export const duckDbFunctions: FunctionDef[] = [
     url: `${duck}/timestamp#current_time`,
     args: [],
     returns: 'timestamp',
+    supportsBareInvocation: true,
   },
   {
     name: 'current_timestamp',
@@ -2130,6 +2132,7 @@ export const duckDbFunctions: FunctionDef[] = [
     url: `${duck}/timestamp#current_localtimestamp`,
     args: [{name: 'precision', type: 'number?'}],
     returns: 'timestamp',
+    supportsBareInvocation: true,
   },
   {
     name: 'local_timestamp',
@@ -2142,6 +2145,20 @@ export const duckDbFunctions: FunctionDef[] = [
     args: [],
     returns: 'timestamp',
     sqlName: 'LOCALTIMESTAMP',
+    aliases: ['localtimestamp'],
+    supportsBareInvocation: true,
+  },
+  {
+    name: 'localtime',
+    description: trim(`
+      localtime
+
+      Returns the current time in the local time zone.
+    `),
+    url: `${duck}/timestamp#current_time`,
+    args: [],
+    returns: 'timestamp',
+    supportsBareInvocation: true,
   },
 
   // ============================================================================

--- a/lang/functionTypes.ts
+++ b/lang/functionTypes.ts
@@ -35,6 +35,10 @@ export interface FunctionDef {
   sqlTemplate?: string
   // Alternative names that should also resolve to this function (e.g., ['count_if'] for 'countif')
   aliases?: string[]
+  // Whether a zero-arg function can also be invoked as a bare identifier without parentheses.
+  supportsBareInvocation?: boolean
+  // SQL spelling to use for bare invocations when it differs from `sqlName`/`name`.
+  bareSqlName?: string
   // For functions with multiple overloads (e.g., string_agg with/without separator)
   // When present, `args` and `returns` are ignored in favor of overloads
   overloads?: FunctionOverload[]

--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -29,6 +29,8 @@ interface Overload {
   returnType: {type: FieldType | 'generic' | 'array'; expressionType?: 'aggregate' | 'scalar' | 'window'}
   fanoutSafe?: boolean
   sqlName?: string
+  supportsBareInvocation?: boolean
+  bareSqlName?: string
 }
 
 // Convert a FunctionDef arg type string (e.g. 'number', 'T', 'string...', 'kw') to allowedTypes
@@ -74,6 +76,8 @@ function convertDef(def: FunctionDef): Overload[] {
     returnType: {type: returnType, expressionType},
     fanoutSafe: def.fanoutSafe,
     sqlName: def.sqlName,
+    supportsBareInvocation: def.supportsBareInvocation && args.length == 0,
+    bareSqlName: def.bareSqlName,
   }))
 }
 
@@ -115,7 +119,18 @@ function findOverloads(name: string, dialect: string): Overload[] {
 export function analyzeFunction(analyzer: Analyzer, node: SyntaxNode, scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
   let name = txt(node.getChild('Identifier')).toLowerCase()
   let argNodes = node.getChildren('Expression')
+  return analyzeNamedFunction(analyzer, node, name, argNodes, scope, opts)
+}
 
+export function analyzeBareFunction(analyzer: Analyzer, node: SyntaxNode, name: string, scope: Scope, opts: {isWindow?: boolean} = {}): Expr | undefined {
+  let overloads = findOverloads(name, analyzer.config.dialect)
+  if (overloads.length == 0) return
+  let overload = overloads.find(o => o.supportsBareInvocation && o.params.length == 0)
+  if (!overload) return
+  return analyzeResolvedFunction(name, overload, [], [], scope, {...opts, bare: true})
+}
+
+function analyzeNamedFunction(analyzer: Analyzer, node: SyntaxNode, name: string, argNodes: SyntaxNode[], scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
   // Check for percentile functions (p50, p90, etc.) before overload lookup
   let percentileMatch = /^p(\d+)$/.exec(name)
   if (percentileMatch) {
@@ -156,6 +171,10 @@ export function analyzeFunction(analyzer: Analyzer, node: SyntaxNode, scope: Sco
     return analyzer.diag(node, `Wrong number of arguments for ${name}: expected ${expected}, got ${argNodes.length}`, {sql: 'NULL', type: scalarType('error')})
   }
 
+  return analyzeResolvedFunction(name, overload, args, argNodes, scope, opts)
+}
+
+function analyzeResolvedFunction(name: string, overload: Overload, args: Expr[], argNodes: SyntaxNode[], scope: Scope, opts: {isWindow?: boolean; bare?: boolean} = {}): Expr {
   let returnType: FieldType = overload.returnType.type as FieldType
   if (overload.returnType.type == 'generic') returnType = args[0]?.type || scalarType('string')
   if (overload.returnType.type == 'array') returnType = inferArrayReturnType(args)
@@ -169,8 +188,8 @@ export function analyzeFunction(analyzer: Analyzer, node: SyntaxNode, scope: Sco
   if (overload.returnType.expressionType == 'aggregate' && !fanoutSafeAgg) {
     fanoutSensitivePaths = mergeSensitiveFanouts(fanoutSensitivePaths, [fanout.path || extendFanoutPath(scope.fanoutPath)])
   }
-  let fnName = overload.sqlName || name
-  let sql = `${fnName}(${args.map(a => a.sql).join(',')})`
+  let fnName = opts.bare ? overload.bareSqlName || overload.sqlName || name : overload.sqlName || name
+  let sql = opts.bare ? fnName : `${fnName}(${args.map(a => a.sql).join(',')})`
   let metadata = inferFunctionFieldMetadata(name, overload, args, argNodes)
   return {
     sql,

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -1209,6 +1209,20 @@ describe('lang', () => {
     `).toRenderSql('select current_date() as col_0, current_time() as col_1, current_timestamp() as col_2, current_timestamp(3) as col_3, localtimestamp() as col_4 from users as users')
   })
 
+  it('supports duckdb bare current datetime functions', () => {
+    expect(`
+      from users select
+        current_date,
+        current_time,
+        current_timestamp,
+        localtime,
+        local_timestamp,
+        localtimestamp
+    `).toRenderSql(
+      'select current_date as current_date, current_time as current_time, current_timestamp as current_timestamp, localtime as localtime, localtimestamp as local_timestamp, localtimestamp as localtimestamp from users as users',
+    )
+  })
+
   it('supports bigquery current datetime functions with optional args', () => {
     setConfig({root: '', bigquery: {}})
     try {
@@ -1229,6 +1243,68 @@ describe('lang', () => {
     } finally {
       setConfig({root: ''})
     }
+  })
+
+  it('supports bigquery bare current datetime functions', () => {
+    setConfig({root: '', bigquery: {}})
+    try {
+      expect(`
+        from users select
+          current_date,
+          current_datetime,
+          current_time,
+          current_timestamp,
+          local_timestamp
+      `).toRenderSql(
+        'select current_date as current_date, current_datetime as current_datetime, current_time as current_time, current_timestamp as current_timestamp, current_datetime as local_timestamp from `users` as users',
+      )
+    } finally {
+      setConfig({root: ''})
+    }
+  })
+
+  it('supports snowflake bare current datetime functions', () => {
+    setConfig({dialect: 'snowflake', root: ''})
+    try {
+      expect(`
+        from users select
+          current_date,
+          current_time,
+          current_timestamp,
+          localtime,
+          localtimestamp
+      `).toRenderSql(
+        'SELECT current_date as current_date, current_time as current_time, current_timestamp as current_timestamp, localtime as localtime, localtimestamp as localtimestamp FROM USERS as users',
+        {preserveCase: true},
+      )
+    } finally {
+      setConfig({root: ''})
+    }
+  })
+
+  it('keeps column refs ahead of bare niladic functions', () => {
+    let queries = analyze(`
+      table t (
+        current_date int
+      )
+      from t select current_date, t.current_date
+    `)
+    expect(toSql(queries[0])).toMatch(/select t\.current_date as current_date, t\.current_date as t_current_date from t as t/i)
+  })
+
+  it('still errors for unknown bare names', () => {
+    expect('from users select definitely_not_a_function').toHaveDiagnostic(/Unknown field "definitely_not_a_function" on users/i)
+  })
+
+  it('does not add bare support for excluded functions', () => {
+    setConfig({dialect: 'snowflake', root: ''})
+    try {
+      expect('from users select sysdate').toHaveDiagnostic(/Unknown field "sysdate" on users/i)
+    } finally {
+      setConfig({root: ''})
+    }
+
+    expect('from users select now').toHaveDiagnostic(/Unknown field "now" on users/i)
   })
 
   it.skip('applies parameters inside views', () => {

--- a/lang/snowflakeFunctions.ts
+++ b/lang/snowflakeFunctions.ts
@@ -2377,6 +2377,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/current_date`,
     args: [],
     returns: 'date',
+    supportsBareInvocation: true,
   },
   {
     name: 'current_time',
@@ -2388,6 +2389,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/current_time`,
     args: [],
     returns: 'timestamp',
+    supportsBareInvocation: true,
   },
   {
     name: 'current_timestamp',
@@ -2399,5 +2401,30 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/current_timestamp`,
     args: [],
     returns: 'timestamp',
+    supportsBareInvocation: true,
+  },
+  {
+    name: 'localtime',
+    description: trim(`
+      LOCALTIME
+
+      Returns the current time in the session time zone.
+    `),
+    url: `${sf}/localtime`,
+    args: [],
+    returns: 'timestamp',
+    supportsBareInvocation: true,
+  },
+  {
+    name: 'localtimestamp',
+    description: trim(`
+      LOCALTIMESTAMP
+
+      Returns the current timestamp in the session time zone.
+    `),
+    url: `${sf}/localtimestamp`,
+    args: [],
+    returns: 'timestamp',
+    supportsBareInvocation: true,
   },
 ]


### PR DESCRIPTION
This PR adds support for bare invocation (no parens) of niladic functions like `current_date` and `current_timestamp`. Fixes #142

