### PR TITLE
suppress implicit order by in set operations

### DIFF
--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -375,7 +375,7 @@ class AnalysisSession implements Analyzer {
     return this.analyzeSimpleQuery(queryNode.getChild('SimpleQuery')!, queryNode, scope, ctes)
   }
 
-  private analyzeSimpleQuery(simpleNode: SyntaxNode, queryNode: SyntaxNode, parentScope: Scope, ctes: Map<string, CteTable>): Query | void {
+  private analyzeSimpleQuery(simpleNode: SyntaxNode, queryNode: SyntaxNode, parentScope: Scope, ctes: Map<string, CteTable>, opts: {suppressImplicitOrderBy?: boolean} = {}): Query | void {
     let query: Query = {sql: '', fields: [], joins: [], filters: [], groupBy: [], orderBy: []}
     let scope: Scope = {...parentScope, query}
     let isAgg = false
@@ -531,7 +531,7 @@ class AnalysisSession implements Analyzer {
     }
 
     // Default ORDER BY for aggregate queries
-    if (orderBy.length == 0 && query.groupBy.length > 0) {
+    if (!opts.suppressImplicitOrderBy && orderBy.length == 0 && query.groupBy.length > 0) {
       let firstAggIdx = query.fields.findIndex(field => field.isAgg)
       if (firstAggIdx >= 0) orderBy.push({idx: firstAggIdx + 1, desc: true})
       else orderBy.push({idx: 1, desc: false}) // SELECT DISTINCT
@@ -549,7 +549,10 @@ class AnalysisSession implements Analyzer {
 
   private analyzeSetQuery(queryNode: SyntaxNode, scope: Scope, ctes: Map<string, CteTable>): Query | void {
     let branches = [
-      {query: this.analyzeSimpleQuery(queryNode.getChild('SimpleQuery')!, queryNode.getChild('SimpleQuery')!, scope, new Map()), parenthesized: false},
+      {
+        query: this.analyzeSimpleQuery(queryNode.getChild('SimpleQuery')!, queryNode.getChild('SimpleQuery')!, scope, new Map(), {suppressImplicitOrderBy: true}),
+        parenthesized: false,
+      },
       ...queryNode.getChildren('SetOperand').map(node => this.analyzeSetOperand(node, scope)),
     ]
 
@@ -594,7 +597,10 @@ class AnalysisSession implements Analyzer {
   private analyzeSetOperand(node: SyntaxNode, scope: Scope) {
     let subqueryNode = node.getChild('SubqueryExpression')
     if (subqueryNode) return {query: this.analyzeQuery(subqueryNode.getChild('QueryExpression')!, scope.otherTables), parenthesized: true}
-    return {query: this.analyzeSimpleQuery(node.getChild('SimpleQuery')!, node.getChild('SimpleQuery')!, scope, new Map()), parenthesized: false}
+    return {
+      query: this.analyzeSimpleQuery(node.getChild('SimpleQuery')!, node.getChild('SimpleQuery')!, scope, new Map(), {suppressImplicitOrderBy: true}),
+      parenthesized: false,
+    }
   }
 
   private analyzeOrderAndLimit(queryNode: SyntaxNode, query: Query) {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -117,6 +117,32 @@ describe('lang', () => {
     await expect('from users select id union all from orders select user_id as id').toReturnRows([1], [2], [1], [1], [2])
   })
 
+  it('suppresses implicit branch order by for aggregate set operations', () => {
+    expect(`
+      from users select name as label, sum(payments.amount) as amt
+      union all
+      from users select email as label, sum(payments.amount) as amt
+    `).toRenderSql(
+      'SELECT users.name as label, sum(payments.amount) as amt FROM users as users LEFT JOIN payments as payments ON payments.user_id=users.id GROUP BY 1 UNION ALL SELECT users.email as label, sum(payments.amount) as amt FROM users as users LEFT JOIN payments as payments ON payments.user_id=users.id GROUP BY 1',
+    )
+  })
+
+  it('keeps implicit order by for standalone aggregate queries', () => {
+    expect('from users select name as label, sum(payments.amount) as amt').toRenderSql(
+      'SELECT users.name as label, sum(payments.amount) as amt FROM users as users LEFT JOIN payments as payments ON payments.user_id=users.id GROUP BY 1 ORDER BY 2 desc NULLS LAST',
+    )
+  })
+
+  it('preserves implicit order by inside parenthesized set operands', () => {
+    expect(`
+      from users select name as label, sum(payments.amount) as amt
+      union all
+      (from users select email as label, sum(payments.amount) as amt)
+    `).toRenderSql(
+      'SELECT users.name as label, sum(payments.amount) as amt FROM users as users LEFT JOIN payments as payments ON payments.user_id=users.id GROUP BY 1 UNION ALL ( SELECT users.email as label, sum(payments.amount) as amt FROM users as users LEFT JOIN payments as payments ON payments.user_id=users.id GROUP BY 1 ORDER BY 2 desc NULLS LAST )',
+    )
+  })
+
   it('supports parenthesized set-operation operands in subqueries and ctes', () => {
     expect('from (select 1 as id union all select 2 as id) nums select id').toRenderSql('SELECT nums.id as id FROM ( SELECT 1 as id UNION ALL SELECT 2 as id ) as nums')
 
@@ -125,6 +151,15 @@ describe('lang', () => {
 
   it('applies outer order by and limit to the full set operation', () => {
     expect('select 2 as id union select 1 as id order by id limit 1').toRenderSql('SELECT 2 as id UNION SELECT 1 as id ORDER BY 1 asc NULLS LAST LIMIT 1')
+  })
+
+  it('executes aggregate set operations with an outer order by', async () => {
+    await expect(`
+      from users select 'name:' || name as label, sum(payments.amount) as amt
+      union all
+      from users select 'email:' || email as label, sum(payments.amount) as amt
+      order by label
+    `).toReturnRows(['email:alice@example.com', 100], ['email:bob@example.com', 50], ['name:Alice', 100], ['name:Bob', 50])
   })
 
   it('requires matching column counts across set-operation branches', () => {


### PR DESCRIPTION
This PR updates GSQL to suppress the implicit `order by` addition in set operations, as it is not syntactically valid (and the set operations don't preserve ordering). Fixes #272.