### PR TITLE
non-big <Value/> component

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -76,6 +76,7 @@ Attributes like `x`, `y`, `y2`, and `splitBy` are the names of columns within th
 - BigValue: data, value, title, fmt, comparison, comparisonFmt, comparisonTitle, downIsGood, sparkline, sparklineType, sparklineColor
 - Table: data, rows, title, subtitle, groupBy, groupType, subtotals, totalRow, search, sort, link, rowShading, rowNumbers, compact, headerColor
   - Column (sub-component of Table): id, title, fmt, align, wrap, contentType, totalAgg, redNegatives
+- Value: data, column, row
 
 ## ECharts
 To further customize the look and feel of a chart, use the ECharts component to provide an echarts config.

--- a/ui/components/QueryLoad.svelte
+++ b/ui/components/QueryLoad.svelte
@@ -9,13 +9,15 @@
     data: string | QueryResult
     height?: number
     fields?: Record<string, string | string[]>
+    inline?: boolean
     children?: Snippet<[QueryResult]>
   }
 
-  let {data, height = 200, fields = {}, children}: Props = $props()
+  let {data, height = 200, fields = {}, inline = false, children}: Props = $props()
 
   let error: GrapheneError | null = $state(null)
   let loaded: QueryResult | null = $state(null)
+  let tooltipId = `query-error-${Math.random().toString(36).slice(2)}`
 
   let handleResults = (result: QueryResult) => {
     error = result?.error || null
@@ -24,6 +26,7 @@
 
   onMount(() => {
     if (typeof data !== 'string') {
+      error = data.error || null
       loaded = {rows: data.rows ?? [], fields: data.fields ?? [], error: data.error, sql: data.sql}
     } else {
       let usedFields = Object.fromEntries(Object.entries(fields).filter(e => !!e[1]))
@@ -37,9 +40,18 @@
 </script>
 
 {#if error}
-  <div style="min-height:{height}px;width:100%;display:grid;align-content:center;padding:8px;box-sizing:border-box">
-    <ErrorDisplay {error} />
-  </div>
+  {#if inline}
+    <span class="inline-error">
+      <button class="inline-error__icon" type="button" aria-label="Query failed" aria-describedby={tooltipId}>!</button>
+      <span class="inline-error__tooltip" id={tooltipId} role="tooltip">
+        <ErrorDisplay {error} />
+      </span>
+    </span>
+  {:else}
+    <div style="min-height:{height}px;width:100%;display:grid;align-content:center;padding:8px;box-sizing:border-box">
+      <ErrorDisplay {error} />
+    </div>
+  {/if}
 {:else if !loaded}
   <Skeleton />
 {:else if loaded.rows.length == 0}
@@ -59,5 +71,46 @@
     color: rgba(75, 85, 99, 0.9);
     text-align: center;
     background: rgba(243, 244, 246, 0.6);
+  }
+
+  .inline-error {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+  }
+
+  .inline-error__icon {
+    width: 1.05em;
+    height: 1.05em;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #ef4444;
+    border-radius: 999px;
+    background: #fef2f2;
+    color: #b91c1c;
+    cursor: help;
+    font: inherit;
+    font-size: 0.75em;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .inline-error__tooltip {
+    display: none;
+    position: absolute;
+    z-index: 1000;
+    top: calc(100% + 8px);
+    left: 0;
+    width: min(420px, 80vw);
+    text-align: left;
+    filter: drop-shadow(0 8px 18px rgba(15, 23, 42, 0.18));
+  }
+
+  .inline-error:hover .inline-error__tooltip,
+  .inline-error:focus-within .inline-error__tooltip {
+    display: block;
   }
 </style>

--- a/ui/components/QueryLoad.svelte
+++ b/ui/components/QueryLoad.svelte
@@ -87,10 +87,10 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid #ef4444;
+    border: 1px solid var(--graphene-error-border, #ef4444);
     border-radius: 999px;
-    background: #fef2f2;
-    color: #b91c1c;
+    background: var(--graphene-error-background, #fef2f2);
+    color: var(--graphene-error-content-strong, #b91c1c);
     cursor: help;
     font: inherit;
     font-size: 0.75em;

--- a/ui/components/Value.svelte
+++ b/ui/components/Value.svelte
@@ -22,4 +22,4 @@
   <span>{formatValue(loaded?.rows?.[row]?.[column], loaded)}</span>
 {/snippet}
 
-<QueryLoad {data} fields={{column}} children={valueContent} />
+<QueryLoad {data} fields={{column}} inline children={valueContent} />

--- a/ui/components/Value.svelte
+++ b/ui/components/Value.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+    import QueryLoad from './QueryLoad.svelte'
+    import {formatFromField} from '../component-utilities/format.ts'
+    import type {QueryResult} from '../component-utilities/types.ts'
+
+    interface Props {
+      data: string | QueryResult
+      column: string
+      row?: number
+    }
+
+    let {data, column, row = 0}: Props = $props()
+
+    function formatValue(input: any, loaded: QueryResult) {
+      if (input === null || input === undefined) return '—'
+      let field = loaded?.fields?.find((entry: any) => entry?.name === column)
+      return formatFromField(field as any, input)
+    }
+</script>
+
+{#snippet valueContent(loaded: QueryResult)}
+  <span>{formatValue(loaded?.rows?.[row]?.[column], loaded)}</span>
+{/snippet}
+
+<QueryLoad {data} fields={{column}} children={valueContent} />

--- a/ui/internal/ErrorDisplay.svelte
+++ b/ui/internal/ErrorDisplay.svelte
@@ -40,9 +40,9 @@
   .g-error {
     padding: 16px 20px;
     border-radius: 6px;
-    border-left: 3px solid #ef4444;
-    background: #fef2f2;
-    color: #991b1b;
+    border-left: 3px solid var(--graphene-error-border, #ef4444);
+    background: var(--graphene-error-background, #fef2f2);
+    color: var(--graphene-error-content, #991b1b);
   }
   .g-error__message {
     margin: 0;
@@ -55,6 +55,6 @@
     line-height: 1.6;
     white-space: pre-wrap;
     word-break: break-word;
-    color: #b91c1c;
+    color: var(--graphene-error-content-strong, #b91c1c);
   }
 </style>

--- a/ui/tests/snapshots/value.test.ts/currency-formatting.png
+++ b/ui/tests/snapshots/value.test.ts/currency-formatting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff7b216616f401dde2ee145a5bde9d7b348c4736486a61c72209a410e2eee6e8
+size 1221

--- a/ui/tests/snapshots/value.test.ts/inline-error-tooltip.png
+++ b/ui/tests/snapshots/value.test.ts/inline-error-tooltip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d08b34d6a789ec5b6977e4c3fb6edaad9e50e41b6f48d1705133d331febb805e
+size 14072

--- a/ui/tests/value.test.ts
+++ b/ui/tests/value.test.ts
@@ -6,9 +6,10 @@ describe('<Value/>', () => {
     await sharedPage.setViewportSize({width: 1280, height: 720})
   })
 
-  test('currency formatting', async ({mount, sharedPage}) => {
+  test('currency formatting', async ({mount, sharedPage, chart}) => {
     await mount('components/Value.svelte', {data: singleDim(), column: 'value'})
     await expect(sharedPage.getByText('$611.1k')).toBeVisible()
+    await expect(chart.el).screenshot('currency-formatting')
   })
 
   test('percent formatting', async ({mount, sharedPage}) => {

--- a/ui/tests/value.test.ts
+++ b/ui/tests/value.test.ts
@@ -18,8 +18,16 @@ describe('<Value/>', () => {
   })
 
   test('null renders em dash', async ({mount, sharedPage}) => {
-    await mount('components/BigValue.svelte', {data: nullValueData(), column: 'value'})
+    await mount('components/Value.svelte', {data: nullValueData(), column: 'value'})
     await expect(sharedPage.getByText('—')).toBeVisible()
+  })
+
+  test('query error renders inline tooltip', async ({mount, sharedPage}) => {
+    await mount('components/Value.svelte', {data: errorData(), column: 'value'})
+    let errorIcon = sharedPage.getByRole('button', {name: 'Query failed'})
+    await errorIcon.hover()
+    await expect(sharedPage.getByText('Could not resolve column "value"')).toBeVisible()
+    await expect(sharedPage).screenshot('inline-error-tooltip')
   })
 
   function percentData() {
@@ -32,5 +40,10 @@ describe('<Value/>', () => {
     let rows = [{value: null}] as any
     let fields = [{name: 'value', type: 'number'}] as any
     return {rows, fields}
+  }
+
+  function errorData() {
+    let error = {message: 'Could not resolve column "value"', queryId: 'broken_value'} as any
+    return {rows: [], fields: [], error}
   }
 })

--- a/ui/tests/value.test.ts
+++ b/ui/tests/value.test.ts
@@ -1,0 +1,35 @@
+import {expect, test} from './fixtures.ts'
+import {singleDim} from './testData.ts'
+
+describe('<Value/>', () => {
+  test.beforeEach(async ({sharedPage}) => {
+    await sharedPage.setViewportSize({width: 1280, height: 720})
+  })
+
+  test('currency formatting', async ({mount, sharedPage}) => {
+    await mount('components/Value.svelte', {data: singleDim(), column: 'value'})
+    await expect(sharedPage.getByText('$611.1k')).toBeVisible()
+  })
+
+  test('percent formatting', async ({mount, sharedPage}) => {
+    await mount('components/Value.svelte', {data: percentData(), column: 'ratio'})
+    await expect(sharedPage.getByText('31%')).toBeVisible()
+  })
+
+  test('null renders em dash', async ({mount, sharedPage}) => {
+    await mount('components/BigValue.svelte', {data: nullValueData(), column: 'value'})
+    await expect(sharedPage.getByText('—')).toBeVisible()
+  })
+
+  function percentData() {
+    let rows = [{ratio: 0.314}] as any
+    let fields = [{name: 'ratio', type: 'number', metadata: {ratio: true}}] as any
+    return {rows, fields}
+  }
+
+  function nullValueData() {
+    let rows = [{value: null}] as any
+    let fields = [{name: 'value', type: 'number'}] as any
+    return {rows, fields}
+  }
+})

--- a/ui/web.js
+++ b/ui/web.js
@@ -31,6 +31,7 @@ import TableRow from './components/TableRow.svelte'
 import TableSubtotalRow from './components/TableSubtotalRow.svelte'
 import TableTotalRow from './components/TableTotalRow.svelte'
 import TextInput from './components/TextInput.svelte'
+import Value from './components/Value.svelte'
 import ErrorChart from './internal/ErrorDisplay.svelte'
 import LocalApp from './internal/LocalApp.svelte'
 
@@ -100,6 +101,7 @@ window.$GRAPHENE.components = {
   TableSubtotalRow,
   TableTotalRow,
   TextInput,
+  Value,
 }
 
 window.$GRAPHENE.svelte = {mount, unmount}


### PR DESCRIPTION
I noticed this in the backlog and thought I'd give it a shot since I haven't touched the UI components much. This PR adds a simple/unstyled `<Value/>` component which can be used to render query data inline, to avoid hardcoding results in prose. Fixes #32 