### PR TITLE
Change chart api to use splitBy and arrange

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -66,11 +66,11 @@ Queries can be referenced by other queries in the `from` or `join` to form DAGs 
 ## Components
 All viz components take `data`, which is the name of a gsql table or code-fenced query in the markdown.
 Component "field" attributes (like x and y) map to a column within data.
-Attributes like `x`, `y`, `y2`, `group`, `stack`, `stack100` are the names of columns within the `data` table.
+Attributes like `x`, `y`, `y2`, and `splitBy` are the names of columns within the `data` table.
 `title` - shown above the viz
-- BarChart: Fields [x,y,y2,group,stack,stack100]. y2 will always be a line, stack and stack100 are mutually exclusive. `label` (show labels above bars)
-- LineChart: Fields [x,y,series]
-- AreaChart: Fields [x,y,group,stack,stack100]
+- BarChart: Fields [x,y,y2,splitBy,arrange]. `arrange` can be `stack`, `group`, or `stack100` (default `stack`). `label` shows labels above bars.
+- LineChart: Fields [x,y,y2,splitBy]
+- AreaChart: Fields [x,y,splitBy,arrange]. `arrange` can be `stack` or `stack100` (default `stack`).
 - PieChart: Fields: [category,value]
 
 - BigValue: data, value, title, fmt, comparison, comparisonFmt, comparisonTitle, downIsGood, sparkline, sparklineType, sparklineColor
@@ -80,12 +80,12 @@ Attributes like `x`, `y`, `y2`, `group`, `stack`, `stack100` are the names of co
 ## ECharts
 To further customize the look and feel of a chart, use the ECharts component to provide an echarts config.
 Be sure to set `data`, and use `encode` on series to map columns in the `data`.
-In addition to the regular fields `encode` takes, it also accepts `stack` and `group`, which will automatically expand that column to the required number of series.
+In addition to the regular fields `encode` takes, it also accepts `splitBy`, which automatically expands one template into multiple series. For bar charts, `splitBy` can be a two-item list (`[groupBy, stackBy]`) for grouped+stacked bars.
 
 ```md
 <ECharts data="sales_by_category">
   xAxis: {axisLine: {lineStyle: {color: 'purple'}}},
-  series: [{type: "bar", encode: {x: "month", y: "revenue", stack: "category"}],
+  series: [{type: "bar", stack: "bar-stack", encode: {x: "month", y: "revenue", splitBy: "category"}],
 </ECharts>
 ```
 

--- a/docs/references/area-chart.md
+++ b/docs/references/area-chart.md
@@ -10,7 +10,8 @@ Here's an example:
   data=revenue_by_month
   x=month
   y=revenue
-  stack=channel
+  splitBy=channel
+  arrange=stack
 />
 ```
 
@@ -31,11 +32,9 @@ Here's an example:
 |----------|-------------|----------|---------|---------|
 | x | Field for x-axis | true | column/expression name | - |
 | y | One or more value fields (comma-separated) | true | column(s), e.g. `revenue` or `revenue, cost` | - |
-| group | Split one `y` field into multiple overlapping area series | false | column/expression name | - |
-| stack | Split one `y` field into stacked areas | false | column/expression name | - |
-| stack100 | Same as `stack`, but normalized to 100% | false | column/expression name | - |
+| splitBy | Split one value field into multiple area series by distinct values of this field | false | column/expression name | - |
+| arrange | Arrangement for `splitBy` series | false | `stack`, `stack100` | `stack` |
 
-`group`, `stack`, and `stack100` are mutually exclusive.
-When `y` has multiple fields, `group`/`stack`/`stack100` are not supported.
+`splitBy` is incompatible with multiple y fields.
 
 For more control, use [`ECharts`](./echarts.md) directly.

--- a/docs/references/bar-chart.md
+++ b/docs/references/bar-chart.md
@@ -10,7 +10,8 @@ Here's an example:
   data=orders_by_category
   x=category
   y=revenue
-  stack=region
+  splitBy=region
+  arrange=stack
 />
 ```
 
@@ -30,14 +31,13 @@ Here's an example:
 | Attribute | Description | Required | Options | Default |
 |----------|-------------|----------|---------|---------|
 | x | Field for category axis | true | column/expression name | - |
-| y | One or more value fields (comma-separated). Multiple values create one series per field. | true | column(s), e.g. `revenue` or `revenue, cost` | - |
+| x | Field for category axis. For horizontal bars you can provide multiple comma-separated x fields. | true | column/expression name(s) | - |
+| y | One or more value fields (comma-separated). For horizontal bars this should be the category field. | true | column(s), e.g. `revenue` or `revenue, cost` | - |
 | y2 | Optional field rendered as a line on secondary axis | false | column/expression name | - |
-| group | Split one `y` field into grouped bars by distinct values of this field | false | column/expression name | - |
-| stack | Split one `y` field into stacked bars by distinct values of this field | false | column/expression name | - |
-| stack100 | Same as `stack`, but normalized to 100% | false | column/expression name | - |
+| splitBy | Split one value field into multiple series by distinct values of this field | false | column/expression name | - |
+| arrange | Arrangement for `splitBy` series | false | `stack`, `group`, `stack100` | `stack` |
 | label | Show value labels on bars | false | `true`, `false` | `false` |
 
-`group`, `stack`, and `stack100` are mutually exclusive.
-When `y` has multiple fields, `group`/`stack`/`stack100` are not supported.
+`splitBy` is incompatible with multiple value fields.
 
 For advanced behavior (custom tooltips, axes, transforms, chart types), use [`ECharts`](./echarts.md) directly.

--- a/docs/references/echarts.md
+++ b/docs/references/echarts.md
@@ -30,26 +30,40 @@ Inside `<ECharts>...</ECharts>`, Graphene parses the config as JSON5:
 - trailing commas are allowed
 - you can wrap the whole thing in `{ ... }` or omit the outer braces
 
-## Grouping and stacking hints
+## Customizing with split hints
 
-Graphene supports a few `encode` extensions to reduce boilerplate:
-- `encode.group`: expands one series template into one series per distinct value
-- `encode.stack`: same expansion, but stacked
-- `stackPercentage: true`: converts stacked values to 100% stacking
+To keep configs concise, Graphene supports a split hint:
 
-Example:
+- `encode.splitBy: "field"`: split one series template into one series per distinct field value
+- `encode.splitBy: ["groupField", "stackField"]` (bar only): expands to grouped+stacked bars, where the first field groups and the second stacks
+- with a single split field, `series.stack` decides stacked vs grouped behavior
+- `stackPercentage: true`: convert stacked values to percentages (100% stacked)
+
+Examples:
 
 ```markdown
 <ECharts data="sales_by_month_and_region">
   xAxis: {},
   yAxis: {},
   series: [{
-    type: "bar",
-    encode: {x: "month", y: "revenue", stack: "region"},
-    stack: "revenue-stack",
-    stackPercentage: true,
-  }],
+    type: 'bar',
+    encode: {x: 'month', y: 'revenue', splitBy: 'region'},
+    stack: 'revenue-stack',
+    stackPercentage: true
+  }]
 </ECharts>
+
+<!-- Char that is both grouped by region and stacked by channel -->
+<ECharts data="sales_by_month_region_channel">
+  xAxis: {},
+  yAxis: {},
+  series: [{
+    type: 'bar',
+    encode: {x: 'month', y: 'revenue', splitBy: ['region', 'channel']},
+    stack: 'revenue-stack',
+    stackPercentage: true
+  }]
+/>
 ```
 
 For common chart types, prefer `BarChart`, `LineChart`, `AreaChart`, and `PieChart`. Use `ECharts` when you need deeper customization.

--- a/docs/references/line-chart.md
+++ b/docs/references/line-chart.md
@@ -10,7 +10,7 @@ Here's an example:
   data=revenue_by_month
   x=month
   y=revenue
-  series=region
+  splitBy=region
 />
 ```
 
@@ -32,9 +32,8 @@ Here's an example:
 | x | Field for x-axis | true | column/expression name | - |
 | y | One or more value fields (comma-separated) | true | column(s), e.g. `revenue` or `revenue, cost` | - |
 | y2 | Optional field rendered on secondary axis | false | column/expression name | - |
-| series | Split one `y` field into one line per distinct value | false | column/expression name | - |
+| splitBy | Split one `y` field into one line per distinct value | false | column/expression name | - |
 
-If `y` includes multiple fields, each field becomes its own line.
-`series` requires a single `y` field.
+`splitBy` is incompatible with multiple y fields. If `y` includes multiple fields, each field becomes its own line.
 
 For advanced behavior (custom line styles, annotations, axis config, dataset transforms), use [`ECharts`](./echarts.md) directly.

--- a/ui/component-utilities/dataShaping.ts
+++ b/ui/component-utilities/dataShaping.ts
@@ -2,7 +2,7 @@ import type {Field, NormalConfig, SeriesWithGroupingHint} from './types.ts'
 
 // Fill sparse grouped data so each split series has a value for each x bucket.
 //
-// This only applies to grouped templates (`encode.group` or `encode.stack`).
+// This only applies to split templates (`encode.splitBy`).
 // We do not attempt to fabricate x values here; we only ensure a full Cartesian
 // product of existing x values and split values.
 //
@@ -16,16 +16,16 @@ export function applyMissingPointDefaults(config: NormalConfig, rows: Record<str
   let series = config.series
   if (series.length === 0 || rows.length === 0) return
 
-  let groups = new Map<string, {xField: string; splitField: string; fills: Map<string, any>}>()
+  let groups = new Map<string, {xField: string; splitFields: string[]; fills: Map<string, any>}>()
 
   for (let entry of series) {
-    let splitField = getSplitField(entry)
+    let splitFields = getSplitFields(entry)
     let xField = getSeriesXField(entry)
     let yField = getSeriesYField(entry)
-    if (!splitField || !xField || !yField) continue
+    if (splitFields.length === 0 || !xField || !yField) continue
 
-    let key = `${xField}::${splitField}`
-    if (!groups.has(key)) groups.set(key, {xField, splitField, fills: new Map()})
+    let key = `${xField}::${splitFields.join('::')}`
+    if (!groups.has(key)) groups.set(key, {xField, splitFields, fills: new Map()})
 
     // This line is where chart-specific missing-value behavior is chosen.
     // See getMissingFillValueForSeries() below for the type mapping.
@@ -39,19 +39,22 @@ export function applyMissingPointDefaults(config: NormalConfig, rows: Record<str
 
   for (let group of groups.values()) {
     let xValues = distinctValues(rows, group.xField)
-    let splitValues = distinctValues(rows, group.splitField)
-    if (xValues.length === 0 || splitValues.length === 0) continue
+    let splitValues = group.splitFields.map(field => distinctValues(rows, field))
+    if (xValues.length === 0 || splitValues.some(values => values.length === 0)) continue
 
     let existing = new Set<string>()
     for (let row of rows) {
-      existing.add(pairKey(row?.[group.xField], row?.[group.splitField]))
+      existing.add(compositeKey([row?.[group.xField], ...group.splitFields.map(field => row?.[field])]))
     }
 
     for (let xValue of xValues) {
-      for (let splitValue of splitValues) {
-        if (existing.has(pairKey(xValue, splitValue))) continue
+      for (let splitCombination of cartesianValues(splitValues)) {
+        if (existing.has(compositeKey([xValue, ...splitCombination]))) continue
 
-        let row: Record<string, any> = {[group.xField]: xValue, [group.splitField]: splitValue}
+        let row: Record<string, any> = {[group.xField]: xValue}
+        group.splitFields.forEach((field, index) => {
+          row[field] = splitCombination[index]
+        })
         for (let [yField, fillValue] of group.fills.entries()) row[yField] = fillValue
         rows.push(row)
       }
@@ -134,7 +137,7 @@ export function applySorting(config: NormalConfig, rows: Record<string, any>[], 
   let primarySeries = series.filter(entry => getSeriesXField(entry) === primaryXField.name && getSeriesYField(entry))
   if (primarySeries.length === 0) return
 
-  let hasStackedBars = primarySeries.some(entry => entry?.type === 'bar' && !!entry?.stack)
+  let hasStackedBars = primarySeries.some(entry => entry?.type === 'bar' && (!!entry?.stack || getSplitFields(entry).length === 2))
   if (hasStackedBars) {
     let yFields = Array.from(new Set(primarySeries.map(entry => getSeriesYField(entry)).filter(Boolean))) as string[]
     sortCategoriesByValue(rows, primaryXField.name, row => yFields.reduce((sum, y) => sum + (Number(row?.[y]) || 0), 0), 'desc')
@@ -351,10 +354,14 @@ function parseSortSpec(sort: string): {field: string; direction: 'asc' | 'desc'}
   return {field, direction}
 }
 
-function getSplitField(series: SeriesWithGroupingHint) {
-  if (typeof series?.encode?.group === 'string') return series.encode.group
-  if (typeof series?.encode?.stack === 'string') return series.encode.stack
-  return undefined
+function getSplitFields(series: SeriesWithGroupingHint) {
+  let splitBy = series?.encode?.splitBy
+  if (typeof splitBy === 'string') return [splitBy]
+  if (!Array.isArray(splitBy)) return []
+  return splitBy
+    .filter(value => typeof value === 'string')
+    .map(value => value.trim())
+    .filter(Boolean)
 }
 
 function isHorizontalBar(config: NormalConfig) {
@@ -400,8 +407,23 @@ function sortableValue(value: unknown, type: 'date' | 'number') {
   return Number.isFinite(timestamp) ? timestamp : Number.POSITIVE_INFINITY
 }
 
-function pairKey(left: unknown, right: unknown) {
-  return `${valueKey(left)}|${valueKey(right)}`
+function cartesianValues(valueLists: unknown[][]) {
+  if (valueLists.length === 0) return [[]] as unknown[][]
+
+  return valueLists.reduce<unknown[][]>(
+    (acc, values) => {
+      let next: unknown[][] = []
+      for (let prefix of acc) {
+        for (let value of values) next.push([...prefix, value])
+      }
+      return next
+    },
+    [[]],
+  )
+}
+
+function compositeKey(values: unknown[]) {
+  return values.map(value => valueKey(value)).join('|')
 }
 
 function valueKey(value: unknown) {

--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -101,30 +101,66 @@ function ensureDataset(config: NormalConfig, rows: Record<string, any>[], fields
   return String(base.id)
 }
 
-// Expand series templates that use `encode.group` or `encode.stack` into one concrete series per distinct field value.
+// Expand series templates that use `encode.splitBy` into one concrete series per distinct field value.
 // We do this with ECharts dataset filter transforms so wrappers stay small and users don't need to duplicate series configs.
 function expandSeriesTransforms(config: NormalConfig, rows: Record<string, any>[], baseDatasetId: string) {
   let templates = config.series
   let expanded: SeriesWithGroupingHint[] = []
 
   templates.forEach((entry, templateIndex) => {
-    let groupField = typeof entry?.encode?.group === 'string' ? entry.encode.group : undefined
-    let stackField = typeof entry?.encode?.stack === 'string' ? entry.encode.stack : undefined
-
-    if (groupField && stackField) throw new Error('Series encode.group and encode.stack cannot both be set')
-
-    let splitField = groupField ?? stackField
-    if (!splitField) {
+    let splitFields = getSplitByFields(entry)
+    if (splitFields.length === 0) {
       let next = {...entry}
       if (shouldBindSeriesToDataset(next) && next.datasetId == null) next.datasetId = baseDatasetId
       expanded.push(next)
       return
     }
 
+    if (splitFields.length > 2) throw new Error('encode.splitBy supports at most two fields')
+
+    let sourceDatasetId = entry.datasetId ?? baseDatasetId
+
+    if (splitFields.length === 2) {
+      if (entry?.type !== 'bar') throw new Error('encode.splitBy with two fields is only supported for bar series')
+
+      let [groupField, stackField] = splitFields
+      let groupValues = distinctValues(rows, groupField)
+      let stackValues = distinctValues(rows, stackField)
+      if (groupValues.length === 0 || stackValues.length === 0) return
+
+      groupValues.forEach((groupValue, groupIndex) => {
+        let groupedDatasetId = `__graphene_series_${templateIndex}_${groupIndex}`
+        config.dataset.push({
+          id: groupedDatasetId,
+          fromDatasetId: sourceDatasetId,
+          transform: {type: 'filter', config: {dimension: groupField, '=': groupValue}},
+        })
+
+        stackValues.forEach((stackValue, stackIndex) => {
+          let datasetId = `__graphene_series_${templateIndex}_${groupIndex}_${stackIndex}`
+          config.dataset.push({
+            id: datasetId,
+            fromDatasetId: groupedDatasetId,
+            transform: {type: 'filter', config: {dimension: stackField, '=': stackValue}},
+          })
+
+          let next = {...entry, datasetId, stack: String(groupValue ?? '')}
+          if (next.name == null) next.name = `${String(groupValue ?? '')} · ${String(stackValue ?? '')}`
+          if (next.encode) {
+            next.encode = {...next.encode}
+            delete next.encode.splitBy
+          }
+          expanded.push(next)
+        })
+      })
+
+      return
+    }
+
+    let splitField = splitFields[0]
     let seriesValues = distinctValues(rows, splitField)
     if (seriesValues.length === 0) return
 
-    let sourceDatasetId = entry.datasetId ?? baseDatasetId
     seriesValues.forEach((seriesValue, valueIndex) => {
       let datasetId = `__graphene_series_${templateIndex}_${valueIndex}`
       config.dataset.push({
@@ -137,8 +173,7 @@ function expandSeriesTransforms(config: NormalConfig, rows: Record<string, any>[
       if (next.name == null) next.name = String(seriesValue ?? '')
       if (next.encode) {
         next.encode = {...next.encode}
-        delete next.encode.group
-        delete next.encode.stack
+        delete next.encode.splitBy
       }
       expanded.push(next)
     })
@@ -573,6 +608,16 @@ function getSeriesValueField(series: SeriesWithGroupingHint, fields: Field[]) {
 
 function getSeriesCategoryFieldForHorizontal(series?: SeriesWithGroupingHint) {
   return getEncodeField(series?.encode?.y)
+}
+
+function getSplitByFields(series?: SeriesWithGroupingHint) {
+  let splitBy = series?.encode?.splitBy
+  if (typeof splitBy === 'string') return [splitBy]
+  if (!Array.isArray(splitBy)) return []
+  return splitBy
+    .filter(value => typeof value === 'string')
+    .map(value => value.trim())
+    .filter(Boolean)
 }
 
 function getEncodeField(value: unknown): string | undefined {

--- a/ui/component-utilities/types.ts
+++ b/ui/component-utilities/types.ts
@@ -35,15 +35,15 @@ type CommonSeriesFields = {
   showSymbol?: boolean
 }
 
-// ECharts supports lightweight grouping hints so configs stay concise.
-// - `encode.group` or `encode.stack` splits one template into one series per distinct value.
-// - these hints are mutually exclusive.
+// ECharts supports a lightweight split hint so configs stay concise.
+// - `encode.splitBy: "field"` splits one template into one series per distinct field value.
+// - `encode.splitBy: ["groupBy", "stackBy"]` is bar-only grouped+stacked shorthand.
+// - with a single split field, use native `series.stack` to choose stacked vs grouped behavior.
 export type SeriesWithGroupingHint = Omit<SeriesOption, 'encode'> &
   CommonSeriesFields & {
     stackPercentage?: boolean
     encode?: SeriesEncode & {
-      group?: string
-      stack?: string
+      splitBy?: string | string[]
       sort?: string
     }
   }

--- a/ui/components/AreaChart.svelte
+++ b/ui/components/AreaChart.svelte
@@ -7,9 +7,8 @@
     data: string | QueryResult
     x: string
     y: string
-    group?: string
-    stack?: string
-    stack100?: string
+    splitBy?: string
+    arrange?: 'stack' | 'stack100'
     sort?: string
     title?: string
     height?: string | number
@@ -20,9 +19,8 @@
     data,
     x,
     y,
-    group = undefined,
-    stack = undefined,
-    stack100 = undefined,
+    splitBy = undefined,
+    arrange = 'stack',
     sort = undefined,
     title = undefined,
     height = undefined,
@@ -31,36 +29,29 @@
 
   function buildConfig(): EChartsConfig {
     let yFields = parseCommaList(y)
-    let mode = resolveGroupingMode(group, stack, stack100)
-    if (mode && yFields.length > 1) throw new Error('AreaChart does not support `group`, `stack`, or `stack100` when `y` has multiple fields')
-    let grouped = Boolean(mode && yFields.length === 1)
-    let stackKey = mode?.kind === 'stack' || mode?.kind === 'stack100' ? 'area-stack' : undefined
-    let stackPercentage = mode?.kind === 'stack100' ? true : undefined
+    if (splitBy && yFields.length > 1) throw new Error('AreaChart does not support splitBy with multiple y fields')
 
+    let stack = arrange === 'stack' || arrange === 'stack100' ? 'area-stack' : undefined
+    let stackPercentage = arrange === 'stack100' ? true : undefined
     let sortHint = typeof sort === 'string' && sort.trim().length > 0 ? {sort} : {}
-    let series = grouped
-      ? [{type: 'line' as const, areaStyle: {opacity: 0.2}, stack: stackKey, stackPercentage, encode: {x, y: yFields[0], group: mode?.field, ...sortHint}}]
-      : yFields.map(field => ({type: 'line' as const, name: field, areaStyle: {opacity: 0.2}, encode: {x, y: field, ...sortHint}}))
+
+    let series
+    if (splitBy) {
+      // "tall" data, one template split into one series per splitBy value by enrich()
+      series = [{type: 'line' as const, areaStyle: {opacity: 0.2}, stack, stackPercentage, encode: {x, y: yFields[0], splitBy, ...sortHint}}]
+    } else {
+      // "wide" data, one area series per field listed in y
+      series = yFields.map(field => ({type: 'line' as const, name: field, areaStyle: {opacity: 0.2}, encode: {x, y: field, ...sortHint}}))
+    }
 
     return {
       title: title ? {text: title} : undefined,
       tooltip: {trigger: 'axis'},
-      legend: {show: grouped || yFields.length > 1},
+      legend: {show: Boolean(splitBy || yFields.length > 1)},
       xAxis: {},
       yAxis: {max: stackPercentage ? 1 : undefined},
       series,
     }
-  }
-
-  function resolveGroupingMode(group?: string, stack?: string, stack100?: string) {
-    let modes = [
-      group ? {kind: 'group' as const, field: group} : undefined,
-      stack ? {kind: 'stack' as const, field: stack} : undefined,
-      stack100 ? {kind: 'stack100' as const, field: stack100} : undefined,
-    ].filter(Boolean)
-
-    if (modes.length <= 1) return modes[0]
-    throw new Error('AreaChart accepts only one of `group`, `stack`, or `stack100`')
   }
 </script>
 

--- a/ui/components/BarChart.svelte
+++ b/ui/components/BarChart.svelte
@@ -8,9 +8,8 @@
     x: string
     y: string
     y2?: string
-    group?: string
-    stack?: string
-    stack100?: string
+    splitBy?: string
+    arrange?: 'stack' | 'group' | 'stack100'
     label?: boolean
     sort?: string
     title?: string
@@ -23,9 +22,8 @@
     x,
     y,
     y2 = undefined,
-    group = undefined,
-    stack = undefined,
-    stack100 = undefined,
+    splitBy = undefined,
+    arrange = 'stack',
     label = false,
     sort = undefined,
     title = undefined,
@@ -34,40 +32,46 @@
   }: Props = $props()
 
   function buildConfig(): EChartsConfig {
+    let xFields = parseCommaList(x)
     let yFields = parseCommaList(y)
-    let mode = resolveGroupingMode(group, stack, stack100)
-    if (mode && yFields.length > 1) throw new Error('BarChart does not support `group`, `stack`, or `stack100` when `y` has multiple fields')
-    let grouped = Boolean(mode && yFields.length === 1)
+    let horizontal = xFields.length > 1
+
+    if (xFields.length > 1 && yFields.length !== 1) throw new Error('BarChart only supports multiple x fields for horizontal charts with a single y field')
+    if (splitBy && horizontal && xFields.length > 1) throw new Error('BarChart does not support splitBy with multiple x fields')
+    if (splitBy && !horizontal && yFields.length > 1) throw new Error('BarChart does not support splitBy with multiple y fields')
+
     let barLabel = label ? {show: true} : undefined
-    let stackKey = mode?.kind === 'stack' || mode?.kind === 'stack100' ? 'bar-stack' : undefined
-    let stackPercentage = mode?.kind === 'stack100' ? true : undefined
-
+    let stack = arrange === 'stack' || arrange === 'stack100' ? 'bar-stack' : undefined
+    let stackPercentage = arrange === 'stack100' ? true : undefined
     let sortHint = typeof sort === 'string' && sort.trim().length > 0 ? {sort} : {}
-    let series: SeriesWithGroupingHint[] = grouped
-      ? [{type: 'bar' as const, encode: {x, y: yFields[0], group: mode?.field, ...sortHint}, stack: stackKey, stackPercentage, label: barLabel}]
-      : yFields.map(field => ({type: 'bar' as const, name: field, encode: {x, y: field, ...sortHint}, label: barLabel}))
 
+    let series: SeriesWithGroupingHint[]
+
+    if (splitBy) {
+      // "tall" data, series are created for unique values of the valueField (handled by an enrichment)
+      let valueField = horizontal ? xFields[0] : yFields[0]
+      let encode = {x: horizontal ? valueField : x, y: horizontal ? y : valueField, splitBy, ...sortHint}
+      series = [{type: 'bar' as const, encode, stack, stackPercentage, label: barLabel}]
+    } else {
+      // "wide" data, series are created for field listed in the y (or x, for horizontal) attribute
+      if (horizontal) {
+        series = xFields.map(field => ({type: 'bar' as const, name: field, encode: {x: field, y, ...sortHint}, label: barLabel}))
+      } else {
+        series = yFields.map(field => ({type: 'bar' as const, name: field, encode: {x, y: field, ...sortHint}, label: barLabel}))
+      }
+    }
+
+    // y2 is a special shortcut for adding a line on top of a bar chart
     if (y2) series.push({type: 'line' as const, name: y2, yAxisIndex: 1, encode: {x, y: y2, ...sortHint}})
 
     return {
       title: title ? {text: title} : undefined,
       tooltip: {trigger: 'axis'},
-      legend: {show: Boolean(grouped || yFields.length > 1 || y2)},
+      legend: {show: Boolean(splitBy || y2 || (!horizontal && yFields.length > 1) || (horizontal && xFields.length > 1))},
       xAxis: {},
       yAxis: [{max: stackPercentage ? 1 : undefined}, ...(y2 ? [{}] : [])],
       series,
     }
-  }
-
-  function resolveGroupingMode(group?: string, stack?: string, stack100?: string) {
-    let modes = [
-      group ? {kind: 'group' as const, field: group} : undefined,
-      stack ? {kind: 'stack' as const, field: stack} : undefined,
-      stack100 ? {kind: 'stack100' as const, field: stack100} : undefined,
-    ].filter(Boolean)
-
-    if (modes.length <= 1) return modes[0]
-    throw new Error('BarChart accepts only one of `group`, `stack`, or `stack100`')
   }
 </script>
 

--- a/ui/components/LineChart.svelte
+++ b/ui/components/LineChart.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import ECharts from './ECharts.svelte'
   import {parseCommaList} from '../component-utilities/inputUtils.ts'
-  import type {EChartsConfig, QueryResult} from '../component-utilities/types.ts'
+  import type {EChartsConfig, QueryResult, SeriesWithGroupingHint} from '../component-utilities/types.ts'
 
   interface Props {
     data: string | QueryResult
     x: string
     y: string
-    series?: string
+    splitBy?: string
     sort?: string
     title?: string
     height?: string | number
@@ -18,7 +18,7 @@
     data,
     x,
     y,
-    series = undefined,
+    splitBy = undefined,
     sort = undefined,
     title = undefined,
     height = undefined,
@@ -27,23 +27,26 @@
 
   function buildConfig(): EChartsConfig {
     let yFields = parseCommaList(y)
-    if (series && yFields.length > 1) throw new Error('LineChart does not support `series` when `y` has multiple fields')
-    let groupedSeries = Boolean(series && yFields.length === 1)
+    if (splitBy && yFields.length > 1) throw new Error('LineChart does not support splitBy with multiple y fields')
 
     let sortHint = typeof sort === 'string' && sort.trim().length > 0 ? {sort} : {}
-    let primarySeries = groupedSeries
-      ? [{type: 'line', encode: {x, y: yFields[0], group: series, ...sortHint}}]
-      : yFields.map(field => ({type: 'line', name: field, encode: {x, y: field, ...sortHint}}))
+    let series: SeriesWithGroupingHint[]
 
-    let seriesTemplates: any[] = [...primarySeries]
+    if (splitBy) {
+      // "tall" data, one template split into one series per splitBy value by enrich()
+      series = [{type: 'line' as const, encode: {x, y: yFields[0], splitBy, ...sortHint}}]
+    } else {
+      // "wide" data, one line per field listed in y
+      series = yFields.map(field => ({type: 'line' as const, name: field, encode: {x, y: field, ...sortHint}}))
+    }
 
     return {
       title: title ? {text: title} : undefined,
       tooltip: {trigger: 'axis'},
-      legend: {show: groupedSeries || yFields.length > 1},
+      legend: {show: Boolean(splitBy || yFields.length > 1)},
       xAxis: {},
       yAxis: [{}],
-      series: seriesTemplates,
+      series,
     }
   }
 

--- a/ui/internal/ChartGallery.svelte
+++ b/ui/internal/ChartGallery.svelte
@@ -207,7 +207,7 @@
     }}
     config={{
       title: {text: 'Stacked Area'},
-      series: [{type: 'line', stack: 'total', areaStyle: {}, encode: {x: 'day', y: 'value', group: 'metric'}}],
+      series: [{type: 'line', stack: 'total', areaStyle: {}, encode: {x: 'day', y: 'value', splitBy: 'metric'}}],
     }}
   />
 
@@ -222,7 +222,7 @@
     }}
     config={{
       title: {text: 'Bar'},
-      series: [{type: 'bar', encode: {x: 'quarter', y: 'value', group: 'metric'}}],
+      series: [{type: 'bar', encode: {x: 'quarter', y: 'value', splitBy: 'metric'}}],
     }}
   />
 
@@ -237,7 +237,7 @@
     }}
     config={{
       title: {text: 'Scatter'},
-      series: [{type: 'scatter', encode: {x: 'x', y: 'y', group: 'group'}}],
+      series: [{type: 'scatter', encode: {x: 'x', y: 'y', splitBy: 'group'}}],
     }}
   />
 
@@ -262,7 +262,7 @@
         {type: 'category', data: groupedStackedQuarterLabels, position: 'bottom', offset: 24, axisTick: {show: false}},
       ],
       yAxis: {type: 'value'},
-      series: [{type: 'bar', stack: 'channels', encode: {x: 'slot', y: 'value', group: 'channel'}}],
+      series: [{type: 'bar', stack: 'channels', encode: {x: 'slot', y: 'value', splitBy: 'channel'}}],
     }}
   />
 
@@ -363,7 +363,7 @@
       title: {text: 'Theme River'},
       tooltip: {trigger: 'axis'},
       singleAxis: {type: 'time'},
-      series: [{type: 'themeRiver', encode: {single: 'month', value: 'value', seriesName: 'topic', group: 'topic'}}],
+      series: [{type: 'themeRiver', encode: {single: 'month', value: 'value', seriesName: 'topic', splitBy: 'topic'}}],
     }}
   />
 

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -45,7 +45,7 @@ test('flights simple stacked bar renders', async ({server, page}) => {
     order by 1 asc, 2 asc
     \`\`\`
 
-    <BarChart title="Flights by Month (Stacked)" data=monthly_flight_status x=month y=flights stack=status />
+    <BarChart title="Flights by Month (Stacked)" data=monthly_flight_status x=month y=flights splitBy=status arrange=stack />
   `,
   )
 

--- a/ui/tests/snapshots/viz.test.ts/echarts-splitby-group-stack.png
+++ b/ui/tests/snapshots/viz.test.ts/echarts-splitby-group-stack.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6eea75235b6d6f8f143cb2579c934f2995a385207a5b908458380a4eb1e74735
+size 9907

--- a/ui/tests/snapshots/viz.test.ts/echarts-stack.png
+++ b/ui/tests/snapshots/viz.test.ts/echarts-stack.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:106541ad9eb5bed1b4e10c309352101cf6e164041ba00bcd6a79ac92b1dff66c
-size 10158
+oid sha256:eceb2b0f50ab9ed1ddd20dd1994ef67ef102347d160a89f41bcee31a425cfea2
+size 8304

--- a/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart-multi-x.png
+++ b/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart-multi-x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a497fd0fe08f345ec57d090c0b1028585adbf60aef16829939a55b7d4f43299
+size 5346

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -52,7 +52,7 @@ test('echarts chart configuration error state', async ({mount, chart}) => {
   await expect(chart.el).screenshot('echarts-chart-config-error-state')
 })
 
-test('echarts expands encode.stack', async ({mount, chart}) => {
+test('echarts expands encode.splitBy', async ({mount, chart}) => {
   await mount('components/ECharts.svelte', {
     data: timeseriesGrouped(),
     config: {
@@ -60,10 +60,38 @@ test('echarts expands encode.stack', async ({mount, chart}) => {
       legend: {show: false},
       xAxis: {show: false},
       yAxis: {show: false},
-      series: {type: 'bar', encode: {x: 'month', y: 'sales_usd0k', stack: 'category'}},
+      series: {type: 'bar', stack: 'bar-stack', encode: {x: 'month', y: 'sales_usd0k', splitBy: 'category'}},
     },
   })
   await expect(chart.el).screenshot('echarts-stack')
+})
+
+test('echarts supports splitBy=[group,stack] for grouped+stacked bars', async ({mount, chart}) => {
+  let rows = [
+    {month: '2024-01-01', region: 'NA', channel: 'Direct', revenue: 40},
+    {month: '2024-01-01', region: 'NA', channel: 'Partner', revenue: 25},
+    {month: '2024-01-01', region: 'EU', channel: 'Direct', revenue: 30},
+    {month: '2024-01-01', region: 'EU', channel: 'Partner', revenue: 18},
+    {month: '2024-02-01', region: 'NA', channel: 'Direct', revenue: 38},
+    {month: '2024-02-01', region: 'NA', channel: 'Partner', revenue: 20},
+    {month: '2024-02-01', region: 'EU', channel: 'Direct', revenue: 35},
+    {month: '2024-02-01', region: 'EU', channel: 'Partner', revenue: 22},
+  ]
+  let fields = [
+    {name: 'month', type: scalarType('date'), metadata: {timeGrain: 'month'}},
+    {name: 'region', type: scalarType('string')},
+    {name: 'channel', type: scalarType('string')},
+    {name: 'revenue', type: scalarType('number'), metadata: {units: 'usd'}},
+  ]
+
+  await mount('components/ECharts.svelte', {
+    data: {rows, fields},
+    config: {
+      title: {text: 'Grouped + Stacked (splitBy list)'},
+      series: {type: 'bar', encode: {x: 'month', y: 'revenue', splitBy: ['region', 'channel']}},
+    },
+  })
+  await expect(chart.el).screenshot('echarts-splitby-group-stack')
 })
 
 test('bar chart', async ({mount, chart}) => {
@@ -100,7 +128,7 @@ test('bar chart with just 0,1 has sensible y axis ticks', async ({mount, chart})
 })
 
 test('bar chart grouped + stacked fills missing points and sorts x', async ({mount, chart}) => {
-  await mount('components/BarChart.svelte', {data: sparseGroupedMonthRows(), x: 'month', y: 'value', stack: 'metric', title: 'Grouped Stacked Missing + Sort'})
+  await mount('components/BarChart.svelte', {data: sparseGroupedMonthRows(), x: 'month', y: 'value', splitBy: 'metric', arrange: 'stack', title: 'Grouped Stacked Missing + Sort'})
   await expect(chart.el).screenshot('bar-chart-stacked-missing-sort')
 })
 
@@ -120,8 +148,24 @@ test('horizontal bar chart auto-expands height for many categories', async ({mou
   await expect(chart.el).screenshot('horizontal-bar-chart-auto-height')
 })
 
+test('horizontal bar chart supports multiple x fields', async ({mount, chart}) => {
+  let rows = [
+    {category: 'A', current: 20, previous: 12},
+    {category: 'B', current: 14, previous: 18},
+    {category: 'C', current: 11, previous: 8},
+  ]
+  let fields = [
+    {name: 'category', type: scalarType('string')},
+    {name: 'current', type: scalarType('number'), metadata: {units: 'count'}},
+    {name: 'previous', type: scalarType('number'), metadata: {units: 'count'}},
+  ]
+
+  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'current,previous', y: 'category'})
+  await expect(chart.el).screenshot('horizontal-bar-chart-multi-x')
+})
+
 test('stacked area chart', async ({mount, chart}) => {
-  await mount('components/AreaChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', stack: 'category'})
+  await mount('components/AreaChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', splitBy: 'category', arrange: 'stack'})
   await expect(chart.el).screenshot('area-chart-stacked')
 })
 
@@ -218,7 +262,7 @@ test('pie chart', async ({mount, chart, sharedPage}) => {
 test.skip('can provide a list of colors for different series', async () => {})
 
 test.skip('line chart seriesLabelFmt formats date series names', async ({mount, chart}) => {
-  await mount('components/LineChart.svelte', {data: timeseriesWithDateSeries(), x: 'category', y: 'sales', series: 'quarter'})
+  await mount('components/LineChart.svelte', {data: timeseriesWithDateSeries(), x: 'category', y: 'sales', splitBy: 'quarter'})
   let names = await chart.config(c => (c.series ?? []).map((s: any) => s.name).sort())
   expect(names).toEqual(['2021-01', '2021-04', '2021-07'])
   await expect(chart.el).screenshot('line-chart-series-label-fmt')
@@ -235,7 +279,7 @@ test.skip('numeric year xFmt=yyyy keeps year labels', async ({mount, chart}) => 
 })
 
 test('bar chart grouped labels', async ({mount, chart}) => {
-  await mount('components/BarChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', group: 'category', label: true})
+  await mount('components/BarChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', splitBy: 'category', arrange: 'group', label: true})
   await expect(chart.el).screenshot('bar-chart-grouped-labels')
 })
 
@@ -255,7 +299,7 @@ test('categorical stacked bar charts sort by total value descending', async ({mo
     {name: 'value', type: scalarType('number'), metadata: {units: 'count'}},
   ]
 
-  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'segment', y: 'value', stack: 'metric', title: 'Stacked Category Sort'})
+  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'segment', y: 'value', splitBy: 'metric', arrange: 'stack', title: 'Stacked Category Sort'})
   await expect(chart.el).screenshot('bar-chart-categorical-stacked-sort-total-desc')
 })
 
@@ -276,32 +320,29 @@ test('bar chart explicit sort orders categories by another column', async ({moun
     {name: 'sort_rank', type: scalarType('number')},
   ]
 
-  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'segment', y: 'value', stack: 'metric', sort: 'sort_rank asc', title: 'Explicit Sort'})
+  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'segment', y: 'value', splitBy: 'metric', arrange: 'stack', sort: 'sort_rank asc', title: 'Explicit Sort'})
   await expect(chart.el).screenshot('bar-chart-explicit-sort-column')
 })
 
 test('line chart sorts time axis, and shows gap for missing points', async ({mount, chart}) => {
-  await mount('components/LineChart.svelte', {data: sparseGroupedMonthRows(), x: 'month', y: 'value', series: 'metric', title: 'Line Missing + Sort'})
+  await mount('components/LineChart.svelte', {data: sparseGroupedMonthRows(), x: 'month', y: 'value', splitBy: 'metric', title: 'Line Missing + Sort'})
   await expect(chart.el).screenshot('line-chart-grouped-missing-sort')
 })
 
 test('stacked area uses 0 for missing points', async ({mount, chart}) => {
-  await mount('components/AreaChart.svelte', {data: sparseGroupedMonthRows(), x: 'month', y: 'value', stack: 'metric', title: 'Area Missing + Sort'})
+  await mount('components/AreaChart.svelte', {data: sparseGroupedMonthRows(), x: 'month', y: 'value', splitBy: 'metric', arrange: 'stack', title: 'Area Missing + Sort'})
   await expect(chart.el).screenshot('area-chart-grouped-missing-sort')
 })
 
-test('unstacked area leaves gaps for missing points', async ({mount, chart}) => {
-  await mount('components/AreaChart.svelte', {data: sparseGroupedMonthRows(), x: 'month', y: 'value', group: 'metric', title: 'Area Missing + Gaps'})
-  await expect(chart.el).screenshot('area-chart-grouped-missing-gap')
-})
+test.skip('unstacked area split-by was removed in the arrange API cutover', async () => {})
 
 test('area chart stacked100', async ({mount, chart}) => {
-  await mount('components/AreaChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', stack100: 'category'})
+  await mount('components/AreaChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', splitBy: 'category', arrange: 'stack100'})
   await expect(chart.el).screenshot('area-chart-stacked100')
 })
 
 test('bar chart stacked100', async ({mount, chart}) => {
-  await mount('components/BarChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', stack100: 'category'})
+  await mount('components/BarChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', splitBy: 'category', arrange: 'stack100'})
   await expect(chart.el).screenshot('bar-chart-stacked100')
 })
 


### PR DESCRIPTION
`<BarChart x=month y=value splitBy=category arrange=group />`

instead of 

`<BarChart x=month y=value group=category />`

Accomplishes more or less the same thing. The main thing that is awkward is if you want to split by multiple dimensions, like a grouped and stacked bar chart. This is no longer possible with the BarChart wrapper, but even with ECharts it's a bit hacky:

Prev that'd be `encode: {x: "month", y: "value", group: "dim1", stack: "dim2"}`
Now it's `encode: {x: "month", y: "value", splitBy: "dim1,dim2"}`

and you just have to to know that in this special case the first one maps to grouping, and the second maps to stacking.
