### PR TITLE
Add timeGrain and timeOrdinal metadata on relevant functions

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -21,6 +21,7 @@ import {parseMarkdown} from './markdown.ts'
 import {extractLeadingMetadata} from './metadata.ts'
 import {parser} from './parser.js'
 import {parseTemporalLiteral, parseIntervalLiteral, parseIntervalUnit, renderTemporalArithmetic, renderStandaloneInterval} from './temporal.ts'
+import {inferTemporalOrdinal} from './temporalMetadata.ts'
 import {
   scalarType,
   type AnalysisConfig,
@@ -1001,7 +1002,14 @@ class AnalysisSession implements Analyzer {
         let unit = txt(node.getChild('ExtractUnit')!)
           .replace(/^['"]|['"]$/g, '')
           .toLowerCase()
-        return {sql: `EXTRACT(${unit} FROM ${expr.sql})`, type: scalarType('number'), isAgg: expr.isAgg, fanout: expr.fanout}
+        let timeOrdinal = inferTemporalOrdinal(unit, this.config.dialect)
+        return {
+          sql: `EXTRACT(${unit} FROM ${expr.sql})`,
+          type: scalarType('number'),
+          metadata: timeOrdinal ? {timeOrdinal} : undefined,
+          isAgg: expr.isAgg,
+          fanout: expr.fanout,
+        }
       }
 
       case 'IntervalExpression': {

--- a/lang/bigQueryFunctions.ts
+++ b/lang/bigQueryFunctions.ts
@@ -6,6 +6,7 @@
 
 import type {FunctionDef} from './functionTypes.ts'
 
+import {inferTemporalGrainMetadata} from './temporalMetadata.ts'
 import {trimIndentation} from './util.ts'
 
 const bq = 'https://cloud.google.com/bigquery/docs/reference/standard-sql'
@@ -1978,6 +1979,7 @@ export const bigQueryFunctions: FunctionDef[] = [
       {name: 'date_part', type: 'kw', description: 'The date part to truncate to.'},
     ],
     returns: 'T',
+    metadata: args => inferTemporalGrainMetadata(args[1]?.sql),
     sqlTemplate: 'DATE_TRUNC(${date_expression}, ${date_part})',
   },
   {
@@ -2182,6 +2184,7 @@ export const bigQueryFunctions: FunctionDef[] = [
       {name: 'part', type: 'string', description: 'The part to truncate to.'},
     ],
     returns: 'datetime',
+    metadata: args => inferTemporalGrainMetadata(args[1]?.sql),
   },
   {
     name: 'format_datetime',
@@ -2340,6 +2343,7 @@ export const bigQueryFunctions: FunctionDef[] = [
       {name: 'part', type: 'string', description: 'The part to truncate to.'},
     ],
     returns: 'time',
+    metadata: args => inferTemporalGrainMetadata(args[1]?.sql),
   },
   {
     name: 'format_time',
@@ -2495,6 +2499,7 @@ export const bigQueryFunctions: FunctionDef[] = [
       {name: 'time_zone', type: 'string?', description: 'The time zone to use.'},
     ],
     returns: 'timestamp',
+    metadata: args => inferTemporalGrainMetadata(args[1]?.sql),
   },
   {
     name: 'format_timestamp',

--- a/lang/clickHouseFunctions.ts
+++ b/lang/clickHouseFunctions.ts
@@ -1,5 +1,6 @@
 import type {FunctionDef} from './functionTypes.ts'
 
+import {inferTemporalGrainMetadata} from './temporalMetadata.ts'
 import {trimIndentation} from './util.ts'
 
 const trim = trimIndentation
@@ -765,6 +766,7 @@ export const clickHouseFunctions: FunctionDef[] = [
       {name: 'datetime', type: ['date', 'timestamp']},
     ],
     returns: 'timestamp',
+    metadata: args => inferTemporalGrainMetadata(args[0]?.sql),
     sqlTemplate: 'DATE_TRUNC(${date_part}, ${datetime})',
   },
   {
@@ -854,6 +856,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#todayofmonth`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: {timeOrdinal: 'day_of_month'},
     sqlName: 'toDayOfMonth',
     aliases: ['to_day_of_month'],
   },
@@ -867,6 +870,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#todayofweek`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: {timeOrdinal: 'dow_1m'},
     sqlName: 'toDayOfWeek',
     aliases: ['to_day_of_week'],
   },
@@ -880,6 +884,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tohour`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: {timeOrdinal: 'hour_of_day'},
     sqlName: 'toHour',
     aliases: ['to_hour'],
   },
@@ -906,6 +911,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tomonth`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: {timeOrdinal: 'month_of_year'},
     sqlName: 'toMonth',
     aliases: ['to_month'],
   },
@@ -932,6 +938,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tostartofday`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'timestamp',
+    metadata: {timeGrain: 'day'},
     sqlName: 'toStartOfDay',
     aliases: ['to_start_of_day'],
   },
@@ -945,6 +952,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tostartofmonth`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'timestamp',
+    metadata: {timeGrain: 'month'},
     sqlName: 'toStartOfMonth',
     aliases: ['to_start_of_month'],
   },
@@ -958,6 +966,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tostartofquarter`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'timestamp',
+    metadata: {timeGrain: 'quarter'},
     sqlName: 'toStartOfQuarter',
     aliases: ['to_start_of_quarter'],
   },
@@ -971,6 +980,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tostartofweek`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'timestamp',
+    metadata: {timeGrain: 'week'},
     sqlName: 'toStartOfWeek',
     aliases: ['to_start_of_week'],
   },
@@ -984,6 +994,7 @@ export const clickHouseFunctions: FunctionDef[] = [
     url: `${click}/functions/date-time-functions#tostartofyear`,
     args: [{name: 'datetime', type: ['date', 'timestamp']}],
     returns: 'timestamp',
+    metadata: {timeGrain: 'year'},
     sqlName: 'toStartOfYear',
     aliases: ['to_start_of_year'],
   },

--- a/lang/duckDbFunctions.ts
+++ b/lang/duckDbFunctions.ts
@@ -6,6 +6,7 @@
 
 import type {FunctionDef} from './functionTypes.ts'
 
+import {inferTemporalGrainMetadata, inferTemporalOrdinalMetadata} from './temporalMetadata.ts'
 import {trimIndentation} from './util.ts'
 
 const duck = 'https://duckdb.org/docs/stable/sql/functions'
@@ -1791,6 +1792,7 @@ export const duckDbFunctions: FunctionDef[] = [
       {name: 'date', type: ['date', 'timestamp']},
     ],
     returns: 'number',
+    metadata: args => inferTemporalOrdinalMetadata(args[0]?.sql, 'duckdb'),
   },
   {
     name: 'date_sub',
@@ -2096,6 +2098,7 @@ export const duckDbFunctions: FunctionDef[] = [
       {name: 'timestamp', type: ['date', 'timestamp']},
     ],
     returns: 'timestamp',
+    metadata: args => inferTemporalGrainMetadata(args[0]?.sql),
     sqlTemplate: 'DATE_TRUNC(${part}, ${timestamp})',
   },
   {

--- a/lang/functionTypes.ts
+++ b/lang/functionTypes.ts
@@ -1,6 +1,8 @@
 // Type definitions for SQL function references
 // These are used to define functions in a human-readable format that gets converted to overloads for type checking
 
+import {type Expr, type FieldMeta} from './types.ts'
+
 export type SQLType = 'string' | 'number' | 'boolean' | 'date' | 'timestamp' | 'json' | 'any' | 'bytes'
 
 // Arg definition - can be a simple tuple or an object with description
@@ -42,4 +44,7 @@ export interface FunctionDef {
   // For functions with multiple overloads (e.g., string_agg with/without separator)
   // When present, `args` and `returns` are ignored in favor of overloads
   overloads?: FunctionOverload[]
+  // Metadata automatically attached to the result of this function.
+  // Can be static or computed from analyzed args.
+  metadata?: FieldMeta | ((args: Expr[]) => FieldMeta | undefined)
 }

--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -8,7 +8,7 @@ import {clickHouseFunctions} from './clickHouseFunctions.ts'
 import {duckDbFunctions} from './duckDbFunctions.ts'
 import {extendFanoutPath, mergeFanoutPaths, mergeSensitiveFanouts, normalizeExprFanout} from './fanout.ts'
 import {snowflakeFunctions} from './snowflakeFunctions.ts'
-import {arrayOf, scalarType, type Expr, type FieldMeta, type FieldType, isArrayType, isScalarType, type Scope, type TimeGrain, type TypeKind} from './types.ts'
+import {arrayOf, scalarType, type Expr, type FieldMeta, type FieldType, isArrayType, isScalarType, type Scope, type TypeKind} from './types.ts'
 import {txt} from './util.ts'
 
 // The shape that analyzeFunction works with. Converted from FunctionDef at startup.
@@ -19,6 +19,7 @@ interface Overload {
   sqlName?: string
   supportsBareInvocation?: boolean
   bareSqlName?: string
+  metadata?: FunctionDef['metadata']
 }
 
 // Convert a FunctionDef arg type string (e.g. 'number', 'T', 'string...', 'kw') to allowedTypes
@@ -66,6 +67,7 @@ function convertDef(def: FunctionDef): Overload[] {
     sqlName: def.sqlName,
     supportsBareInvocation: def.supportsBareInvocation && args.length == 0,
     bareSqlName: def.bareSqlName,
+    metadata: def.metadata,
   }))
 }
 
@@ -116,7 +118,7 @@ export function analyzeBareFunction(analyzer: Analyzer, node: SyntaxNode, name: 
   if (overloads.length == 0) return
   let overload = overloads.find(o => o.supportsBareInvocation && o.params.length == 0)
   if (!overload) return
-  return analyzeResolvedFunction(name, overload, [], [], scope, {...opts, bare: true})
+  return analyzeResolvedFunction(name, overload, [], scope, {...opts, bare: true})
 }
 
 function analyzeNamedFunction(analyzer: Analyzer, node: SyntaxNode, name: string, argNodes: SyntaxNode[], scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
@@ -160,10 +162,10 @@ function analyzeNamedFunction(analyzer: Analyzer, node: SyntaxNode, name: string
     return analyzer.diag(node, `Wrong number of arguments for ${name}: expected ${expected}, got ${argNodes.length}`, {sql: 'NULL', type: scalarType('error')})
   }
 
-  return analyzeResolvedFunction(name, overload, args, argNodes, scope, opts)
+  return analyzeResolvedFunction(name, overload, args, scope, opts)
 }
 
-function analyzeResolvedFunction(name: string, overload: Overload, args: Expr[], argNodes: SyntaxNode[], scope: Scope, opts: {isWindow?: boolean; bare?: boolean} = {}): Expr {
+function analyzeResolvedFunction(name: string, overload: Overload, args: Expr[], scope: Scope, opts: {isWindow?: boolean; bare?: boolean} = {}): Expr {
   let returnType: FieldType = overload.returnType.type as FieldType
   if (overload.returnType.type == 'generic') returnType = args[0]?.type || scalarType('string')
   if (overload.returnType.type == 'array') returnType = inferArrayReturnType(args)
@@ -179,7 +181,7 @@ function analyzeResolvedFunction(name: string, overload: Overload, args: Expr[],
   }
   let fnName = opts.bare ? overload.bareSqlName || overload.sqlName || name : overload.sqlName || name
   let sql = opts.bare ? fnName : `${fnName}(${args.map(a => a.sql).join(',')})`
-  let metadata = inferFunctionFieldMetadata(name, overload, args, argNodes)
+  let metadata = inferFunctionFieldMetadata(overload, args)
   return {
     sql,
     type: returnType,
@@ -230,45 +232,10 @@ function analyzePercentile(analyzer: Analyzer, node: SyntaxNode, args: Expr[], d
   }
 }
 
-function inferFunctionFieldMetadata(name: string, overload: Overload, args: Expr[], argNodes: SyntaxNode[]): FieldMeta | undefined {
-  if (name != 'date_trunc') return
-
-  let partIdx = overload.params.findIndex(param => param.name.includes('part'))
-  if (partIdx < 0 || !args[partIdx]) return
-  if (!isScalarType(args[partIdx].type, 'string') && !isScalarType(args[partIdx].type, 'sql native')) return
-
-  let timeGrain = inferTemporalMetadata(txt(argNodes[partIdx]))
-  if (!timeGrain) return
-  return {timeGrain}
-}
-
-// date_trunc part syntax varies by dialect:
-// - BigQuery commonly uses bare keywords like `month`, plus special values like `isoweek` and `week(monday)`.
-// - DuckDB and Snowflake typically pass the part as a string literal like `'month'`.
-// We normalize the supported forms into our shared grain enum and intentionally drop any finer detail.
-function inferTemporalMetadata(rawPart: string): TimeGrain | undefined {
-  let normalized = rawPart
-    .trim()
-    .replace(/^['"]|['"]$/g, '')
-    .toLowerCase()
-  if (!normalized) return
-
-  if (/^week(?:\([a-z]+\))?$/.test(normalized) || normalized == 'isoweek') return 'week'
-  if (normalized == 'isoyear') return 'year'
-  return normalizeTemporalGrain(normalized)
-}
-
-function normalizeTemporalGrain(value: string): TimeGrain | undefined {
-  let grains: Record<string, TimeGrain> = {
-    year: 'year',
-    quarter: 'quarter',
-    month: 'month',
-    day: 'day',
-    hour: 'hour',
-    minute: 'minute',
-    second: 'second',
-  }
-  return grains[value]
+function inferFunctionFieldMetadata(overload: Overload, args: Expr[]): FieldMeta | undefined {
+  if (!overload.metadata) return
+  if (typeof overload.metadata == 'function') return overload.metadata(args)
+  return overload.metadata
 }
 
 function inferArrayReturnType(args: Expr[]): FieldType {

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -23,6 +23,7 @@ export type FieldMeta = {
   pct?: true // 0 to 100 value
   units?: string
   timeGrain?: TimeGrain // resolution when the field is a date or timestamp
+  timeOrdinal?: TimeOrdinal // if the value represents something special like day_of_week, week_of_year, etc
   [key: string]: string | true | undefined
 }
 
@@ -31,6 +32,12 @@ export type ScalarField = 'string' | 'number' | 'boolean' | 'date' | 'timestamp'
 export type ArrayField = {type: 'array'; elementType: FieldType}
 
 export type TimeGrain = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second'
+export type TimeOrdinal = 'hour_of_day' | DayOfWeek | 'day_of_month' | 'day_of_year' | 'week_of_year' | 'month_of_year'
+
+export type DayOfWeek =
+  | 'dow_1s' // 1-7, starting sunday
+  | 'dow_0s' // 0-6, starting sunday
+  | 'dow_1m' // 1-7, starting monday
 
 export interface GrapheneError {
   message: string

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -1094,6 +1094,30 @@ describe('lang', () => {
     expect('from users select extract(hour from created_at)').toRenderSql('select extract(hour from users.created_at) as col_0 from users as users')
   })
 
+  it('infers time ordinal metadata for extract and date_part', () => {
+    updateFile('table events (event_date date, created_at timestamp)', 'events.gsql')
+
+    setConfig({root: '', bigquery: {}})
+    let [bigQuery] = analyze('from events select extract(dayofweek from event_date) as dow')
+    expect(bigQuery.fields[0].metadata).toEqual({timeOrdinal: 'dow_1s'})
+
+    setConfig({root: ''})
+    let [duckDbDow] = analyze("from events select date_part('dow', event_date) as dow")
+    expect(duckDbDow.fields[0].metadata).toEqual({timeOrdinal: 'dow_0s'})
+    let [duckDbIsoDow] = analyze('from events select extract(isodow from event_date) as iso_dow')
+    expect(duckDbIsoDow.fields[0].metadata).toEqual({timeOrdinal: 'dow_1m'})
+
+    setConfig({dialect: 'snowflake', root: ''})
+    let [snowflake] = analyze('from events select dayofweek(event_date) as dow')
+    expect(snowflake.fields[0].metadata).toEqual({timeOrdinal: 'dow_0s'})
+
+    setConfig({dialect: 'clickhouse', root: ''})
+    let [clickhouse] = analyze('from events select to_day_of_week(created_at) as dow')
+    expect(clickhouse.fields[0].metadata).toEqual({timeOrdinal: 'dow_1m'})
+
+    setConfig({root: ''})
+  })
+
   it('supports null and boolean literals', () => {
     expect('from users select name, null, true, FALSE').toRenderSql('select users.name as name, null as col_1, true as col_2, false as col_3 from users as users')
   })

--- a/lang/snowflakeFunctions.ts
+++ b/lang/snowflakeFunctions.ts
@@ -6,6 +6,7 @@
 
 import type {FunctionDef} from './functionTypes.ts'
 
+import {inferTemporalGrainMetadata, inferTemporalOrdinalMetadata} from './temporalMetadata.ts'
 import {trimIndentation} from './util.ts'
 
 const sf = 'https://docs.snowflake.com/en/sql-reference/functions'
@@ -1826,6 +1827,7 @@ export const snowflakeFunctions: FunctionDef[] = [
       {name: 'date_expr', type: ['date', 'timestamp']},
     ],
     returns: 'number',
+    metadata: args => inferTemporalOrdinalMetadata(args[0]?.sql, 'snowflake'),
   },
   {
     name: 'dateadd',
@@ -1965,6 +1967,7 @@ export const snowflakeFunctions: FunctionDef[] = [
       {name: 'date_or_time_part', type: 'string'},
     ],
     returns: 'timestamp',
+    metadata: args => inferTemporalGrainMetadata(args[2]?.sql),
   },
   {
     name: 'timestamp_from_parts',
@@ -2023,6 +2026,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: {timeOrdinal: 'month_of_year'},
   },
   {
     name: 'day',
@@ -2035,6 +2039,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: {timeOrdinal: 'day_of_month'},
   },
   {
     name: 'dayofweek',
@@ -2046,6 +2051,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: {timeOrdinal: 'dow_0s'},
   },
   {
     name: 'dayofyear',
@@ -2057,6 +2063,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: {timeOrdinal: 'day_of_year'},
   },
   {
     name: 'week',
@@ -2069,6 +2076,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/year`,
     args: [{name: 'date_expr', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: {timeOrdinal: 'week_of_year'},
   },
   {
     name: 'quarter',
@@ -2091,6 +2099,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     url: `${sf}/hour-minute-second`,
     args: [{name: 'time_expr', type: ['date', 'timestamp']}],
     returns: 'number',
+    metadata: {timeOrdinal: 'hour_of_day'},
   },
   {
     name: 'minute',
@@ -2365,6 +2374,7 @@ export const snowflakeFunctions: FunctionDef[] = [
       {name: 'date_expr', type: ['date', 'timestamp']},
     ],
     returns: 'timestamp',
+    metadata: args => inferTemporalGrainMetadata(args[0]?.sql),
     sqlTemplate: 'DATE_TRUNC(${part}, ${date_expr})',
   },
   {

--- a/lang/temporalMetadata.ts
+++ b/lang/temporalMetadata.ts
@@ -1,0 +1,55 @@
+import type {FieldMeta, TimeGrain, TimeOrdinal} from './types.ts'
+
+export function inferTemporalGrain(rawPart?: string): TimeGrain | undefined {
+  let normalized = String(rawPart || '')
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .toLowerCase()
+  if (!normalized) return
+
+  if (/^week(?:\([a-z]+\))?$/.test(normalized) || normalized == 'isoweek') return 'week'
+  if (normalized == 'isoyear') return 'year'
+
+  let grains: Record<string, TimeGrain> = {
+    year: 'year',
+    quarter: 'quarter',
+    month: 'month',
+    day: 'day',
+    hour: 'hour',
+    minute: 'minute',
+    second: 'second',
+  }
+  return grains[normalized]
+}
+
+export function inferTemporalGrainMetadata(rawPart?: string): FieldMeta | undefined {
+  let timeGrain = inferTemporalGrain(rawPart)
+  return timeGrain ? {timeGrain} : undefined
+}
+
+export function inferTemporalOrdinal(rawPart: string | undefined, dialect: string): TimeOrdinal | undefined {
+  let normalized = String(rawPart || '')
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .toLowerCase()
+  if (!normalized) return
+
+  if (normalized == 'hour') return 'hour_of_day'
+  if (normalized == 'day' || normalized == 'dayofmonth') return 'day_of_month'
+  if (normalized == 'dayofyear' || normalized == 'doy') return 'day_of_year'
+  if (normalized == 'week' || normalized == 'weekofyear' || normalized == 'isoweek') return 'week_of_year'
+  if (normalized == 'month') return 'month_of_year'
+
+  if (normalized == 'isodow' || normalized == 'dayofweekiso' || normalized == 'iso_dayofweek') return 'dow_1m'
+
+  if (normalized == 'dayofweek' || normalized == 'dow' || normalized == 'weekday') {
+    if (dialect == 'bigquery') return 'dow_1s'
+    if (dialect == 'clickhouse') return 'dow_1m'
+    return 'dow_0s'
+  }
+}
+
+export function inferTemporalOrdinalMetadata(rawPart: string | undefined, dialect: string): FieldMeta | undefined {
+  let timeOrdinal = inferTemporalOrdinal(rawPart, dialect)
+  return timeOrdinal ? {timeOrdinal} : undefined
+}

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -1,7 +1,7 @@
 import type {SyntaxNode, Tree} from '@lezer/common'
 
 import type {ExprFanout, FanoutPath} from './fanout.ts'
-import type {ArrayField, FieldMeta, FieldType, GrapheneError, Position, ScalarField, TimeGrain} from './index.d.ts'
+import type {ArrayField, FieldMeta, FieldType, GrapheneError, Position, ScalarField, TimeGrain, TimeOrdinal} from './index.d.ts'
 import type {TimestampUnit} from './temporal.ts'
 
 declare module '@lezer/common' {
@@ -40,7 +40,7 @@ export interface ParsedFileArtifacts {
   virtualToMarkdownOffset?: number[]
 }
 
-export type {FieldType, FieldMeta, GrapheneError, Position, ScalarField, ArrayField, TimeGrain}
+export type {FieldType, FieldMeta, GrapheneError, Position, ScalarField, ArrayField, TimeGrain, TimeOrdinal}
 export type TypeKind = ScalarField | 'array'
 
 let SCALAR_TYPE_ALIASES: Record<string, ScalarField> = {


### PR DESCRIPTION
This is set on functions, and can either be a static object, or a function that returns metadata given the raw args.