### PR TITLE
Ignore agents.md

### DIFF
--- a/lang/config.ts
+++ b/lang/config.ts
@@ -67,7 +67,7 @@ export function normalizeConfig(input: ConfigInput, defaultRoot = process.cwd())
     dialect,
     root: cfg.root || defaultRoot,
     port: cfg.port || Number(process.env.GRAPHENE_PORT) || 4000,
-    ignoredFiles: cfg.ignoredFiles || ['agents.md', 'claude.md'],
+    ignoredFiles: cfg.ignoredFiles || ['**/agents.md', '**/claude.md'],
     envFile,
   } as Config
 }

--- a/lang/core.ts
+++ b/lang/core.ts
@@ -15,7 +15,7 @@ export type {AnalysisResult, AnalysisWorkspace, FileInfo, Query, Table, Workspac
 
 export async function loadWorkspace(dir: string, includeMd: boolean, ignoredFiles: string[] = []): Promise<WorkspaceFileInput[]> {
   let ignore = ['node_modules/**', '**/.*/**', ...ignoredFiles]
-  let paths = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore, follow: false})
+  let paths = await glob(includeMd ? '**/*.{gsql,md}' : '**/*.gsql', {cwd: dir, ignore, follow: false, nocase: true})
   let files: WorkspaceFileInput[] = []
 
   for await (let file of paths) {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -190,6 +190,14 @@ describe('lang', () => {
     expect('from nyc_taxi select trip_id').toRenderSql('SELECT nyc_taxi.trip_id as trip_id FROM default.nyc_taxi as nyc_taxi')
   })
 
+  it('excludes agents.md from workspace by default', async () => {
+    let root = path.join(import.meta.dirname, '../examples/flights')
+    clearWorkspace()
+    setConfig({root})
+    await loadWorkspace(root, true)
+    expect(getFile('AGENTS.md')).toBeUndefined()
+  })
+
   it('ignores workspace files matched by ignoredFiles globs', async () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-workspace-ignore-'))
 


### PR DESCRIPTION
This wasn't working properly because glob doesn't handle bare filenames, but I think `**/agents.md` is a better default anyway.

glob seemed to be case-sensitive, which it shouldn't be on macos, but add this just to be safe.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>