### PR TITLE
rework telemetry API

### DIFF
--- a/cli/check.ts
+++ b/cli/check.ts
@@ -2,13 +2,13 @@ import {readFileSync} from 'node:fs'
 import path from 'path'
 
 import type {WorkspaceFileInput} from '../lang/types.ts'
-import type {CliTelemetry} from './telemetry/index.ts'
 
 import {config} from '../lang/config.ts'
 import {analyzeWorkspace, loadWorkspace} from '../lang/core.ts'
 import {mockFileMap} from './mockFiles.ts'
 import {normalizeFile} from './normalizeFile.ts'
 import {printDiagnostics} from './printer.ts'
+import {getWorkspaceScanCounts, type CliTelemetry} from './telemetry/index.ts'
 
 interface CheckOptions {
   fileArg?: string
@@ -26,7 +26,7 @@ export async function check(options: CheckOptions): Promise<boolean> {
   }
 
   let files = await loadWorkspace(config.root, !targetFile, config.ignoredFiles)
-  options.telemetry?.workspaceScanned('check', files)
+  options.telemetry?.event('workspace_scanned', {command: 'check', ...getWorkspaceScanCounts(files)})
   if (process.env.NODE_ENV == 'test') {
     for (let [path, contents] of Object.entries(mockFileMap)) {
       if (targetFile && path != targetFile) continue

--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -197,6 +197,8 @@ describe('cli telemetry', () => {
       expect(scanned.command).toBe('compile')
       expect(scanned.gsql_file_count).toBeGreaterThan(0)
       expect(scanned.md_file_count).toBe(0)
+      expect(scanned).not.toHaveProperty('files')
+      expect(JSON.stringify(scanned)).not.toContain('flights.gsql')
 
       for (let batch of batches) {
         expect(batch).toMatchObject({events: expect.any(Array)})

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -15,7 +15,7 @@ import {check} from './check.ts'
 import {getConnection, runQuery} from './connections/index.ts'
 import {printDiagnostics, printTable} from './printer.ts'
 import {runMdFile, runNamedQueryFromMd} from './run.ts'
-import {CliTelemetry, type TelemetryCommand} from './telemetry/index.ts'
+import {CliTelemetry, getPresentFlags, getWorkspaceScanCounts, type TelemetryCommand} from './telemetry/index.ts'
 
 const program = new Command()
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -40,7 +40,7 @@ program
   .action(
     withTelemetry('compile', async (exit, input: string | undefined) => {
       let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
-      telemetry.workspaceScanned('compile', files)
+      telemetry.event('workspace_scanned', {command: 'compile', ...getWorkspaceScanCounts(files)})
       let sql = await readInput(input)
       let analysis = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: sql})}, 'input')
       let [query] = validateInputQuery(analysis, exit)
@@ -78,7 +78,7 @@ program
       }
 
       let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
-      telemetry.workspaceScanned('run', files)
+      telemetry.event('workspace_scanned', {command: 'run', ...getWorkspaceScanCounts(files)})
       let gsql = await readInput(input)
       let analysis = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: gsql})}, 'input')
       let [query] = validateInputQuery(analysis, exit)
@@ -159,7 +159,7 @@ program
         return exit(0)
       } else {
         let mod = await import('./serve2.ts') // load dynamically, so we're not pulling in a bunch of deps we might not need
-        await mod.serve2()
+        await mod.serve2(telemetry)
       }
     }),
   )
@@ -248,7 +248,7 @@ function withTelemetry(command: TelemetryCommand, action: (exit: (code?: number)
     let exitCalled = false
     let caughtError: unknown
 
-    telemetry.commandStarted(command)
+    telemetry.event('cli_command_started', {command, flags: getPresentFlags(command, process.argv.slice(2))})
 
     let exit = (code: number = 0): never => {
       exitCalled = true
@@ -264,7 +264,12 @@ function withTelemetry(command: TelemetryCommand, action: (exit: (code?: number)
       success = false
       caughtError = err
     } finally {
-      await telemetry.commandCompleted(command, {success, exit_code: exitCode, duration_ms: Date.now() - startedAt})
+      if (success) {
+        let {shouldSendInstallSeen, fromVersion} = await telemetry.markSuccessfulInvocation()
+        if (shouldSendInstallSeen) telemetry.event('cli_install_seen')
+        if (fromVersion) telemetry.event('cli_upgraded', {from_version: fromVersion, to_version: libPkg.version})
+      }
+      telemetry.event('cli_command_completed', {command, success, exit_code: exitCode, duration_ms: Date.now() - startedAt})
     }
 
     if (caughtError) throw caughtError

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -8,7 +8,6 @@ import {type PluginOption, type ViteDevServer} from 'vite'
 import {WebSocketServer, type WebSocket} from 'ws'
 
 import type {GrapheneError} from '../lang/index.d.ts'
-import type {CliTelemetry} from './telemetry/index.ts'
 
 import {config} from '../lang/config.ts'
 import {analyzeWorkspace, getFile, loadWorkspace, toSql} from '../lang/core.ts'
@@ -20,6 +19,7 @@ import {runQuery} from './connections/index.ts'
 import {mockFileMap} from './mockFiles.ts'
 import {normalizeFile} from './normalizeFile.ts'
 import {printDiagnostics, printTable} from './printer.ts'
+import {getWorkspaceScanCounts, type CliTelemetry} from './telemetry/index.ts'
 
 export interface RunMdFileOptions {
   mdArg: string
@@ -40,7 +40,7 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
   }
 
   let files = await loadWorkspace(config.root, false, config.ignoredFiles)
-  options.telemetry?.workspaceScanned('run', files)
+  options.telemetry?.event('workspace_scanned', {command: 'run', ...getWorkspaceScanCounts(files)})
   let mdContents: string
   if (process.env.NODE_ENV == 'test' && mockFileMap[mdFile]) {
     mdContents = mockFileMap[mdFile]
@@ -117,7 +117,7 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
 
 export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string, telemetry?: CliTelemetry): Promise<boolean> {
   let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
-  telemetry?.workspaceScanned('run', files)
+  telemetry?.event('workspace_scanned', {command: 'run', ...getWorkspaceScanCounts(files)})
   let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
   let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
 

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -16,6 +16,7 @@ import {runQuery} from './connections/index.ts'
 import {extractFrontmatter, injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 import {mockFileMap} from './mockFiles.ts'
 import {runVitePlugin} from './run.ts'
+import {getWorkspaceScanCounts, type CliTelemetry} from './telemetry/index.ts'
 
 // Collect Svelte compiler warnings for test assertions
 export type SvelteWarning = {code: string; message: string; filename?: string}
@@ -29,8 +30,8 @@ const QUERY_VERSION = 1
 
 let uiRoot: string
 
-export async function serve2(): Promise<ViteDevServer> {
-  let server = await createServer(await createConfig())
+export async function serve2(telemetry?: CliTelemetry): Promise<ViteDevServer> {
+  let server = await createServer(await createConfig(telemetry))
   // I originally added this to avoid the page refreshing immediately on load.
   // We def don't want to run it in tests, because its not safe to do in parallel.
   // I'm not sure it's still needed, now that we explicitly list out `optimizeDeps.includes`, refreshes should be rare
@@ -41,7 +42,7 @@ export async function serve2(): Promise<ViteDevServer> {
   return server
 }
 
-async function createConfig(): Promise<InlineConfig> {
+async function createConfig(telemetry?: CliTelemetry): Promise<InlineConfig> {
   uiRoot = path.join(fileURLToPath(import.meta.url), '../../ui')
   let port = Number(process.env.GRAPHENE_PORT) || 4000
   await fs.ensureDir(path.resolve(config.root, 'node_modules/.graphene'))
@@ -77,7 +78,7 @@ async function createConfig(): Promise<InlineConfig> {
       fixHmrForFailedModules(),
       runVitePlugin(),
       handleRequestPlugin,
-      updateWorkspacePlugin(),
+      updateWorkspacePlugin(telemetry),
       mockFilesForTests(),
     ],
     publicDir: path.resolve(uiRoot, 'public'),
@@ -232,7 +233,7 @@ function fixHmrForFailedModules() {
 let workspaceLoadPromise: Promise<void> | undefined
 let workspaceFiles: WorkspaceFileInput[] = []
 let mdFiles: {path: string; title?: string}[] = []
-function updateWorkspacePlugin() {
+function updateWorkspacePlugin(telemetry?: CliTelemetry) {
   return {
     name: 'updateWorkspace',
     resolveId(id: string) {
@@ -259,8 +260,12 @@ function updateWorkspacePlugin() {
     configureServer: (s: ViteDevServer) => {
       let refresh = async () => {
         workspaceLoadPromise = (async () => {
-          workspaceFiles = await loadWorkspace(config.root, true, config.ignoredFiles)
-          // telemetry?.workspaceScanned('serve', workspaceFiles) // TODO this fires every time a file changes. Too much?
+          let loaded = await loadWorkspace(config.root, true, config.ignoredFiles)
+          telemetry?.event('workspace_scanned', {command: 'serve', ...getWorkspaceScanCounts(loaded)})
+          workspaceFiles = loaded.map(file => {
+            let existing = workspaceFiles.find(existing => existing.path == file.path && existing.contents == file.contents)
+            return existing?.parsed ? {...file, parsed: existing.parsed} : file
+          })
         })()
         await workspaceLoadPromise
 

--- a/cli/telemetry.test.ts
+++ b/cli/telemetry.test.ts
@@ -3,10 +3,21 @@ import * as fsp from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 
-import {getPresentFlags, getProjectHash, isTelemetryEnabled} from './telemetry/index.ts'
+import {getPresentFlags, getProjectHash, getWorkspaceScanCounts, isTelemetryEnabled} from './telemetry/index.ts'
 import {TelemetryStorage} from './telemetry/storage.ts'
 
 describe('cli telemetry', () => {
+  it('summarizes workspace scans as file type counts', () => {
+    let files = [
+      {path: 'tables/flights.gsql', contents: 'from flights'},
+      {path: 'tables/carriers.gsql', contents: 'from carriers'},
+      {path: 'reports/index.md', contents: '# Report'},
+      {path: 'README.txt', contents: 'ignore me'},
+    ]
+
+    expect(getWorkspaceScanCounts(files)).toEqual({gsql_file_count: 2, md_file_count: 1})
+  })
+
   it('tracks only safe flag names, not values', () => {
     expect(getPresentFlags('run', ['run', 'report.md', '--query', 'weekly_trends', '--chart', 'Revenue by Region'])).toEqual(['chart', 'query'])
     expect(getPresentFlags('serve', ['serve', '--bg'])).toEqual(['bg'])

--- a/cli/telemetry/index.ts
+++ b/cli/telemetry/index.ts
@@ -55,7 +55,7 @@ export class CliTelemetry {
 
   async markSuccessfulInvocation() {
     if (!this.enabled) return {shouldSendInstallSeen: false, fromVersion: undefined}
-    return this.storage.markSuccessfulInvocation(this.cliVersion)
+    return await this.storage.markSuccessfulInvocation(this.cliVersion)
   }
 
   private commonFields() {

--- a/cli/telemetry/index.ts
+++ b/cli/telemetry/index.ts
@@ -5,10 +5,10 @@ import path from 'node:path'
 
 import type {Config} from '../../lang/config.ts'
 import type {WorkspaceFileInput} from '../../lang/core.ts'
-import type {CliCommandCompletedEvent, TelemetryBatch, TelemetryCommand, TelemetryEvent, WorkspaceScannedEvent} from './types.ts'
+import type {TelemetryBatch, TelemetryCommand, TelemetryEvent, TelemetryEventName, TelemetryPayloads} from './types.ts'
 
 import {TelemetryStorage} from './storage.ts'
-export type {TelemetryCommand} from './types.ts'
+export type {TelemetryCommand, TelemetryEventName, TelemetryPayloads} from './types.ts'
 
 const DEFAULT_TELEMETRY_ENDPOINT = 'https://app.graphenedata.com/cli-telemetry'
 const SAFE_FLAG_NAMES: Partial<Record<TelemetryCommand, Record<string, string[]>>> = {
@@ -42,47 +42,20 @@ export class CliTelemetry {
     this.projectHash = await getProjectHash(cwd)
   }
 
-  commandStarted(command: TelemetryCommand, argv = process.argv.slice(2)) {
+  event<K extends TelemetryEventName>(event: K, ...args: TelemetryPayloads[K] extends undefined ? [] : [payload: TelemetryPayloads[K]]) {
     if (!this.enabled) return
-    this.send({
-      ...this.commonFields(),
-      event: 'cli_command_started',
-      command,
-      flags: getPresentFlags(command, argv),
-    })
-  }
-
-  async commandCompleted(command: TelemetryCommand, event: Omit<CliCommandCompletedEvent, keyof ReturnType<CliTelemetry['commonFields']> | 'event' | 'command'>) {
-    if (!this.enabled) return
-
-    if (event.success) {
-      let {shouldSendInstallSeen, fromVersion} = await this.storage.markSuccessfulInvocation(this.cliVersion)
-      if (shouldSendInstallSeen) this.send({...this.commonFields(), event: 'cli_install_seen'})
-      if (fromVersion) {
-        this.send({
-          ...this.commonFields(),
-          event: 'cli_upgraded',
-          from_version: fromVersion,
-          to_version: this.cliVersion,
-        })
-      }
+    if (event == 'workspace_scanned') {
+      if (this.workspaceScanSent) return
+      this.workspaceScanSent = true
     }
 
-    this.send({...this.commonFields(), event: 'cli_command_completed', command, ...event})
+    let payload = args[0] || {}
+    this.send({...this.commonFields(), event, ...payload} as TelemetryEvent)
   }
 
-  workspaceScanned(command: Extract<TelemetryCommand, 'check' | 'compile' | 'run' | 'serve'>, files: WorkspaceFileInput[]) {
-    if (!this.enabled || this.workspaceScanSent) return
-    this.workspaceScanSent = true
-
-    let event: WorkspaceScannedEvent = {
-      ...this.commonFields(),
-      event: 'workspace_scanned',
-      command,
-      gsql_file_count: files.filter(file => file.path.endsWith('.gsql')).length,
-      md_file_count: files.filter(file => file.path.endsWith('.md')).length,
-    }
-    this.send(event)
+  async markSuccessfulInvocation() {
+    if (!this.enabled) return {shouldSendInstallSeen: false, fromVersion: undefined}
+    return this.storage.markSuccessfulInvocation(this.cliVersion)
   }
 
   private commonFields() {
@@ -130,6 +103,13 @@ export function getPresentFlags(command: TelemetryCommand, argv: string[]) {
     .map(([name]) => name)
 
   return present.sort()
+}
+
+export function getWorkspaceScanCounts(files: Pick<WorkspaceFileInput, 'path'>[]) {
+  return {
+    gsql_file_count: files.filter(file => file.path.endsWith('.gsql')).length,
+    md_file_count: files.filter(file => file.path.endsWith('.md')).length,
+  }
 }
 
 export async function getProjectHash(startDir: string) {

--- a/cli/telemetry/types.ts
+++ b/cli/telemetry/types.ts
@@ -16,38 +16,38 @@ export interface CommonEventFields {
   node_version: string
 }
 
-export interface CliInstallSeenEvent extends CommonEventFields {
-  event: 'cli_install_seen'
+export interface TelemetryPayloads {
+  cli_install_seen: undefined
+  cli_upgraded: {
+    from_version: string
+    to_version: string
+  }
+  workspace_scanned: {
+    command: 'check' | 'compile' | 'run' | 'serve'
+    gsql_file_count: number
+    md_file_count: number
+  }
+  cli_command_started: {
+    command: TelemetryCommand
+    flags: string[]
+  }
+  cli_command_completed: {
+    command: TelemetryCommand
+    success: boolean
+    exit_code: number
+    duration_ms: number
+  }
 }
 
-export interface CliUpgradedEvent extends CommonEventFields {
-  event: 'cli_upgraded'
-  from_version: string
-  to_version: string
-}
+export type TelemetryEventName = keyof TelemetryPayloads
+export type TelemetryEventFor<K extends TelemetryEventName> = CommonEventFields & {event: K} & (TelemetryPayloads[K] extends undefined ? object : TelemetryPayloads[K])
+export type TelemetryEvent = {[K in TelemetryEventName]: TelemetryEventFor<K>}[TelemetryEventName]
 
-export interface WorkspaceScannedEvent extends CommonEventFields {
-  event: 'workspace_scanned'
-  command: 'check' | 'compile' | 'run' | 'serve'
-  gsql_file_count: number
-  md_file_count: number
-}
-
-export interface CliCommandStartedEvent extends CommonEventFields {
-  event: 'cli_command_started'
-  command: TelemetryCommand
-  flags: string[]
-}
-
-export interface CliCommandCompletedEvent extends CommonEventFields {
-  event: 'cli_command_completed'
-  command: TelemetryCommand
-  success: boolean
-  exit_code: number
-  duration_ms: number
-}
-
-export type TelemetryEvent = CliInstallSeenEvent | CliUpgradedEvent | WorkspaceScannedEvent | CliCommandStartedEvent | CliCommandCompletedEvent
+export type CliInstallSeenEvent = TelemetryEventFor<'cli_install_seen'>
+export type CliUpgradedEvent = TelemetryEventFor<'cli_upgraded'>
+export type WorkspaceScannedEvent = TelemetryEventFor<'workspace_scanned'>
+export type CliCommandStartedEvent = TelemetryEventFor<'cli_command_started'>
+export type CliCommandCompletedEvent = TelemetryEventFor<'cli_command_completed'>
 
 export interface TelemetryBatch {
   events: TelemetryEvent[]


### PR DESCRIPTION
This PR updates the telemetry API to make it clearer exactly what values are being passed as telemetry, by reflecting the event schema more directly in the API. Fixes #288