### PR TITLE
Sankey enrichment + example

### DIFF
--- a/examples/clickhouse/flows.md
+++ b/examples/clickhouse/flows.md
@@ -1,0 +1,134 @@
+# NYC Taxi Origin-Destination Flows
+
+Trip movement between pickup and dropoff neighborhoods in the NYC taxi sample.
+
+```sql flow_summary
+select
+  count(*) as trips,
+  count(distinct pickup_ntaname) as pickup_neighborhoods,
+  count(distinct dropoff_ntaname) as dropoff_neighborhoods,
+  count(distinct concat(pickup_ntaname, ' -> ', dropoff_ntaname)) as routes
+from nyc_taxi
+where pickup_ntaname is not null
+  and dropoff_ntaname is not null
+  and pickup_ntaname != ''
+  and dropoff_ntaname != ''
+```
+
+<Row>
+  <BigValue data=flow_summary value=trips title="Trips with OD" fmt=num0 />
+  <BigValue data=flow_summary value=routes title="Routes" fmt=num0 />
+  <BigValue data=flow_summary value=pickup_neighborhoods title="Pickup Areas" fmt=num0 />
+  <BigValue data=flow_summary value=dropoff_neighborhoods title="Dropoff Areas" fmt=num0 />
+</Row>
+
+```sql flow_edges
+select
+  concat('Pickup: ', pickup_ntaname) as source,
+  concat('Dropoff: ', dropoff_ntaname) as target,
+  count(*) as trips
+from nyc_taxi
+where pickup_ntaname is not null
+  and dropoff_ntaname is not null
+  and pickup_ntaname != ''
+  and dropoff_ntaname != ''
+group by 1, 2
+order by 3 desc
+limit 40
+```
+
+<ECharts data=flow_edges height=640 renderer=canvas>
+  title: {
+    text: "Top Pickup to Dropoff Flows",
+    left: "center",
+  },
+  tooltip: {
+    trigger: "item",
+  },
+  series: [{
+    type: "sankey",
+    nodeAlign: "justify",
+    draggable: false,
+    left: 12,
+    right: 140,
+    top: 64,
+    bottom: 20,
+    layoutIterations: 64,
+    emphasis: {
+      focus: "adjacency",
+    },
+    encode: {
+      source: "source",
+      target: "target",
+      value: "trips",
+    },
+    label: {
+      fontSize: 11,
+      overflow: "truncate",
+      width: 130,
+    },
+    lineStyle: {
+      color: "gradient",
+      curveness: 0.5,
+      opacity: 0.35,
+    },
+  }],
+</ECharts>
+
+```sql top_pickups
+select
+  pickup_ntaname,
+  count(*) as trips,
+  avg(total_amount) as avg_total_amount
+from nyc_taxi
+where pickup_ntaname is not null
+  and pickup_ntaname != ''
+group by 1
+order by 2 desc
+limit 12
+```
+
+```sql top_dropoffs
+select
+  dropoff_ntaname,
+  count(*) as trips,
+  avg(total_amount) as avg_total_amount
+from nyc_taxi
+where dropoff_ntaname is not null
+  and dropoff_ntaname != ''
+group by 1
+order by 2 desc
+limit 12
+```
+
+<Row>
+  <BarChart title="Top Pickup Neighborhoods" data=top_pickups x=pickup_ntaname y=trips />
+  <BarChart title="Top Dropoff Neighborhoods" data=top_dropoffs x=dropoff_ntaname y=trips />
+</Row>
+
+```sql top_routes
+select
+  pickup_ntaname as pickup,
+  dropoff_ntaname as dropoff,
+  count(*) as trips,
+  avg(trip_distance) as avg_distance,
+  avg(trip_minutes) as avg_minutes,
+  avg(total_amount) as avg_total_amount
+from nyc_taxi
+where pickup_ntaname is not null
+  and dropoff_ntaname is not null
+  and pickup_ntaname != ''
+  and dropoff_ntaname != ''
+group by 1, 2
+order by 3 desc
+limit 25
+```
+
+<Table data=top_routes title="Top Origin-Destination Routes" rows=25 compact=true search=true totalRow=true>
+  <Column id=pickup title="Pickup" />
+  <Column id=dropoff title="Dropoff" />
+  <Column id=trips title="Trips" fmt=num0 />
+  <Column id=avg_distance title="Avg Distance" fmt=num1 />
+  <Column id=avg_minutes title="Avg Minutes" fmt=num1 />
+  <Column id=avg_total_amount title="Avg Fare" fmt=usd2 />
+</Table>

--- a/examples/clickhouse/flows.md
+++ b/examples/clickhouse/flows.md
@@ -1,6 +1,21 @@
 # NYC Taxi Origin-Destination Flows
 
-Trip movement between pickup and dropoff neighborhoods in the NYC taxi sample.
+Trip movement between pickup and dropoff neighborhoods from a bounded sample of NYC taxi trips.
+
+```sql flow_sample
+select
+  pickup_ntaname,
+  dropoff_ntaname,
+  trip_distance,
+  trip_minutes,
+  total_amount
+from nyc_taxi
+where pickup_ntaname is not null
+  and dropoff_ntaname is not null
+  and pickup_ntaname != ''
+  and dropoff_ntaname != ''
+limit 250000
+```
 
 ```sql flow_summary
 select
@@ -8,16 +23,12 @@ select
   count(distinct pickup_ntaname) as pickup_neighborhoods,
   count(distinct dropoff_ntaname) as dropoff_neighborhoods,
   count(distinct concat(pickup_ntaname, ' -> ', dropoff_ntaname)) as routes
-from nyc_taxi
-where pickup_ntaname is not null
-  and dropoff_ntaname is not null
-  and pickup_ntaname != ''
-  and dropoff_ntaname != ''
+from flow_sample
 ```
 
 <Row>
-  <BigValue data=flow_summary value=trips title="Trips with OD" fmt=num0 />
-  <BigValue data=flow_summary value=routes title="Routes" fmt=num0 />
+  <BigValue data=flow_summary value=trips title="Sample Trips" fmt=num0 />
+  <BigValue data=flow_summary value=routes title="Sample Routes" fmt=num0 />
   <BigValue data=flow_summary value=pickup_neighborhoods title="Pickup Areas" fmt=num0 />
   <BigValue data=flow_summary value=dropoff_neighborhoods title="Dropoff Areas" fmt=num0 />
 </Row>
@@ -27,11 +38,7 @@ select
   concat('Pickup: ', pickup_ntaname) as source,
   concat('Dropoff: ', dropoff_ntaname) as target,
   count(*) as trips
-from nyc_taxi
-where pickup_ntaname is not null
-  and dropoff_ntaname is not null
-  and pickup_ntaname != ''
-  and dropoff_ntaname != ''
+from flow_sample
 group by 1, 2
 order by 3 desc
 limit 40
@@ -80,9 +87,7 @@ select
   pickup_ntaname,
   count(*) as trips,
   avg(total_amount) as avg_total_amount
-from nyc_taxi
-where pickup_ntaname is not null
-  and pickup_ntaname != ''
+from flow_sample
 group by 1
 order by 2 desc
 limit 12
@@ -93,9 +98,7 @@ select
   dropoff_ntaname,
   count(*) as trips,
   avg(total_amount) as avg_total_amount
-from nyc_taxi
-where dropoff_ntaname is not null
-  and dropoff_ntaname != ''
+from flow_sample
 group by 1
 order by 2 desc
 limit 12
@@ -114,11 +117,7 @@ select
   avg(trip_distance) as avg_distance,
   avg(trip_minutes) as avg_minutes,
   avg(total_amount) as avg_total_amount
-from nyc_taxi
-where pickup_ntaname is not null
-  and dropoff_ntaname is not null
-  and pickup_ntaname != ''
-  and dropoff_ntaname != ''
+from flow_sample
 group by 1, 2
 order by 3 desc
 limit 25

--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -27,6 +27,7 @@ export function enrich(config: EChartsConfig, rows: Record<string, any>[], field
   applyMissingPointDefaults(normalized, rows)
   applyStackPercentage(normalized, rows, fields)
   applySorting(normalized, rows, fields)
+  materializeSankeySeries(normalized, rows)
 
   let baseDatasetId = ensureDataset(normalized, rows, fields)
   expandSeriesTransforms(normalized, rows, baseDatasetId)
@@ -181,6 +182,42 @@ function expandSeriesTransforms(config: NormalConfig, rows: Record<string, any>[
   })
 
   config.series = expanded
+}
+
+// Sankey does not consume dataset+encode directly, so turn encoded edge rows into native nodes/links.
+function materializeSankeySeries(config: NormalConfig, rows: Record<string, any>[]) {
+  for (let series of config.series) {
+    let target = series as SeriesWithGroupingHint & {links?: unknown[]}
+    if (target?.type !== 'sankey' || target.data != null || target.links != null) continue
+
+    let sourceField = getEncodeFieldName(target, 'source')
+    let targetField = getEncodeFieldName(target, 'target')
+    let valueField = getEncodeFieldName(target, 'value')
+    if (!sourceField || !targetField || !valueField) continue
+
+    let seen = new Set<string>()
+    let nodes: {name: string}[] = []
+    let links: {source: string; target: string; value: number}[] = []
+
+    for (let row of rows) {
+      let source = row?.[sourceField]
+      let targetName = row?.[targetField]
+      if (source == null || targetName == null) continue
+
+      for (let name of [String(source), String(targetName)]) {
+        if (seen.has(name)) continue
+        seen.add(name)
+        nodes.push({name})
+      }
+
+      links.push({source: String(source), target: String(targetName), value: Number(row?.[valueField]) || 0})
+    }
+
+    target.data = nodes
+    target.links = links
+    delete target.encode
+    delete target.datasetId
+  }
 }
 
 // Ensure cartesian series always have at least one x/y axis object.


### PR DESCRIPTION
This PR adds a `materializeSankeySeries` enrichment, which Codex suggested to massage query results into a format consumable by an ECharts Sankey diagram. I think this is the same issue as #258? With it it was able to create an origin-destination diagram from the NYC taxi data:

<img width="748" height="846" alt="Screenshot 2026-04-21 at 9 22 40 AM" src="https://github.com/user-attachments/assets/caf57e9b-5c66-42bc-a336-391734dc44bb" />
