### PR TITLE
No default echarts background

### DIFF
--- a/ui/component-utilities/theme.ts
+++ b/ui/component-utilities/theme.ts
@@ -28,7 +28,7 @@ let clr = {
 
 registerTheme('graphene-theme', {
   color: colorPalette,
-  backgroundColor: clr.white,
+  backgroundColor: 'transparent',
   textStyle: {
     fontFamily: "'Source Sans 3', sans-serif",
     color: clr.textMid,

--- a/ui/tests/snapshots/pack-install.test.ts/packaged-cli-check-index.png
+++ b/ui/tests/snapshots/pack-install.test.ts/packaged-cli-check-index.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ff9aff8b8108b578a993c69e6ef847c080843907dc3cb3e46d2ea03c1d7780b
-size 247932
+oid sha256:b5ecbe3a0e77442704d87f845041756cfe88f02ddfd1d442eb5289c4690286d9
+size 248454


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #243 
- <kbd>&nbsp;1&nbsp;</kbd> #242 👈 
<!-- GitButler Footer Boundary Bottom -->

