### PR TITLE
date part functions

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -21,7 +21,7 @@ import {parseMarkdown} from './markdown.ts'
 import {extractLeadingMetadata} from './metadata.ts'
 import {parser} from './parser.js'
 import {parseTemporalLiteral, parseIntervalLiteral, parseIntervalUnit, renderTemporalArithmetic, renderStandaloneInterval} from './temporal.ts'
-import {inferTemporalOrdinal} from './temporalMetadata.ts'
+import {inferTemporalExtractionMetadata} from './temporalMetadata.ts'
 import {
   scalarType,
   type AnalysisConfig,
@@ -1022,11 +1022,10 @@ class AnalysisSession implements Analyzer {
         let unit = txt(node.getChild('ExtractUnit')!)
           .replace(/^['"]|['"]$/g, '')
           .toLowerCase()
-        let timeOrdinal = inferTemporalOrdinal(unit, this.config.dialect)
         return {
           sql: `EXTRACT(${unit} FROM ${expr.sql})`,
           type: scalarType('number'),
-          metadata: timeOrdinal ? {timeOrdinal} : undefined,
+          metadata: inferTemporalExtractionMetadata(unit, this.config.dialect),
           isAgg: expr.isAgg,
           fanout: expr.fanout,
         }
@@ -1133,18 +1132,18 @@ class AnalysisSession implements Analyzer {
   private preserveTemporalMetadataThroughCast(expr: Expr, resultType: FieldType): FieldMeta | undefined {
     if (!expr.metadata?.timeGrain) return undefined
     if (!isScalarType(resultType, 'date') && !isScalarType(resultType, 'timestamp')) return undefined
-    return expr.metadata
+    return {timeGrain: expr.metadata.timeGrain}
   }
 
   private sameFieldMetadata(left?: FieldMeta, right?: FieldMeta) {
     if (!left && !right) return true
     if (!left || !right) return false
-    return left.timeGrain == right.timeGrain
+    return left.timeGrain == right.timeGrain && left.timePart == right.timePart && left.timeOrdinal == right.timeOrdinal
   }
 
   private withoutTimeGrain(metadata?: FieldMeta): FieldMeta | undefined {
-    if (!metadata?.timeGrain) return metadata
-    let {timeGrain: _timeGrain, ...next} = metadata
+    if (!metadata?.timeGrain && !metadata?.timePart && !metadata?.timeOrdinal) return metadata
+    let {timeGrain: _timeGrain, timePart: _timePart, timeOrdinal: _timeOrdinal, ...next} = metadata
     return Object.keys(next).length ? next : undefined
   }
 

--- a/lang/clickHouseFunctions.ts
+++ b/lang/clickHouseFunctions.ts
@@ -1,6 +1,6 @@
 import type {FunctionDef} from './functionTypes.ts'
 
-import {inferTemporalGrainMetadata} from './temporalMetadata.ts'
+import {inferTemporalExtractionMetadata, inferTemporalGrainMetadata} from './temporalMetadata.ts'
 import {trimIndentation} from './util.ts'
 
 const trim = trimIndentation
@@ -856,9 +856,23 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#todayofmonth`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
-    metadata: {timeOrdinal: 'day_of_month'},
+    metadata: inferTemporalExtractionMetadata('day', 'clickhouse'),
     sqlName: 'toDayOfMonth',
     aliases: ['to_day_of_month'],
+  },
+  {
+    name: 'todayofyear',
+    description: trim(`
+      toDayOfYear(datetime)
+
+      Extracts the day of the year.
+    `),
+    url: `${click}/functions/date-time-functions#todayofyear`,
+    args: [{name: 'datetime', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('dayofyear', 'clickhouse'),
+    sqlName: 'toDayOfYear',
+    aliases: ['to_day_of_year'],
   },
   {
     name: 'todayofweek',
@@ -870,7 +884,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#todayofweek`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
-    metadata: {timeOrdinal: 'dow_1m'},
+    metadata: inferTemporalExtractionMetadata('dayofweek', 'clickhouse'),
     sqlName: 'toDayOfWeek',
     aliases: ['to_day_of_week'],
   },
@@ -884,7 +898,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tohour`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
-    metadata: {timeOrdinal: 'hour_of_day'},
+    metadata: inferTemporalExtractionMetadata('hour', 'clickhouse'),
     sqlName: 'toHour',
     aliases: ['to_hour'],
   },
@@ -898,6 +912,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tominute`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: inferTemporalExtractionMetadata('minute', 'clickhouse'),
     sqlName: 'toMinute',
     aliases: ['to_minute'],
   },
@@ -911,9 +926,23 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tomonth`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
-    metadata: {timeOrdinal: 'month_of_year'},
+    metadata: inferTemporalExtractionMetadata('month', 'clickhouse'),
     sqlName: 'toMonth',
     aliases: ['to_month'],
+  },
+  {
+    name: 'toquarter',
+    description: trim(`
+      toQuarter(datetime)
+
+      Extracts the quarter.
+    `),
+    url: `${click}/functions/date-time-functions#toquarter`,
+    args: [{name: 'datetime', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('quarter', 'clickhouse'),
+    sqlName: 'toQuarter',
+    aliases: ['to_quarter'],
   },
   {
     name: 'tosecond',
@@ -925,8 +954,23 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tosecond`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: inferTemporalExtractionMetadata('second', 'clickhouse'),
     sqlName: 'toSecond',
     aliases: ['to_second'],
+  },
+  {
+    name: 'toweek',
+    description: trim(`
+      toWeek(datetime)
+
+      Extracts the week number.
+    `),
+    url: `${click}/functions/date-time-functions#toweek`,
+    args: [{name: 'datetime', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('week', 'clickhouse'),
+    sqlName: 'toWeek',
+    aliases: ['to_week'],
   },
   {
     name: 'tostartofday',
@@ -1008,6 +1052,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#toyear`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: inferTemporalExtractionMetadata('year', 'clickhouse'),
     sqlName: 'toYear',
     aliases: ['to_year'],
   },

--- a/lang/duckDbFunctions.ts
+++ b/lang/duckDbFunctions.ts
@@ -6,7 +6,7 @@
 
 import type {FunctionDef} from './functionTypes.ts'
 
-import {inferTemporalGrainMetadata, inferTemporalOrdinalMetadata} from './temporalMetadata.ts'
+import {inferTemporalExtractionMetadata, inferTemporalGrainMetadata} from './temporalMetadata.ts'
 import {trimIndentation} from './util.ts'
 
 const duck = 'https://duckdb.org/docs/stable/sql/functions'
@@ -1792,7 +1792,187 @@ export const duckDbFunctions: FunctionDef[] = [
       {name: 'date', type: ['date', 'timestamp']},
     ],
     returns: 'number',
-    metadata: args => inferTemporalOrdinalMetadata(args[0]?.sql, 'duckdb'),
+    metadata: args => inferTemporalExtractionMetadata(args[0]?.sql, 'duckdb'),
+  },
+  {
+    name: 'year',
+    description: trim(`
+      year(date)
+
+      Extracts the year.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('year', 'duckdb'),
+  },
+  {
+    name: 'quarter',
+    description: trim(`
+      quarter(date)
+
+      Extracts the quarter.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('quarter', 'duckdb'),
+  },
+  {
+    name: 'month',
+    description: trim(`
+      month(date)
+
+      Extracts the month.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('month', 'duckdb'),
+  },
+  {
+    name: 'week',
+    description: trim(`
+      week(date)
+
+      Extracts the week number.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('week', 'duckdb'),
+  },
+  {
+    name: 'weekofyear',
+    description: trim(`
+      weekofyear(date)
+
+      Extracts the ISO week number.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('weekofyear', 'duckdb'),
+  },
+  {
+    name: 'day',
+    description: trim(`
+      day(date)
+
+      Extracts the day of month.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('day', 'duckdb'),
+  },
+  {
+    name: 'dayofmonth',
+    description: trim(`
+      dayofmonth(date)
+
+      Extracts the day of month.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('dayofmonth', 'duckdb'),
+  },
+  {
+    name: 'dayofweek',
+    description: trim(`
+      dayofweek(date)
+
+      Extracts the day of week.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('dayofweek', 'duckdb'),
+  },
+  {
+    name: 'weekday',
+    description: trim(`
+      weekday(date)
+
+      Extracts the day of week.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('weekday', 'duckdb'),
+  },
+  {
+    name: 'dayofyear',
+    description: trim(`
+      dayofyear(date)
+
+      Extracts the day of year.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('dayofyear', 'duckdb'),
+  },
+  {
+    name: 'hour',
+    description: trim(`
+      hour(date)
+
+      Extracts the hour.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('hour', 'duckdb'),
+  },
+  {
+    name: 'minute',
+    description: trim(`
+      minute(date)
+
+      Extracts the minute.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('minute', 'duckdb'),
+  },
+  {
+    name: 'second',
+    description: trim(`
+      second(date)
+
+      Extracts the second.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('second', 'duckdb'),
+  },
+  {
+    name: 'isodow',
+    description: trim(`
+      isodow(date)
+
+      Extracts the ISO day of week.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('isodow', 'duckdb'),
+  },
+  {
+    name: 'isoyear',
+    description: trim(`
+      isoyear(date)
+
+      Extracts the ISO year.
+    `),
+    url: `${duck}/datepart.html`,
+    args: [{name: 'date', type: ['date', 'timestamp']}],
+    returns: 'number',
+    metadata: inferTemporalExtractionMetadata('isoyear', 'duckdb'),
   },
   {
     name: 'date_sub',

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -23,6 +23,7 @@ export type FieldMeta = {
   pct?: true // 0 to 100 value
   units?: string
   timeGrain?: TimeGrain // resolution when the field is a date or timestamp
+  timePart?: string // extracted temporal part, normalized across backend spellings
   timeOrdinal?: TimeOrdinal // if the value represents something special like day_of_week, week_of_year, etc
   [key: string]: string | true | undefined
 }

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -1136,7 +1136,7 @@ describe('lang', () => {
     expect(clickhouse.fields[0].metadata).toEqual({timeGrain: 'week'})
   })
 
-  it('propagates temporal grain through refs and drops it for reshaping expressions', () => {
+  it('propagates temporal grain through refs and replaces it with extraction metadata for reshaping expressions', () => {
     updateFile(
       `
       table events (
@@ -1154,7 +1154,7 @@ describe('lang', () => {
     expect(throughCast.fields[0].metadata).toEqual({timeGrain: 'month'})
 
     let [reshaped] = analyze('from events select extract(year from month_start) as year_num')
-    expect(reshaped.fields[0].metadata).toBeUndefined()
+    expect(reshaped.fields[0].metadata).toEqual({timePart: 'year'})
   })
 
   it('drops temporal grain on set operations when branches disagree', () => {
@@ -1173,28 +1173,63 @@ describe('lang', () => {
     expect('from users select extract(hour from created_at)').toRenderSql('select extract(hour from users.created_at) as col_0 from users as users')
   })
 
-  it('infers time ordinal metadata for extract and date_part', () => {
+  it('supports backend-native temporal extraction shorthands', () => {
+    updateFile('table events (event_date date, created_at timestamp)', 'events.gsql')
+
+    setConfig({root: ''})
+    expect('from events select hour(created_at), quarter(event_date)').toHaveNoErrors()
+
+    setConfig({dialect: 'snowflake', root: ''})
+    expect('from events select dayofmonth(event_date), weekofyear(event_date)').toHaveNoErrors()
+
+    setConfig({dialect: 'clickhouse', root: ''})
+    expect('from events select to_quarter(created_at), to_week(created_at), to_day_of_year(created_at)').toHaveNoErrors()
+
+    setConfig({root: ''})
+  })
+
+  it('infers time part and ordinal metadata for extract, date_part, and native shorthands', () => {
     updateFile('table events (event_date date, created_at timestamp)', 'events.gsql')
 
     setConfig({root: '', bigquery: {}})
     let [bigQuery] = analyze('from events select extract(dayofweek from event_date) as dow')
-    expect(bigQuery.fields[0].metadata).toEqual({timeOrdinal: 'dow_1s'})
+    expect(bigQuery.fields[0].metadata).toEqual({timePart: 'dayofweek', timeOrdinal: 'dow_1s'})
 
     setConfig({root: ''})
     let [duckDbDow] = analyze("from events select date_part('dow', event_date) as dow")
-    expect(duckDbDow.fields[0].metadata).toEqual({timeOrdinal: 'dow_0s'})
+    expect(duckDbDow.fields[0].metadata).toEqual({timePart: 'dayofweek', timeOrdinal: 'dow_0s'})
     let [duckDbIsoDow] = analyze('from events select extract(isodow from event_date) as iso_dow')
-    expect(duckDbIsoDow.fields[0].metadata).toEqual({timeOrdinal: 'dow_1m'})
+    expect(duckDbIsoDow.fields[0].metadata).toEqual({timePart: 'isodow', timeOrdinal: 'dow_1m'})
+    let [duckDbQuarter] = analyze('from events select quarter(event_date) as quarter_num')
+    expect(duckDbQuarter.fields[0].metadata).toEqual({timePart: 'quarter', timeOrdinal: 'quarter_of_year'})
 
     setConfig({dialect: 'snowflake', root: ''})
     let [snowflake] = analyze('from events select dayofweek(event_date) as dow')
-    expect(snowflake.fields[0].metadata).toEqual({timeOrdinal: 'dow_0s'})
+    expect(snowflake.fields[0].metadata).toEqual({timePart: 'dayofweek', timeOrdinal: 'dow_0s'})
+    let [snowflakeQuarter] = analyze('from events select quarter(event_date) as quarter_num')
+    expect(snowflakeQuarter.fields[0].metadata).toEqual({timePart: 'quarter', timeOrdinal: 'quarter_of_year'})
 
     setConfig({dialect: 'clickhouse', root: ''})
     let [clickhouse] = analyze('from events select to_day_of_week(created_at) as dow')
-    expect(clickhouse.fields[0].metadata).toEqual({timeOrdinal: 'dow_1m'})
+    expect(clickhouse.fields[0].metadata).toEqual({timePart: 'dayofweek', timeOrdinal: 'dow_1m'})
+    let [clickhouseHour] = analyze('from events select to_hour(created_at) as hour_num')
+    expect(clickhouseHour.fields[0].metadata).toEqual({timePart: 'hour', timeOrdinal: 'hour_of_day'})
+    let [clickhouseQuarter] = analyze('from events select to_quarter(created_at) as quarter_num')
+    expect(clickhouseQuarter.fields[0].metadata).toEqual({timePart: 'quarter', timeOrdinal: 'quarter_of_year'})
 
     setConfig({root: ''})
+  })
+
+  it('drops extraction metadata on set operations when branches disagree', () => {
+    updateFile('table events (event_date date, created_at timestamp)', 'events.gsql')
+
+    let [query] = analyze(`
+      from events select extract(hour from created_at) as bucket
+      union all
+      from events select extract(month from created_at) as bucket
+    `)
+
+    expect(query.fields[0].metadata).toBeUndefined()
   })
 
   it('supports null and boolean literals', () => {

--- a/lang/snowflakeFunctions.ts
+++ b/lang/snowflakeFunctions.ts
@@ -6,7 +6,7 @@
 
 import type {FunctionDef} from './functionTypes.ts'
 
-import {inferTemporalGrainMetadata, inferTemporalOrdinalMetadata} from './temporalMetadata.ts'
+import {inferTemporalExtractionMetadata, inferTemporalGrainMetadata} from './temporalMetadata.ts'
 import {trimIndentation} from './util.ts'
 
 const sf = 'https://docs.snowflake.com/en/sql-reference/functions'
@@ -1827,7 +1827,7 @@ export const snowflakeFunctions: FunctionDef[] = [
       {name: 'date_expr', type: ['date', 'timestamp']},
     ],
     returns: 'number',
-    metadata: args => inferTemporalOrdinalMetadata(args[0]?.sql, 'snowflake'),
+    metadata: args => inferTemporalExtractionMetadata(args[0]?.sql, 'snowflake'),
   },
   {
     name: 'dateadd',
@@ -2015,6 +2015,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: inferTemporalExtractionMetadata('year', 'snowflake'),
   },
   {
     name: 'month',
@@ -2026,7 +2027,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
-    metadata: {timeOrdinal: 'month_of_year'},
+    metadata: inferTemporalExtractionMetadata('month', 'snowflake'),
   },
   {
     name: 'day',
@@ -2039,7 +2040,8 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
-    metadata: {timeOrdinal: 'day_of_month'},
+    aliases: ['dayofmonth'],
+    metadata: inferTemporalExtractionMetadata('day', 'snowflake'),
   },
   {
     name: 'dayofweek',
@@ -2051,7 +2053,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
-    metadata: {timeOrdinal: 'dow_0s'},
+    metadata: inferTemporalExtractionMetadata('dayofweek', 'snowflake'),
   },
   {
     name: 'dayofyear',
@@ -2063,7 +2065,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
-    metadata: {timeOrdinal: 'day_of_year'},
+    metadata: inferTemporalExtractionMetadata('dayofyear', 'snowflake'),
   },
   {
     name: 'week',
@@ -2076,7 +2078,8 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
-    metadata: {timeOrdinal: 'week_of_year'},
+    aliases: ['weekofyear'],
+    metadata: inferTemporalExtractionMetadata('week', 'snowflake'),
   },
   {
     name: 'quarter',
@@ -2088,6 +2091,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: inferTemporalExtractionMetadata('quarter', 'snowflake'),
   },
   {
     name: 'hour',
@@ -2099,7 +2103,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/hour-minute-second`,
     args: [{name: 'time_expr', type: ['date', 'timestamp']}],
     returns: 'number',
-    metadata: {timeOrdinal: 'hour_of_day'},
+    metadata: inferTemporalExtractionMetadata('hour', 'snowflake'),
   },
   {
     name: 'minute',
@@ -2111,6 +2115,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/hour-minute-second`,
     args: [{name: 'time_expr', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: inferTemporalExtractionMetadata('minute', 'snowflake'),
   },
   {
     name: 'second',
@@ -2122,6 +2127,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/hour-minute-second`,
     args: [{name: 'time_expr', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: inferTemporalExtractionMetadata('second', 'snowflake'),
   },
 
   // ============================================================================

--- a/lang/temporalMetadata.ts
+++ b/lang/temporalMetadata.ts
@@ -1,10 +1,32 @@
 import type {FieldMeta, TimeGrain, TimeOrdinal} from './types.ts'
 
-export function inferTemporalGrain(rawPart?: string): TimeGrain | undefined {
-  let normalized = String(rawPart || '')
+function normalizeTemporalPart(rawPart?: string) {
+  return String(rawPart || '')
     .trim()
     .replace(/^['"]|['"]$/g, '')
     .toLowerCase()
+}
+
+export function inferTemporalPart(rawPart?: string): string | undefined {
+  let normalized = normalizeTemporalPart(rawPart)
+  if (!normalized) return
+
+  if (/^week(?:\([a-z]+\))?$/.test(normalized)) return 'week'
+
+  let parts: Record<string, string> = {
+    dow: 'dayofweek',
+    weekday: 'dayofweek',
+    dayofmonth: 'day',
+    doy: 'dayofyear',
+    weekofyear: 'week',
+    dayofweekiso: 'isodow',
+    iso_dayofweek: 'isodow',
+  }
+  return parts[normalized] || normalized
+}
+
+export function inferTemporalGrain(rawPart?: string): TimeGrain | undefined {
+  let normalized = normalizeTemporalPart(rawPart)
   if (!normalized) return
 
   if (/^week(?:\([a-z]+\))?$/.test(normalized) || normalized == 'isoweek') return 'week'
@@ -27,11 +49,13 @@ export function inferTemporalGrainMetadata(rawPart?: string): FieldMeta | undefi
   return timeGrain ? {timeGrain} : undefined
 }
 
+export function inferTemporalPartMetadata(rawPart?: string): FieldMeta | undefined {
+  let timePart = inferTemporalPart(rawPart)
+  return timePart ? {timePart} : undefined
+}
+
 export function inferTemporalOrdinal(rawPart: string | undefined, dialect: string): TimeOrdinal | undefined {
-  let normalized = String(rawPart || '')
-    .trim()
-    .replace(/^['"]|['"]$/g, '')
-    .toLowerCase()
+  let normalized = normalizeTemporalPart(rawPart)
   if (!normalized) return
 
   if (normalized == 'hour') return 'hour_of_day'
@@ -39,6 +63,7 @@ export function inferTemporalOrdinal(rawPart: string | undefined, dialect: strin
   if (normalized == 'dayofyear' || normalized == 'doy') return 'day_of_year'
   if (normalized == 'week' || normalized == 'weekofyear' || normalized == 'isoweek') return 'week_of_year'
   if (normalized == 'month') return 'month_of_year'
+  if (normalized == 'quarter') return 'quarter_of_year'
 
   if (normalized == 'isodow' || normalized == 'dayofweekiso' || normalized == 'iso_dayofweek') return 'dow_1m'
 
@@ -52,4 +77,14 @@ export function inferTemporalOrdinal(rawPart: string | undefined, dialect: strin
 export function inferTemporalOrdinalMetadata(rawPart: string | undefined, dialect: string): FieldMeta | undefined {
   let timeOrdinal = inferTemporalOrdinal(rawPart, dialect)
   return timeOrdinal ? {timeOrdinal} : undefined
+}
+
+export function inferTemporalExtractionMetadata(rawPart: string | undefined, dialect: string): FieldMeta | undefined {
+  let timePart = inferTemporalPart(rawPart)
+  let timeOrdinal = inferTemporalOrdinal(rawPart, dialect)
+  if (!timePart && !timeOrdinal) return
+  return {
+    ...(timePart ? {timePart} : {}),
+    ...(timeOrdinal ? {timeOrdinal} : {}),
+  }
 }


### PR DESCRIPTION
This PR adds support for shorthand date part-extraction functions as supported natively by duckdb and Snowflake, and lowered to `extract` for BigQuery and the corresponding functions for ClickHouse (`toPart`). We do not try to normalize the behavior of these functions - for parts where behavior varies (mostly week-related) we just pass through to the warehouse. And a `timePart` metadata entry is attached to the field's metadata.



Fixes #174