### PR TITLE
load fonts before charts render

### DIFF
--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -22,6 +22,7 @@ function liftInlineEChartsConfig(content: string) {
   })
 }
 
+// Turn code fences into <GrapheneQuery> tags, which register those queries
 export function extractQueries() {
   return function transformer(tree: any) {
     visit(tree, 'code', (node, index, parent) => {

--- a/ui/internal/LocalApp.svelte
+++ b/ui/internal/LocalApp.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {onDestroy} from 'svelte'
+  import {onDestroy, onMount} from 'svelte'
   import {errorProvider} from './telemetry.ts'
   import {PageInputs, activatePageInputs, releasePageInputs, setPageInputsContext} from './pageInputs.svelte.ts'
   import navFiles from 'virtual:nav'
@@ -36,16 +36,26 @@
 
   // The md file is dynamically imported, so even if there's a compile error, we'll still load LocalApp and can show the user the issue
   let Page = $state(null)
-  let pathName = window.location.pathname.replace(/^\//, '') || 'index'
 
-  if (pathName == '__dev/echarts') {
-    Page = DevEChartsGallery
-  } else if (pathName !== '__ct') {
-    import(/* @vite-ignore */ '/' + pathName + '.md').then(mod => {
+  onMount(async () => {
+    let pathName = window.location.pathname.replace(/^\//, '') || 'index'
+
+    // force fonts to load before we mount the component.
+    // This is important for echarts, as it measures text and if done with the wrong font, then
+    // a) when the right font loads, things will just slightly not line up with edges
+    // b) test snapshots will differ, as they measure with whatever the system sans font is
+    // c) screenshots taken by `graphene run` might have the wrong font
+    document.fonts.load("12px 'Source Sans 3'")
+    await document.fonts.ready
+
+    if (pathName == '__dev/echarts') {
+      Page = DevEChartsGallery
+    } else if (pathName !== '__ct') {
+      let mod = await import(/* @vite-ignore */ '/' + pathName + '.md')
       Page = mod.default
       compileError = null
-    }).catch(() => {})
-  }
+    }
+  })
 </script>
 
 <nav id="nav"><NavSidebar files={navData} /></nav>

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -150,7 +150,7 @@ export const test = base.extend<{browser: Browser; page: Page; sharedPage: Page;
       // now send the props down to the page, and put the evidence types back where they're expected
       let compName = componentPath.match(/(\w+)\.svelte/)?.[1] || 'splat'
       await sharedPage.evaluate(
-        ({compName, props}) => {
+        async ({compName, props}) => {
           if (window.__inst) window.$GRAPHENE.svelte.unmount(window.__inst)
 
           if (props._evidenceColumnTypes) {
@@ -158,6 +158,10 @@ export const test = base.extend<{browser: Browser; page: Page; sharedPage: Page;
             props.data.rows.dataLoaded = true // hack since evidence expects this on an array
             delete props._evidenceColumnTypes
           }
+
+          // ensure fonts have loaded before we mount our component
+          document.fonts.load("12px 'Source Sans 3'")
+          await document.fonts.ready
 
           document.getElementById('nav')?.remove()
           let container = document.getElementById('content')

--- a/ui/tests/pack-install.test.ts
+++ b/ui/tests/pack-install.test.ts
@@ -61,13 +61,6 @@ function parseTarballPath(result: RunResult, cwd: string) {
   return path.isAbsolute(tarball) ? tarball : path.resolve(cwd, tarball)
 }
 
-function parseScreenshotPath(output: string, cwd: string) {
-  let match = output.match(/Screenshot saved to\s+(.+\.png)/)
-  if (!match) throw new Error(`Could not find screenshot path in output:\n${output}`)
-  let screenshotPath = match[1].trim()
-  return path.isAbsolute(screenshotPath) ? screenshotPath : path.resolve(cwd, screenshotPath)
-}
-
 async function startServe(cwd: string, env: NodeJS.ProcessEnv, port: number, timeoutMs = 60_000): Promise<ServeHandle> {
   let child = spawn('npm', ['run', 'graphene', '--', 'serve'], {cwd, env})
   let logs = ''
@@ -164,19 +157,24 @@ test.skipIf(!shouldRunPackInstallTest)('packs cli and installs it into a user pr
 
     let checkOutput = stripAnsi(checkResult.stdout + checkResult.stderr)
     expect(checkOutput).toContain('No errors found')
+    expect(checkOutput).not.toContain('Warning: Queries were still loading when the screenshot was taken')
 
     let runResult = await run('npm', ['run', 'graphene', '--', 'run', 'index.md'], projectDir, childEnv)
     expectSuccess('npm run graphene run index.md', runResult)
 
     let runOutput = stripAnsi(runResult.stdout + runResult.stderr)
     expect(runOutput).toContain('No errors found')
+    expect(runOutput).toContain('Screenshot saved to')
+    expect(runOutput).not.toContain('Warning: Queries were still loading when the screenshot was taken')
 
-    let screenshotPath = parseScreenshotPath(runOutput, projectDir)
-    let screenshot = await fsp.readFile(screenshotPath)
-    expect(screenshot.length).toBeGreaterThan(20_000)
-
-    await page.setContent(`<img id="shot" src="data:image/png;base64,${screenshot.toString('base64')}" />`)
-    await expect(page.locator('#shot')).screenshot('packaged-cli-check-index')
+    // Snapshot the live page with Playwright while the packaged server is running.
+    await page.goto(`http://localhost:${port}/`)
+    await waitForGrapheneLoad(page)
+    await page.evaluate(async () => {
+      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    })
+    await page.waitForTimeout(500)
+    await expect(page).screenshot('packaged-cli-check-index')
   } finally {
     expectConsoleError(/WebSocket connection to 'ws:\/\/(localhost|127\.0\.0\.1):\d+\/_api\/ws' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED/)
     serveHandle?.child.kill('SIGTERM')

--- a/ui/tests/snapshots/pack-install.test.ts/packaged-cli-check-index.png
+++ b/ui/tests/snapshots/pack-install.test.ts/packaged-cli-check-index.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4b6c60b31e6aae9cb9db91d6e9fde9677259db0c57e4b8a4451fef178dc44d6
-size 248409
+oid sha256:1df7714e0abe963ce074bcd48d96df0f70b2761aa2ccfe8878166c436977116f
+size 227740

--- a/ui/tests/snapshots/pack-install.test.ts/packaged-cli-check-index.png
+++ b/ui/tests/snapshots/pack-install.test.ts/packaged-cli-check-index.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5ecbe3a0e77442704d87f845041756cfe88f02ddfd1d442eb5289c4690286d9
-size 248454
+oid sha256:b4b6c60b31e6aae9cb9db91d6e9fde9677259db0c57e4b8a4451fef178dc44d6
+size 248409

--- a/ui/tests/snapshots/viz.test.ts/area-chart-stacked.png
+++ b/ui/tests/snapshots/viz.test.ts/area-chart-stacked.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c21e035163cbb73e6495b3eeb1170bd1f82a608f522cef95ca8a09ef6b868a1
-size 30978
+oid sha256:b37c5f75a1f59b87474c1a0dc5529c957e56d82f3a7818ef778cf5b96ea340ad
+size 31204

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-secondary-axis-line.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-secondary-axis-line.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a058f510ff397f828552e1c58219b46314a89fb3c81c8c1cc8ffa07d21fe3130
-size 22295
+oid sha256:2cc7ecae79ab9cca577c649cbce314cc3da515f124d6b97b119c32ea6f65583d
+size 22074

--- a/ui/tests/snapshots/viz.test.ts/bar-chart.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:14eae68d71f8c6b5c46d9953571d5c2bc19b19484210afcbd9bf266ef3f7f696
-size 10490
+oid sha256:eb6238d0665be7c05e84f0cd082ddc8d059ec1dc9f3c69886fc4dc1c6867ae80
+size 10238

--- a/ui/tests/snapshots/viz.test.ts/line-chart-timeseries.png
+++ b/ui/tests/snapshots/viz.test.ts/line-chart-timeseries.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e57ee894011ddcf09c6d51ae3bee4412c047bdf29a32c49f9ff960c912e24bdc
-size 11686
+oid sha256:cf5e05b5a98dc0c6cd4f2af881385dae559429bd7bf53c78f7511ef84d281e22
+size 11808


### PR DESCRIPTION
This is important for echarts, as it measures text and if done with the wrong font, then
a) when the right font loads, things will just slightly not line up with edges
b) test snapshots will differ, as they measure with whatever the system sans font is
c) screenshots taken by `graphene run` might have the wrong font