### PR TITLE
Clean up multi-y support

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -69,7 +69,7 @@ Component "field" attributes (like x and y) map to a column within data.
 Attributes like `x`, `y`, `y2`, `group`, `stack`, `stack100` are the names of columns within the `data` table.
 `title` - shown above the viz
 - BarChart: Fields [x,y,y2,group,stack,stack100]. y2 will always be a line, stack and stack100 are mutually exclusive. `label` (show labels above bars)
-- LineChart: Fields [x,y,y2,series]
+- LineChart: Fields [x,y,series]
 - AreaChart: Fields [x,y,group,stack,stack100]
 - PieChart: Fields: [category,value]
 

--- a/docs/references/area-chart.md
+++ b/docs/references/area-chart.md
@@ -36,5 +36,6 @@ Here's an example:
 | stack100 | Same as `stack`, but normalized to 100% | false | column/expression name | - |
 
 `group`, `stack`, and `stack100` are mutually exclusive.
+When `y` has multiple fields, `group`/`stack`/`stack100` are not supported.
 
 For more control, use [`ECharts`](./echarts.md) directly.

--- a/docs/references/bar-chart.md
+++ b/docs/references/bar-chart.md
@@ -38,5 +38,6 @@ Here's an example:
 | label | Show value labels on bars | false | `true`, `false` | `false` |
 
 `group`, `stack`, and `stack100` are mutually exclusive.
+When `y` has multiple fields, `group`/`stack`/`stack100` are not supported.
 
 For advanced behavior (custom tooltips, axes, transforms, chart types), use [`ECharts`](./echarts.md) directly.

--- a/docs/references/echarts.md
+++ b/docs/references/echarts.md
@@ -1,75 +1,55 @@
-Use `ECharts` when you want full control over chart behavior and styling.
+Use `ECharts` when you need chart behavior that goes beyond the built-in chart components.
 
-Graphene uses Apache ECharts under the hood. The `ECharts` component lets you pass an ECharts config directly, while Graphene enrichments still fill in sensible defaults (dataset wiring, axis inference, formatting, and common layout fixes).
+Graphene charts are powered by Apache ECharts. In markdown, you define the ECharts option object **inside the `<ECharts>` tag body**.
 
-Here's a simple example:
+Example:
 
 ```markdown
-<ECharts
-  data=sales_by_month
-  config={{
-    title: {text: 'Revenue'},
-    tooltip: {trigger: 'axis'},
-    xAxis: {},
-    yAxis: {},
-    series: [{type: 'line', encode: {x: 'month', y: 'revenue'}}]
-  }}
-/>
+<ECharts data="sales_by_month">
+  title: {text: "Revenue"},
+  tooltip: {trigger: "axis"},
+  xAxis: {},
+  yAxis: {},
+  series: [{type: "line", encode: {x: "month", y: "revenue"}}],
+</ECharts>
 ```
 
 # Attributes
 
 | Attribute | Description | Required | Options | Default |
 |----------|-------------|----------|---------|---------|
-| data | GSQL query/table name, or inline query result object | true | query name or `{rows, fields}` | - |
-| config | ECharts option object | true | valid ECharts config | - |
+| data | GSQL query or table name | true | query/table name | - |
 | height | Chart height in px or CSS size string | false | number, string | `240px` |
 | width | Chart width in px or CSS size string | false | number, string | `100%` |
 | renderer | ECharts renderer | false | `svg`, `canvas` | `svg` |
 
-## Data shape
+## Config body syntax
 
-When using inline data, pass both `rows` and `fields`:
+Inside `<ECharts>...</ECharts>`, Graphene parses the config as JSON5:
+- unquoted keys are allowed (`xAxis: {}`)
+- trailing commas are allowed
+- you can wrap the whole thing in `{ ... }` or omit the outer braces
 
-```markdown
-<ECharts
-  data={{
-    rows: [{month: '2026-01', revenue: 120}],
-    fields: [
-      {name: 'month', type: {kind: 'scalar', scalar: 'date'}},
-      {name: 'revenue', type: {kind: 'scalar', scalar: 'number', metadata: {units: 'usd'}}}
-    ]
-  }}
-  config={{...}}
-/>
-```
+## Grouping and stacking hints
 
-`fields` replaces the old `_evidenceColumnTypes` approach.
-
-## Customizing with grouping hints
-
-To keep configs concise, Graphene supports series grouping hints:
-
-- `encode.group`: split one series template into one series per distinct field value
-- `encode.stack`: same split behavior, but with stacked series semantics
-- `stackPercentage: true`: convert stacked values to percentages (100% stacked)
+Graphene supports a few `encode` extensions to reduce boilerplate:
+- `encode.group`: expands one series template into one series per distinct value
+- `encode.stack`: same expansion, but stacked
+- `stackPercentage: true`: converts stacked values to 100% stacking
 
 Example:
 
 ```markdown
-<ECharts
-  data=sales_by_month_and_region
-  config={{
-    xAxis: {},
-    yAxis: {},
-    series: [{
-      type: 'bar',
-      encode: {x: 'month', y: 'revenue', stack: 'region'},
-      stack: 'revenue-stack',
-      stackPercentage: true
-    }]
-  }}
-/>
+<ECharts data="sales_by_month_and_region">
+  xAxis: {},
+  yAxis: {},
+  series: [{
+    type: "bar",
+    encode: {x: "month", y: "revenue", stack: "region"},
+    stack: "revenue-stack",
+    stackPercentage: true,
+  }],
+</ECharts>
 ```
 
-This is the recommended path for custom charts: start from an ECharts config, then rely on Graphene enrichments for defaults instead of re-implementing shared behavior.
+For common chart types, prefer `BarChart`, `LineChart`, `AreaChart`, and `PieChart`. Use `ECharts` when you need deeper customization.

--- a/docs/references/line-chart.md
+++ b/docs/references/line-chart.md
@@ -35,5 +35,6 @@ Here's an example:
 | series | Split one `y` field into one line per distinct value | false | column/expression name | - |
 
 If `y` includes multiple fields, each field becomes its own line.
+`series` requires a single `y` field.
 
 For advanced behavior (custom line styles, annotations, axis config, dataset transforms), use [`ECharts`](./echarts.md) directly.

--- a/ui/components/AreaChart.svelte
+++ b/ui/components/AreaChart.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ECharts from './ECharts.svelte'
   import type {EChartsConfig, QueryResult} from '../component-utilities/types.ts'
+  import {parseCommaList} from '../component-utilities/inputUtils.ts'
 
   interface Props {
     data: string | QueryResult
@@ -29,8 +30,9 @@
   }: Props = $props()
 
   function buildConfig(): EChartsConfig {
-    let yFields = parseList(y)
+    let yFields = parseCommaList(y)
     let mode = resolveGroupingMode(group, stack, stack100)
+    if (mode && yFields.length > 1) throw new Error('AreaChart does not support `group`, `stack`, or `stack100` when `y` has multiple fields')
     let grouped = Boolean(mode && yFields.length === 1)
     let stackKey = mode?.kind === 'stack' || mode?.kind === 'stack100' ? 'area-stack' : undefined
     let stackPercentage = mode?.kind === 'stack100' ? true : undefined
@@ -48,11 +50,6 @@
       yAxis: {max: stackPercentage ? 1 : undefined},
       series,
     }
-  }
-
-  function parseList(value?: string) {
-    if (!value) return []
-    return value.split(',').map(v => v.trim()).filter(Boolean)
   }
 
   function resolveGroupingMode(group?: string, stack?: string, stack100?: string) {

--- a/ui/components/BarChart.svelte
+++ b/ui/components/BarChart.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ECharts from './ECharts.svelte'
   import type {EChartsConfig, QueryResult, SeriesWithGroupingHint} from '../component-utilities/types.ts'
+  import {parseCommaList} from '../component-utilities/inputUtils.ts'
 
   interface Props {
     data: string | QueryResult
@@ -33,8 +34,9 @@
   }: Props = $props()
 
   function buildConfig(): EChartsConfig {
-    let yFields = parseList(y)
+    let yFields = parseCommaList(y)
     let mode = resolveGroupingMode(group, stack, stack100)
+    if (mode && yFields.length > 1) throw new Error('BarChart does not support `group`, `stack`, or `stack100` when `y` has multiple fields')
     let grouped = Boolean(mode && yFields.length === 1)
     let barLabel = label ? {show: true} : undefined
     let stackKey = mode?.kind === 'stack' || mode?.kind === 'stack100' ? 'bar-stack' : undefined
@@ -55,11 +57,6 @@
       yAxis: [{max: stackPercentage ? 1 : undefined}, ...(y2 ? [{}] : [])],
       series,
     }
-  }
-
-  function parseList(value?: string) {
-    if (!value) return []
-    return value.split(',').map(v => v.trim()).filter(Boolean)
   }
 
   function resolveGroupingMode(group?: string, stack?: string, stack100?: string) {

--- a/ui/components/ECharts.svelte
+++ b/ui/components/ECharts.svelte
@@ -127,8 +127,9 @@
       let value = queryableEncodeValue(attr, col)
       if (!value) continue
       fields[attr] ||= []
-      fields[attr].push(value)
+      if (!fields[attr].includes(value)) fields[attr].push(value)
     }
+
     return fields
   }
 

--- a/ui/components/LineChart.svelte
+++ b/ui/components/LineChart.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import ECharts from './ECharts.svelte'
+  import {parseCommaList} from '../component-utilities/inputUtils.ts'
   import type {EChartsConfig, QueryResult} from '../component-utilities/types.ts'
 
   interface Props {
     data: string | QueryResult
     x: string
     y: string
-    y2?: string
     series?: string
     sort?: string
     title?: string
@@ -18,7 +18,6 @@
     data,
     x,
     y,
-    y2 = undefined,
     series = undefined,
     sort = undefined,
     title = undefined,
@@ -27,7 +26,8 @@
   }: Props = $props()
 
   function buildConfig(): EChartsConfig {
-    let yFields = parseList(y)
+    let yFields = parseCommaList(y)
+    if (series && yFields.length > 1) throw new Error('LineChart does not support `series` when `y` has multiple fields')
     let groupedSeries = Boolean(series && yFields.length === 1)
 
     let sortHint = typeof sort === 'string' && sort.trim().length > 0 ? {sort} : {}
@@ -36,24 +36,17 @@
       : yFields.map(field => ({type: 'line', name: field, encode: {x, y: field, ...sortHint}}))
 
     let seriesTemplates: any[] = [...primarySeries]
-    if (y2) {
-      seriesTemplates.push({type: 'line', name: y2, yAxisIndex: 1, encode: {x, y: y2, ...sortHint}})
-    }
 
     return {
       title: title ? {text: title} : undefined,
       tooltip: {trigger: 'axis'},
-      legend: {show: groupedSeries || yFields.length > 1 || Boolean(y2)},
+      legend: {show: groupedSeries || yFields.length > 1},
       xAxis: {},
-      yAxis: [{}, ...(y2 ? [{}] : [])],
+      yAxis: [{}],
       series: seriesTemplates,
     }
   }
 
-  function parseList(value?: string) {
-    if (!value) return []
-    return value.split(',').map(v => v.trim()).filter(Boolean)
-  }
 </script>
 
 <ECharts data={data} config={buildConfig()} {height} {width} />

--- a/ui/tests/snapshots/viz.test.ts/area-chart-multiple-y.png
+++ b/ui/tests/snapshots/viz.test.ts/area-chart-multiple-y.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:713fc99184c0aa2dbe787c165bf2d273308d093a8892e8f84806806fdb939929
+size 24319

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-multiple-y.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-multiple-y.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d18027be5b32874b628b19365241e84977067c38062481b561f5b166e56119f
+size 13803

--- a/ui/tests/snapshots/viz.test.ts/line-chart-multiple-y.png
+++ b/ui/tests/snapshots/viz.test.ts/line-chart-multiple-y.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cd72c169fd1124af6879b9dd536a95e4d7c337598ac8ad2abc1454f07382db6
+size 23777

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -14,6 +14,22 @@ function seededRandom(seed: number) {
   }
 }
 
+function timeseriesWithMultipleY() {
+  let data = timeseries() as any
+  let nextRandom = seededRandom(202604)
+  data.rows = data.rows.map((row: any) => {
+    let jitter = (nextRandom() - 0.5) * 0.06
+    return {
+      ...row,
+      profit_usd0k: row.sales_usd0k * (0.22 + jitter),
+      cost_usd0k: row.sales_usd0k * (0.68 - jitter),
+    }
+  })
+  data.fields.push({name: 'profit_usd0k', type: scalarType('number'), metadata: {units: 'usd'}})
+  data.fields.push({name: 'cost_usd0k', type: scalarType('number'), metadata: {units: 'usd'}})
+  return data
+}
+
 test.beforeEach(async ({sharedPage}) => {
   await sharedPage.setViewportSize({width: 680, height: 400})
 })
@@ -53,6 +69,11 @@ test('echarts expands encode.stack', async ({mount, chart}) => {
 test('bar chart', async ({mount, chart}) => {
   await mount('components/BarChart.svelte', {data: timeseries(), x: 'month', y: 'sales_usd0k', title: 'Monthly Sales'})
   await expect(chart.el).screenshot('bar-chart')
+})
+
+test('bar chart supports multiple y fields', async ({mount, chart}) => {
+  await mount('components/BarChart.svelte', {data: timeseriesWithMultipleY(), x: 'month', y: 'sales_usd0k,profit_usd0k,cost_usd0k'})
+  await expect(chart.el).screenshot('bar-chart-multiple-y')
 })
 
 test('bar chart formats very small values on y axis', async ({mount, chart}) => {
@@ -104,9 +125,19 @@ test('stacked area chart', async ({mount, chart}) => {
   await expect(chart.el).screenshot('area-chart-stacked')
 })
 
+test('area chart supports multiple y fields', async ({mount, chart}) => {
+  await mount('components/AreaChart.svelte', {data: timeseriesWithMultipleY(), x: 'month', y: 'sales_usd0k,profit_usd0k,cost_usd0k'})
+  await expect(chart.el).screenshot('area-chart-multiple-y')
+})
+
 test('line chart timeseries', async ({mount, chart}) => {
   await mount('components/LineChart.svelte', {data: timeseries(), x: 'month', y: 'sales_usd0k'})
   await expect(chart.el).screenshot('line-chart-timeseries')
+})
+
+test('line chart supports multiple y fields', async ({mount, chart}) => {
+  await mount('components/LineChart.svelte', {data: timeseriesWithMultipleY(), x: 'month', y: 'sales_usd0k,profit_usd0k,cost_usd0k'})
+  await expect(chart.el).screenshot('line-chart-multiple-y')
 })
 
 test('line charts hide markers on timeseries', async ({mount, chart}) => {


### PR DESCRIPTION
Turns out an agent already did this in an earlier change, but I wanted add tests and clean the code a bit.