### PR TITLE
proper tooltip formatting for scatter plots

### DIFF
--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -32,7 +32,7 @@ export function enrich(config: EChartsConfig, rows: Record<string, any>[], field
   expandSeriesTransforms(normalized, rows, baseDatasetId)
 
   // stylistic rules to provide great defaults
-  lineSeriesMarkerVisibility(normalized, rows)
+  lineSeriesMarkerVisibility(normalized, rows, fields)
   horizontalBarGuard(normalized, fields)
   computeTitleLegendAndGridPadding(normalized)
   applyLegendSelection(normalized)
@@ -213,7 +213,7 @@ function inferAxisTypesFromEncodedFields(config: NormalConfig, fields: Field[]) 
     if (!axis) continue
     let encodedFields = config.series
       .filter(entry => Number(entry?.xAxisIndex ?? 0) === axisIndex)
-      .map(entry => getSeriesXField(entry))
+      .map(entry => getSeriesXField(entry, fields))
       .filter(Boolean) as string[]
 
     axis.field ||= fields.find(field => field.name === encodedFields[0])
@@ -224,7 +224,7 @@ function inferAxisTypesFromEncodedFields(config: NormalConfig, fields: Field[]) 
     if (!axis) continue
     let encodedFields = config.series
       .filter(entry => Number(entry?.yAxisIndex ?? 0) === axisIndex)
-      .map(entry => getSeriesValueFieldName(entry))
+      .map(entry => getSeriesValueFieldName(entry, fields))
       .filter(Boolean) as string[]
 
     axis.field ||= fields.find(field => field.name === encodedFields[0])
@@ -274,7 +274,7 @@ function ordinalFormatting(config: NormalConfig) {
 // - Respect explicit `showSymbol` from users.
 // - Category/time axes: show markers for small series (< 30 points).
 // - Value axes: hide markers by default.
-function lineSeriesMarkerVisibility(config: NormalConfig, rows: Record<string, any>[]) {
+function lineSeriesMarkerVisibility(config: NormalConfig, rows: Record<string, any>[], fields: Field[]) {
   for (let series of config.series) {
     if (series?.type !== 'line' || series.showSymbol != null) continue
 
@@ -290,7 +290,7 @@ function lineSeriesMarkerVisibility(config: NormalConfig, rows: Record<string, a
       continue
     }
 
-    let xField = getSeriesXField(series)
+    let xField = getSeriesXField(series, fields)
     if (!xField) {
       series.showSymbol = false
       continue
@@ -337,16 +337,13 @@ function valueFormatting(config: NormalConfig, fields: Field[]) {
   let valueAxes = [...config.xAxis, ...config.yAxis].filter(axis => axis?.type === 'value')
   for (let axis of valueAxes) {
     if (axis.axisLabel?.formatter != null) continue
-    axis.axisLabel = {...axis.axisLabel, formatter: makeValueFormatter(axis.field)}
+    axis.axisLabel = {...axis.axisLabel, formatter: makeValueFormatter(axis.field ? [axis.field] : [])}
   }
 
   for (let series of config.series) {
     series.tooltip ||= {}
-    let tooltip = series.tooltip as Record<string, any>
-    if (tooltip.formatter != null || tooltip.valueFormatter != null) continue
-
-    let field = getSeriesValueField(series, fields)
-    tooltip.valueFormatter = makeValueFormatter(field)
+    if (series.tooltip?.formatter || series.tooltip.valueFormatter) continue
+    series.tooltip.valueFormatter = makeValueFormatter(getSeriesValueFields(series, fields))
   }
 }
 
@@ -618,22 +615,31 @@ function inferAxisTypeFromFields(fields: Field[], fieldNames: string[]) {
   return 'category'
 }
 
-function getSeriesXField(series?: SeriesWithGroupingHint) {
-  return getEncodeField(series?.encode?.x)
+function getSeriesXField(series: SeriesWithGroupingHint | undefined, fields?: Field[]) {
+  return getEncodeField(series, fields || [], 'x')?.name ?? getEncodeFieldName(series, 'x')
 }
 
-function getSeriesValueFieldName(series?: SeriesWithGroupingHint) {
-  return getEncodeField(series?.encode?.y) ?? getEncodeField(series?.encode?.value)
+function getSeriesValueFieldName(series: SeriesWithGroupingHint | undefined, fields?: Field[]) {
+  return getEncodeField(series, fields || [], 'y')?.name ?? getEncodeField(series, fields || [], 'value')?.name ?? getEncodeFieldName(series, 'y') ?? getEncodeFieldName(series, 'value')
 }
 
-function getSeriesValueField(series: SeriesWithGroupingHint, fields: Field[]) {
-  let fieldName = getSeriesValueFieldName(series)
-  if (!fieldName) return undefined
-  return fields.find(field => field.name === fieldName)
+function getSeriesValueFields(series: SeriesWithGroupingHint, fields: Field[]) {
+  switch (series.type) {
+    case 'scatter':
+    case 'effectScatter':
+      return [getEncodeField(series, fields, 'x'), getEncodeField(series, fields, 'y')].filter(Boolean) as Field[]
+    case 'bar': {
+      let xField = getEncodeField(series, fields, 'x')
+      let yField = getEncodeField(series, fields, 'y')
+      return xField?.type == 'number' ? [xField] : ([yField].filter(Boolean) as Field[])
+    }
+    default:
+      return [getEncodeField(series, fields, 'y')].filter(Boolean) as Field[]
+  }
 }
 
 function getSeriesCategoryFieldForHorizontal(series?: SeriesWithGroupingHint) {
-  return getEncodeField(series?.encode?.y)
+  return getEncodeFieldName(series, 'y')
 }
 
 function getSplitByFields(series?: SeriesWithGroupingHint) {
@@ -646,10 +652,21 @@ function getSplitByFields(series?: SeriesWithGroupingHint) {
     .filter(Boolean)
 }
 
-function getEncodeField(value: unknown): string | undefined {
-  if (typeof value === 'string') return value
-  if (Array.isArray(value)) return value.find(entry => typeof entry === 'string')
-  return undefined
+function getEncodeFields(value: unknown): string[] {
+  if (typeof value === 'string') return [value]
+  if (!Array.isArray(value)) return []
+  return value.filter(entry => typeof entry === 'string') as string[]
+}
+
+function getEncodeFieldName(series: SeriesWithGroupingHint | undefined, encodeProp: string) {
+  let encode = series?.encode as Record<string, unknown> | undefined
+  return getEncodeFields(encode?.[encodeProp])[0]
+}
+
+function getEncodeField(series: SeriesWithGroupingHint | undefined, fields: Field[], encodeProp: string): Field | undefined {
+  let name = getEncodeFieldName(series, encodeProp)
+  if (!name) return undefined
+  return fields.find(field => field.name === name)
 }
 
 function shouldBindSeriesToDataset(series: SeriesWithGroupingHint) {

--- a/ui/component-utilities/format.ts
+++ b/ui/component-utilities/format.ts
@@ -21,39 +21,46 @@ export function formatTitle(column: string) {
   })
 }
 
-// Creates a formatter function that takes a numeric value and type/metadata info about a field to determine how to format it.
-export function makeValueFormatter(field?: Field) {
+// ECharts valueFormatter will take different arguments depending on the chart type.
+// For bar/line/area it's just a number
+// for scatter, it's [x,y], for candlestick [open, close, low, high], etc
+export function makeValueFormatter(fields: Field[] = []) {
+  return (value: unknown) => {
+    if (Array.isArray(value)) return value.map((entry, index) => formatSingleValue(entry, fields[index] || fields[0])).join(', ')
+    return formatSingleValue(value, fields[0])
+  }
+}
+
+// Formats one numeric value with field metadata (units, ratio/pct, compact notation).
+export function formatSingleValue(value: any, field?: Field) {
+  let amount = Number(value)
+  if (!Number.isFinite(amount)) return String(value ?? '')
+
+  if (field?.metadata?.ratio) return `${percent.format(amount * 100)}%`
+  if (field?.metadata?.pct) return `${percent.format(amount)}%`
+
   let unit = field?.metadata?.units?.toLowerCase() as keyof typeof currencySymbols | undefined
   let currencyUnit = unit != null && unit in currencySymbols ? unit : undefined
-
-  return (value: unknown) => {
-    let amount = Number(value)
-    if (!Number.isFinite(amount)) return String(value ?? '')
-
-    if (field?.metadata?.ratio) return `${percent.format(amount * 100)}%`
-    if (field?.metadata?.pct) return `${percent.format(amount)}%`
-
-    if (currencyUnit) {
-      let sign = amount < 0 ? '-' : ''
-      let formatted = currencyCompact.format(Math.abs(amount)).replace('K', 'k').replace('M', 'm').replace('B', 'b')
-      return `${sign}${currencySymbols[currencyUnit]}${formatted}`
-    }
-
-    if (amount === 0) return '0'
+  if (currencyUnit) {
     let sign = amount < 0 ? '-' : ''
-    let absolute = Math.abs(amount)
-
-    if (absolute >= 1e12) return `${sign}${compactValue(absolute / 1e12)}T`
-    if (absolute >= 1e9) return `${sign}${compactValue(absolute / 1e9)}B`
-    if (absolute >= 1e6) return `${sign}${compactValue(absolute / 1e6)}M`
-    if (absolute >= 1e3) return `${sign}${compactValue(absolute / 1e3)}k`
-    if (absolute >= 1) return `${sign}${compactValue(absolute)}`
-    if (absolute >= 1e-3) return `${sign}${compactValue(absolute)}`
-    if (absolute >= 1e-6) return `${sign}${compactValue(absolute * 1e3)}m`
-    if (absolute >= 1e-9) return `${sign}${compactValue(absolute * 1e6)}u`
-    if (absolute >= 1e-12) return `${sign}${compactValue(absolute * 1e9)}n`
-    return `${sign}${compactValue(absolute)}`
+    let formatted = currencyCompact.format(Math.abs(amount)).replace('K', 'k').replace('M', 'm').replace('B', 'b')
+    return `${sign}${currencySymbols[currencyUnit]}${formatted}`
   }
+
+  if (amount === 0) return '0'
+  let sign = amount < 0 ? '-' : ''
+  let absolute = Math.abs(amount)
+
+  if (absolute >= 1e12) return `${sign}${compactValue(absolute / 1e12)}T`
+  if (absolute >= 1e9) return `${sign}${compactValue(absolute / 1e9)}B`
+  if (absolute >= 1e6) return `${sign}${compactValue(absolute / 1e6)}M`
+  if (absolute >= 1e3) return `${sign}${compactValue(absolute / 1e3)}k`
+  if (absolute >= 1) return `${sign}${compactValue(absolute)}`
+  if (absolute >= 1e-3) return `${sign}${compactValue(absolute)}`
+  if (absolute >= 1e-6) return `${sign}${compactValue(absolute * 1e3)}m`
+  if (absolute >= 1e-9) return `${sign}${compactValue(absolute * 1e6)}u`
+  if (absolute >= 1e-12) return `${sign}${compactValue(absolute * 1e9)}n`
+  return `${sign}${compactValue(absolute)}`
 }
 
 // Creates a formatter function that renders date/timestamp values based on field metadata.timeGrain.
@@ -61,7 +68,11 @@ export function makeTimeFormatter(field?: Field) {
   let timeGrain = String(field?.metadata?.timeGrain || '').toLowerCase()
 
   return (input: unknown) => {
-    let value = extractFormatterValue(input)
+    let value = input
+    if (value && typeof value === 'object' && 'value' in (value as Record<string, unknown>)) {
+      value = (value as Record<string, unknown>).value
+    }
+
     let date = value instanceof Date ? value : new Date(Number(value))
     if (!Number.isFinite(date.getTime())) return String(value ?? '')
 
@@ -89,7 +100,7 @@ export function formatFromField(field: Field | undefined, value: unknown) {
   if (value === null || value === undefined) return '-'
 
   let type = String(field?.type || '').toLowerCase()
-  if (type === 'number') return makeValueFormatter(field)(value)
+  if (type === 'number') return formatSingleValue(value, field)
   if (type === 'date' || type === 'timestamp') return makeTimeFormatter(field)(value)
   return String(value)
 }

--- a/ui/tests/snapshots/viz.test.ts/scatter-tooltip-high-precision.png
+++ b/ui/tests/snapshots/viz.test.ts/scatter-tooltip-high-precision.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d41315b78811f94cd21c854c472592cd5e85109ee1165171069d4c708cde867a
+size 7254

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -338,6 +338,42 @@ test('line chart hides markers at 30 categorical points', async ({mount, chart})
   await expect(chart.el).screenshot('line-chart-categorical-markers-over-threshold')
 })
 
+test('scatter tooltip preserves high precision values on hover', async ({mount, chart, sharedPage}) => {
+  let rows = [
+    {point: 'A', x: 0.123456789123, y: 98.765432198765},
+    {point: 'B', x: 0.333333333333, y: 12.987654321987},
+    {point: 'C', x: 0.987654321987, y: 45.123456789123},
+  ]
+  let fields = [
+    {name: 'point', type: scalarType('string')},
+    {name: 'x', type: scalarType('number')},
+    {name: 'y', type: scalarType('number')},
+  ]
+
+  await mount('components/ECharts.svelte', {
+    data: {rows, fields},
+    config: {
+      tooltip: {trigger: 'item', position: [24, 24]},
+      xAxis: {type: 'value'},
+      yAxis: {type: 'value'},
+      series: [{type: 'scatter', symbolSize: 14, encode: {x: 'x', y: 'y', tooltip: ['point', 'x', 'y']}}],
+    },
+  })
+
+  await sharedPage.evaluate(async () => {
+    await window.$GRAPHENE?.waitForLoad?.()
+    await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))
+
+    let domNode = document.querySelector('#component-test .echarts') as HTMLElement | null
+    let chart = domNode ? window.$GRAPHENE.getChart(domNode) : null
+    chart?.dispatchAction({type: 'showTip', seriesIndex: 0, dataIndex: 1})
+
+    await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))
+  })
+
+  await expect(chart.el).screenshot('scatter-tooltip-high-precision')
+})
+
 test('pie chart', async ({mount, chart, sharedPage}) => {
   await mount('components/PieChart.svelte', {data: singleDim(), category: 'category', value: 'value'})
   await expect(chart.el).screenshot('pie-chart')


### PR DESCRIPTION
and other, non-scalar-value plots like candlestick. valueFormatter is usually given a number, but sometimes an array of values, all of which need to be formatted.