### PR TITLE
point CI tests at self-hosted clickhouse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
           GOOGLE_CREDENTIALS_CONTENT: ${{ secrets.GOOGLE_CREDENTIALS_CONTENT }}
           SNOWFLAKE_PRI_KEY: ${{ secrets.SNOWFLAKE_PRI_KEY }}
           SNOWFLAKE_PRI_PASSPHRASE: graphenedata
+          CLICKHOUSE_URL: ${{ vars.CLICKHOUSE_URL }}
+          CLICKHOUSE_USERNAME: ${{ vars.CLICKHOUSE_USERNAME }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
 
   test-examples:
     runs-on: ubuntu-latest
@@ -96,3 +99,6 @@ jobs:
           GOOGLE_CREDENTIALS_CONTENT: ${{ secrets.GOOGLE_CREDENTIALS_CONTENT }}
           SNOWFLAKE_PRI_KEY: ${{ secrets.SNOWFLAKE_PRI_KEY }}
           SNOWFLAKE_PRI_PASSPHRASE: graphenedata
+          CLICKHOUSE_URL: ${{ vars.CLICKHOUSE_URL }}
+          CLICKHOUSE_USERNAME: ${{ vars.CLICKHOUSE_USERNAME }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}

--- a/cli/schema.test.ts
+++ b/cli/schema.test.ts
@@ -16,6 +16,7 @@ const flightDir = path.resolve(dir, '../examples/flights')
 const snowflakeDir = path.resolve(dir, '../examples/snowflake')
 const ecommDir = path.resolve(dir, '../examples/ecomm')
 const clickhouseDir = path.resolve(dir, '../examples/clickhouse')
+const hasClickHouseAuth = !!process.env.CLICKHOUSE_URL && !!process.env.CLICKHOUSE_USERNAME && !!process.env.CLICKHOUSE_PASSWORD
 
 function runCli(args: string[], cwd?: string): Promise<RunResult> {
   return new Promise(resolve => {
@@ -140,7 +141,7 @@ describe.skipIf(!process.env.SLOW_TEST)('bigquery', () => {
   })
 })
 
-describe.skipIf(!process.env.SLOW_TEST || true)('clickhouse', () => {
+describe.skipIf(!process.env.SLOW_TEST || !hasClickHouseAuth)('clickhouse', () => {
   it('lists available tables in the configured database', async () => {
     let res = await runCli(['schema'], clickhouseDir)
     expectCliSuccess(res, 'schema list tables (clickhouse)')

--- a/examples/clickhouse/package.json
+++ b/examples/clickhouse/package.json
@@ -21,8 +21,8 @@
     "dialect": "clickhouse",
     "defaultNamespace": "default",
     "clickhouse": {
-      "url": "https://kzo1vb16sa.us-east-1.aws.clickhouse.cloud:8443",
-      "username": "default"
+      "url": "http://ec2-3-217-185-14.compute-1.amazonaws.com:8123",
+      "username": "graphene"
     },
     "envFile": [
       ".env",

--- a/ui/tests/run-examples.test.ts
+++ b/ui/tests/run-examples.test.ts
@@ -73,8 +73,7 @@ async function getExampleDirs(examplesDir: string): Promise<string[]> {
 }
 
 function shouldRunExample(exampleName: string) {
-  // Temporarily skip clickhouse example until CI creds are configured.
-  if (exampleName === 'clickhouse') return false
+  if (exampleName === 'clickhouse') return !!process.env.CLICKHOUSE_URL && !!process.env.CLICKHOUSE_USERNAME && !!process.env.CLICKHOUSE_PASSWORD
   return true
 }
 


### PR DESCRIPTION
This PR uses the ClickHouse instance provisioned with #96 for CI testing, to avoid the ClickHouse Cloud premium and flakiness due to instance idling. I re-ran the CI tests here several times and didn't hit any flakes.