### PR TITLE
better query column disambiguation

### DIFF
--- a/examples/ecomm/index.md
+++ b/examples/ecomm/index.md
@@ -29,11 +29,11 @@ from order_items select products.category, revenue, gross_profit, gross_margin_p
 from order_items select users.state, revenue, units_sold as units order by 2 desc limit 25
 ```
 
-<BarChart data="revenue_by_state" title="Top States by Revenue" x="users_state" y="revenue" swapXY="true" />
+<BarChart data="revenue_by_state" title="Top States by Revenue" x="state" y="revenue" swapXY="true" />
 
 <Row>
-  <BarChart data="revenue_by_category" title="Revenue by Category" x="products_category" y="revenue" swapXY="true" />
-  <PieChart data="revenue_by_category" title="Category Revenue Share" category="products_category" value="revenue" />
+  <BarChart data="revenue_by_category" title="Revenue by Category" x="category" y="revenue" swapXY="true" />
+  <PieChart data="revenue_by_category" title="Category Revenue Share" category="category" value="revenue" />
 </Row>
 
 ```sql top_products

--- a/examples/ecomm/product-explorer.md
+++ b/examples/ecomm/product-explorer.md
@@ -44,6 +44,6 @@ group by 1 order by 2 desc limit 20
 ```
 
 <Row>
-  <BarChart data="category_breakdown" title="Units by Category" x="products_category" y="units" swapXY="true"/>
-  <PieChart data="category_breakdown" title="Revenue Share by Category" category="products_category" value="revenue"/>
+  <BarChart data="category_breakdown" title="Units by Category" x="category" y="units" swapXY="true"/>
+  <PieChart data="category_breakdown" title="Revenue Share by Category" category="category" value="revenue"/>
 </Row>

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -463,9 +463,7 @@ class AnalysisSession implements Analyzer {
         let aliasNode = select.getChild('Alias')
         let expr = this.analyzeExpr(exprNode, scope)
         if (isScalarType(expr.type, 'interval') && expr.interval?.form == 'scaled') this.diag(exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
-        let {name, disambiguatedName} = aliasNode
-          ? {name: txt(aliasNode), disambiguatedName: undefined}
-          : this.inferName(exprNode, scope)
+        let {name, disambiguatedName} = aliasNode ? {name: txt(aliasNode), disambiguatedName: undefined} : this.inferName(exprNode, scope)
         isAgg ||= !!expr.isAgg
         this.addQueryField(query, {
           name,
@@ -515,9 +513,7 @@ class AnalysisSession implements Analyzer {
         // If it's not in there, add it to the select.
         if (!existing) {
           let field = {
-            ...(groupBy.getChild('Alias')
-              ? {name: txt(groupBy.getChild('Alias')), disambiguatedName: undefined}
-              : this.inferName(exprNode, scope)),
+            ...(groupBy.getChild('Alias') ? {name: txt(groupBy.getChild('Alias')), disambiguatedName: undefined} : this.inferName(exprNode, scope)),
             sql: expr.sql,
             type: expr.type,
             metadata: expr.metadata,
@@ -1448,7 +1444,8 @@ class AnalysisSession implements Analyzer {
   }
 
   private insertQueryField(query: Query, field: Query['fields'][number], opts?: {prepend?: boolean}) {
-    opts?.prepend ? query.fields.unshift(field) : query.fields.push(field)
+    if (opts?.prepend) query.fields.unshift(field)
+    else query.fields.push(field)
   }
 
   private renameInferredFields(fields: Query['fields'], taken: Set<string>, extraNames: string[] = []): boolean {

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -327,22 +327,24 @@ class AnalysisSession implements Analyzer {
         if (col.isAgg) continue
         let expr = this.analyzeExpr(col.exprNode, {file, query: scope.query, table, alias, otherTables: scope.otherTables, fanoutPath: scope.fanoutPath})
         if (isScalarType(expr.type, 'interval') && expr.interval?.form == 'scaled') this.diag(col.exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
-        query.fields.push({
+        this.addQueryField(query, {
           name: outName,
           sql: expr.sql,
           type: expr.type,
           metadata: {...expr.metadata, ...col.metadata},
           fanout: expr.fanout,
           definitionLocation: col.location,
+          diagNode: col.exprNode || table.syntaxNode,
         })
       } else {
-        query.fields.push({
+        this.addQueryField(query, {
           name: outName,
           sql: `${alias}.${col.name}`,
           type: col.type,
           metadata: col.metadata,
           fanout: normalizeExprFanout({path: scope.fanoutPath}),
           definitionLocation: col.location,
+          diagNode: table.syntaxNode,
         })
       }
     }
@@ -461,16 +463,20 @@ class AnalysisSession implements Analyzer {
         let aliasNode = select.getChild('Alias')
         let expr = this.analyzeExpr(exprNode, scope)
         if (isScalarType(expr.type, 'interval') && expr.interval?.form == 'scaled') this.diag(exprNode, 'Multiplied intervals are only supported inside date/time arithmetic')
-        let name = aliasNode ? txt(aliasNode) : this.inferName(exprNode, scope)
+        let {name, disambiguatedName} = aliasNode
+          ? {name: txt(aliasNode), disambiguatedName: undefined}
+          : this.inferName(exprNode, scope)
         isAgg ||= !!expr.isAgg
-        query.fields.push({
+        this.addQueryField(query, {
           name,
+          disambiguatedName,
           sql: expr.sql,
           type: expr.type,
           metadata: expr.metadata,
           isAgg: expr.isAgg,
           fanout: expr.fanout,
           definitionLocation: this.locationForNode(aliasNode || exprNode),
+          diagNode: aliasNode || exprNode,
         })
         fanoutExprs.push({node: exprNode, expr})
       }
@@ -503,12 +509,24 @@ class AnalysisSession implements Analyzer {
         // If that expression is already in the selected fields, it's just a reference.
         let expr = this.analyzeExpr(exprNode, scope)
         if (expr.isAgg) this.diag(groupBy, 'Cannot group by aggregate expressions')
-        let name = groupBy.getChild('Alias') ? txt(groupBy.getChild('Alias')) : this.inferName(exprNode, scope)
-        query.groupBy.push(name)
+        let existing = query.fields.find(field => field.sql == expr.sql)
+        if (existing) query.groupBy.push(existing.name)
 
         // If it's not in there, add it to the select.
-        if (!query.fields.find(field => field.name == name)) {
-          query.fields.unshift({name, sql: expr.sql, type: expr.type, metadata: expr.metadata, fanout: expr.fanout, definitionLocation: this.locationForNode(groupBy.getChild('Alias') || exprNode)})
+        if (!existing) {
+          let field = {
+            ...(groupBy.getChild('Alias')
+              ? {name: txt(groupBy.getChild('Alias')), disambiguatedName: undefined}
+              : this.inferName(exprNode, scope)),
+            sql: expr.sql,
+            type: expr.type,
+            metadata: expr.metadata,
+            fanout: expr.fanout,
+            definitionLocation: this.locationForNode(groupBy.getChild('Alias') || exprNode),
+            diagNode: groupBy.getChild('Alias') || exprNode,
+          }
+          this.addQueryField(query, field, {prepend: true})
+          query.groupBy.push(field.name)
         }
         fanoutExprs.push({node: groupBy.getChild('Expression')!, expr})
       }
@@ -1399,13 +1417,63 @@ class AnalysisSession implements Analyzer {
     return table
   }
 
-  private inferName(exprNode: SyntaxNode, scope: Scope): string {
-    if (exprNode.name == 'Ref')
-      return exprNode
-        .getChildren('Identifier')
-        .map(i => txt(i))
-        .join('_')
-    return `col_${scope.query?.fields.length || 0}`
+  private addQueryField(query: Query, field: Query['fields'][number] & {diagNode?: SyntaxNode}, opts?: {prepend?: boolean}) {
+    let conflicts = query.fields.filter(existing => existing.name == field.name)
+    if (conflicts.length == 0) return this.insertQueryField(query, field, opts)
+
+    if (field.disambiguatedName && conflicts.every(existing => existing.disambiguatedName)) {
+      let taken = new Set(query.fields.filter(existing => existing.name != field.name).map(existing => existing.name))
+      if (this.renameInferredFields(conflicts, taken, [field.disambiguatedName])) {
+        field.name = field.disambiguatedName
+        return this.insertQueryField(query, field, opts)
+      }
+    }
+
+    if (field.disambiguatedName) {
+      let taken = new Set(query.fields.filter(existing => existing.name != field.name).map(existing => existing.name))
+      if (!taken.has(field.disambiguatedName)) {
+        field.name = field.disambiguatedName
+        conflicts = query.fields.filter(existing => existing.name == field.name)
+        if (conflicts.length == 0) return this.insertQueryField(query, field, opts)
+      }
+    }
+
+    if (!field.disambiguatedName && conflicts.every(existing => existing.disambiguatedName)) {
+      let taken = new Set(query.fields.filter(existing => existing.name != field.name).map(existing => existing.name))
+      if (this.renameInferredFields(conflicts, taken)) return this.insertQueryField(query, field, opts)
+    }
+
+    if (field.diagNode) this.diag(field.diagNode, `Duplicate output column name "${field.name}"`)
+    this.insertQueryField(query, field, opts)
+  }
+
+  private insertQueryField(query: Query, field: Query['fields'][number], opts?: {prepend?: boolean}) {
+    opts?.prepend ? query.fields.unshift(field) : query.fields.push(field)
+  }
+
+  private renameInferredFields(fields: Query['fields'], taken: Set<string>, extraNames: string[] = []): boolean {
+    let nextNames = new Set<string>()
+    for (let field of fields) {
+      if (!field.disambiguatedName || taken.has(field.disambiguatedName) || nextNames.has(field.disambiguatedName)) return false
+      nextNames.add(field.disambiguatedName)
+    }
+    for (let name of extraNames) {
+      if (taken.has(name) || nextNames.has(name)) return false
+      nextNames.add(name)
+    }
+    fields.forEach(field => {
+      field.name = field.disambiguatedName!
+    })
+    return true
+  }
+
+  private inferName(exprNode: SyntaxNode, scope: Scope): Pick<Query['fields'][number], 'name' | 'disambiguatedName'> {
+    if (exprNode.name == 'Ref') {
+      let names = exprNode.getChildren('Identifier').map(i => txt(i))
+      return {name: names.at(-1)!, disambiguatedName: names.join('_')}
+    }
+    let name = `col_${scope.query?.fields.length || 0}`
+    return {name, disambiguatedName: name}
   }
 
   // TODO: do we still need this?

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -231,7 +231,7 @@ describe('lang', () => {
   })
 
   it('expands dot-join syntax', () => {
-    expect('from orders select id, users.name').toRenderSql('select orders.id as id, users.name as users_name from orders as orders left join users as users on users.id=orders.user_id')
+    expect('from orders select id, users.name').toRenderSql('select orders.id as id, users.name as name from orders as orders left join users as users on users.id=orders.user_id')
   })
 
   it('handles column naming when mutliple columns have the same name', () => {
@@ -242,12 +242,56 @@ describe('lang', () => {
 
   it('supports ad-hoc query joins', () => {
     expect('from orders join users on users.id = orders.user_id select amount, users.name').toRenderSql(
-      'select orders.amount as amount, users.name as users_name from orders as orders inner join users as users on users.id=orders.user_id',
+      'select orders.amount as amount, users.name as name from orders as orders inner join users as users on users.id=orders.user_id',
     )
   })
 
+  it('uses leaf names for unambiguous columns when joining aliased ctes', () => {
+    let q = `
+      with dep as (
+        from orders
+        select user_id as code, avg(amount) as dep_delay
+      ),
+      arr as (
+        from payments
+        select user_id as code, avg(amount) as arr_delay
+      )
+      select d.code, d.dep_delay, a.arr_delay
+      from dep d inner join arr a on d.code = a.code
+    `
+    expect(q).toRenderSql(
+      'with dep as ( select orders.user_id as code, avg(orders.amount) as dep_delay from orders as orders group by 1 order by 2 desc nulls last ), arr as ( select payments.user_id as code, avg(payments.amount) as arr_delay from payments as payments group by 1 order by 2 desc nulls last ) select d.code as code, d.dep_delay as dep_delay, a.arr_delay as arr_delay from dep as d inner join arr as a on d.code=a.code',
+    )
+    let [query] = analyze(q)
+    expect(query.fields.map(field => field.name)).toEqual(['code', 'dep_delay', 'arr_delay'])
+  })
+
+  it('falls back to qualified names when inferred join columns collide', () => {
+    let q = `
+      with dep as (
+        from orders
+        select user_id as code, avg(amount) as dep_delay
+      ),
+      arr as (
+        from payments
+        select user_id as code, avg(amount) as arr_delay
+      )
+      select d.code, a.code
+      from dep d inner join arr a on d.code = a.code
+    `
+    expect(q).toRenderSql(
+      'with dep as ( select orders.user_id as code, avg(orders.amount) as dep_delay from orders as orders group by 1 order by 2 desc nulls last ), arr as ( select payments.user_id as code, avg(payments.amount) as arr_delay from payments as payments group by 1 order by 2 desc nulls last ) select d.code as d_code, a.code as a_code from dep as d inner join arr as a on d.code=a.code',
+    )
+    let [query] = analyze(q)
+    expect(query.fields.map(field => field.name)).toEqual(['d_code', 'a_code'])
+  })
+
+  it('reports diagnostics for duplicate final output names', () => {
+    expect('from orders join users on users.id = orders.user_id select amount as value, users.name as value').toHaveDiagnostic(/Duplicate output column name "value"/i)
+  })
+
   it('supports cross join without an ON clause', () => {
-    expect('from orders cross join users select amount, users.name').toRenderSql('select orders.amount as amount, users.name as users_name from orders as orders cross join users as users')
+    expect('from orders cross join users select amount, users.name').toRenderSql('select orders.amount as amount, users.name as name from orders as orders cross join users as users')
   })
 
   it('rejects cross join with an ON clause', () => {
@@ -326,11 +370,11 @@ describe('lang', () => {
     updateFile('table user_totals as (from orders select user_id, sum(amount) as total)', 'user_totals.gsql')
 
     expect('from users join user_totals on user_totals.user_id = users.id select name, user_totals.total').toRenderSql(
-      'with user_totals as ( select orders.user_id as user_id, sum(orders.amount) as total from orders as orders group by 1 order by 2 desc nulls last ) select users.name as name, user_totals.total as user_totals_total from users as users inner join user_totals as user_totals on user_totals.user_id=users.id',
+      'with user_totals as ( select orders.user_id as user_id, sum(orders.amount) as total from orders as orders group by 1 order by 2 desc nulls last ) select users.name as name, user_totals.total as total from users as users inner join user_totals as user_totals on user_totals.user_id=users.id',
     )
 
     expect('with active_users as (from users select id, name) from orders join active_users on active_users.id = orders.user_id select active_users.name').toRenderSql(
-      'with active_users as ( select users.id as id, users.name as name from users as users ) select active_users.name as active_users_name from orders as orders inner join active_users as active_users on active_users.id=orders.user_id',
+      'with active_users as ( select users.id as id, users.name as name from users as users ) select active_users.name as name from orders as orders inner join active_users as active_users on active_users.id=orders.user_id',
     )
   })
 
@@ -558,7 +602,7 @@ describe('lang', () => {
     )
 
     expect('from order_items select id, users.name').toRenderSql(
-      'select order_items.id as id, users.name as users_name from order_items as order_items left join users as users on users.id=order_items.user_id',
+      'select order_items.id as id, users.name as name from order_items as order_items left join users as users on users.id=order_items.user_id',
     )
   })
 
@@ -610,7 +654,7 @@ describe('lang', () => {
     )
 
     expect('from users select name, order_stats.total_spent order by name').toRenderSql(
-      'with order_stats as ( select orders.user_id as user_id, sum(orders.amount) as total_spent from orders as orders group by 1 order by 2 desc nulls last ) select users.name as name, order_stats.total_spent as order_stats_total_spent from users as users left join order_stats as order_stats on order_stats.user_id=users.id order by 1 asc nulls last',
+      'with order_stats as ( select orders.user_id as user_id, sum(orders.amount) as total_spent from orders as orders group by 1 order by 2 desc nulls last ) select users.name as name, order_stats.total_spent as total_spent from users as users left join order_stats as order_stats on order_stats.user_id=users.id order by 1 asc nulls last',
     )
 
     await expect('from users select name, order_stats.total_spent order by name').toReturnRows(['Alice', 60], ['Bob', 40])
@@ -1278,7 +1322,7 @@ describe('lang', () => {
   })
 
   it('allows join expressions to refer to the alias', () => {
-    expect('table t (oid int, join one users as usr on usr.id = oid); from t select usr.name').toRenderSql('select usr.name as usr_name from t as t left join users as usr on usr.id=t.oid')
+    expect('table t (oid int, join one users as usr on usr.id = oid); from t select usr.name').toRenderSql('select usr.name as name from t as t left join users as usr on usr.id=t.oid')
   })
 
   it('allows measures to refer to themselves', () => {

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -211,6 +211,7 @@ export interface Expr {
 // A field in a query's SELECT clause
 export interface QueryField extends Expr {
   name: string // output column name
+  disambiguatedName?: string // alternate inferred name used when output names would otherwise collide
   definitionLocation?: Location // where this field is defined when materialized into a view
 }
 


### PR DESCRIPTION
This PR updates our query rendering to pick "leaf" column names when possible, and only qualify when necessary to disambiguate. Fixes #273.