### PR TITLE
rework telemetry local storage

### DIFF
--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -46,6 +46,14 @@ function expectCliSuccess(res: RunResult, step: string) {
   expect(res.code).toBe(0)
 }
 
+async function createTelemetryProject(prefix: string) {
+  let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix))
+  await fsp.writeFile(path.join(tmpDir, 'package.json'), JSON.stringify({name: prefix, graphene: {duckdb: {}}}, null, 2) + '\n')
+  await fsp.cp(path.join(flightDir, 'tables'), path.join(tmpDir, 'tables'), {recursive: true})
+  await fsp.mkdir(path.join(tmpDir, 'node_modules'))
+  return tmpDir
+}
+
 describe('cli compile', () => {
   it('compiles a basic query (happy path)', async () => {
     let res = await runCli(['compile', 'from flights select carrier'], {cwd: flightDir})
@@ -150,7 +158,7 @@ describe('cli check', () => {
 
 describe('cli telemetry', () => {
   it('sends telemetry to the configured endpoint', async () => {
-    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-cli-telemetry-'))
+    let tmpDir = await createTelemetryProject('graphene-cli-telemetry-')
     let batches: any[] = []
     let server = createServer(async (req: IncomingMessage, res: ServerResponse<IncomingMessage>) => {
       let body = await readRequestBody(req)
@@ -162,11 +170,10 @@ describe('cli telemetry', () => {
     try {
       let endpoint = await listen(server)
       let res = await runCli(['compile', 'from flights select carrier'], {
-        cwd: flightDir,
+        cwd: tmpDir,
         env: {
           GRAPHENE_TELEMETRY_DISABLED: '0',
           GRAPHENE_TELEMETRY_ENDPOINT: endpoint,
-          XDG_CONFIG_HOME: tmpDir,
         },
       })
 
@@ -212,7 +219,7 @@ describe('cli telemetry', () => {
   })
 
   it('only sends cli_install_seen on the first run for an install', async () => {
-    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-cli-telemetry-install-seen-'))
+    let tmpDir = await createTelemetryProject('graphene-cli-telemetry-install-seen-')
     let batches: any[] = []
     let server = createServer(async (req: IncomingMessage, res: ServerResponse<IncomingMessage>) => {
       let body = await readRequestBody(req)
@@ -226,10 +233,9 @@ describe('cli telemetry', () => {
       let env = {
         GRAPHENE_TELEMETRY_DISABLED: '0',
         GRAPHENE_TELEMETRY_ENDPOINT: endpoint,
-        XDG_CONFIG_HOME: tmpDir,
       }
 
-      let first = await runCli(['compile', 'from flights select carrier'], {cwd: flightDir, env})
+      let first = await runCli(['compile', 'from flights select carrier'], {cwd: tmpDir, env})
       expectCliSuccess(first, 'telemetry first compile')
       await waitFor(() => batches.length >= 4)
       let events = batches.flatMap(batch => batch.events)
@@ -237,7 +243,7 @@ describe('cli telemetry', () => {
 
       batches.length = 0
 
-      let second = await runCli(['compile', 'from flights select carrier'], {cwd: flightDir, env})
+      let second = await runCli(['compile', 'from flights select carrier'], {cwd: tmpDir, env})
       expectCliSuccess(second, 'telemetry second compile')
       await waitFor(() => batches.length >= 3)
 
@@ -248,6 +254,26 @@ describe('cli telemetry', () => {
       expect(events.filter(event => event.event == 'cli_install_seen')).toHaveLength(0)
     } finally {
       await new Promise(resolve => server.close(resolve))
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('does not fail the command when telemetry state cannot be persisted', async () => {
+    let tmpDir = await createTelemetryProject('graphene-cli-telemetry-blocked-')
+
+    try {
+      await fsp.writeFile(path.join(tmpDir, 'node_modules/.graphene'), '')
+      let res = await runCli(['check', 'tables/flights.gsql'], {
+        cwd: tmpDir,
+        env: {
+          GRAPHENE_TELEMETRY_DISABLED: '0',
+          GRAPHENE_TELEMETRY_ENDPOINT: 'http://127.0.0.1:9',
+        },
+      })
+
+      expectCliSuccess(res, 'telemetry blocked check')
+      expect(res.stdout).toContain('No errors found')
+    } finally {
       await fsp.rm(tmpDir, {recursive: true, force: true})
     }
   })

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -264,7 +264,7 @@ function withTelemetry(command: TelemetryCommand, action: (exit: (code?: number)
       success = false
       caughtError = err
     } finally {
-      telemetry.commandCompleted(command, {success, exit_code: exitCode, duration_ms: Date.now() - startedAt})
+      await telemetry.commandCompleted(command, {success, exit_code: exitCode, duration_ms: Date.now() - startedAt})
     }
 
     if (caughtError) throw caughtError

--- a/cli/package.json
+++ b/cli/package.json
@@ -43,7 +43,6 @@
     "ci-info": "^4.4.0",
     "cli-table3": "^0.6.3",
     "commander": "^11.0.0",
-    "conf": "^15.1.0",
     "debounce": "^1.2.1",
     "dotenv": "^17.2.3",
     "echarts": "^5.5.0",

--- a/cli/telemetry.test.ts
+++ b/cli/telemetry.test.ts
@@ -45,36 +45,70 @@ describe('cli telemetry', () => {
 
   it('persists install and upgrade state', async () => {
     let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-telemetry-state-'))
-    let originalConfigHome = process.env.XDG_CONFIG_HOME
-    process.env.XDG_CONFIG_HOME = tmpDir
 
     try {
-      let storage = new TelemetryStorage()
+      await fsp.mkdir(path.join(tmpDir, 'node_modules'))
+      let storage = new TelemetryStorage({projectRoot: tmpDir})
+      await storage.init()
       let firstInstallId = storage.installId
       expect(firstInstallId).toBeTruthy()
 
-      let initialSuccess = storage.markSuccessfulInvocation('0.0.15')
+      let initialSuccess = await storage.markSuccessfulInvocation('0.0.15')
       expect(initialSuccess).toEqual({shouldSendInstallSeen: true, fromVersion: undefined})
       expect(storage.installId).toBe(firstInstallId)
 
-      let repeatSuccess = storage.markSuccessfulInvocation('0.0.15')
+      let repeatSuccess = await storage.markSuccessfulInvocation('0.0.15')
       expect(repeatSuccess).toEqual({shouldSendInstallSeen: false, fromVersion: undefined})
       expect(storage.installId).toBe(firstInstallId)
 
-      let upgradeSuccess = storage.markSuccessfulInvocation('0.0.16')
+      let upgradeSuccess = await storage.markSuccessfulInvocation('0.0.16')
       expect(upgradeSuccess).toEqual({shouldSendInstallSeen: false, fromVersion: '0.0.15'})
       expect(storage.installId).toBe(firstInstallId)
 
-      let repeatUpgradeVersion = storage.markSuccessfulInvocation('0.0.16')
+      let repeatUpgradeVersion = await storage.markSuccessfulInvocation('0.0.16')
       expect(repeatUpgradeVersion).toEqual({shouldSendInstallSeen: false, fromVersion: undefined})
       expect(storage.installId).toBe(firstInstallId)
 
-      let switchBackVersion = storage.markSuccessfulInvocation('0.0.15')
+      let nextStorage = new TelemetryStorage({projectRoot: tmpDir})
+      await nextStorage.init()
+      expect(nextStorage.installId).toBe(firstInstallId)
+      expect(await nextStorage.markSuccessfulInvocation('0.0.17')).toEqual({shouldSendInstallSeen: false, fromVersion: '0.0.16'})
+
+      let switchBackVersion = await storage.markSuccessfulInvocation('0.0.15')
       expect(switchBackVersion).toEqual({shouldSendInstallSeen: false, fromVersion: undefined})
       expect(storage.installId).toBe(firstInstallId)
     } finally {
-      if (originalConfigHome === undefined) delete process.env.XDG_CONFIG_HOME
-      else process.env.XDG_CONFIG_HOME = originalConfigHome
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('does not throw when telemetry state cannot be persisted', async () => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-telemetry-unwritable-'))
+
+    try {
+      await fsp.mkdir(path.join(tmpDir, 'node_modules'))
+      await fsp.writeFile(path.join(tmpDir, 'node_modules/.graphene'), '')
+
+      let storage = new TelemetryStorage({projectRoot: tmpDir})
+      await storage.init()
+      expect(storage.installId).toBeTruthy()
+      expect(await storage.markSuccessfulInvocation('0.0.15')).toEqual({shouldSendInstallSeen: false, fromVersion: undefined})
+      expect(await storage.markSuccessfulInvocation('0.0.16')).toEqual({shouldSendInstallSeen: false, fromVersion: undefined})
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('uses ephemeral state when the project has no node_modules', async () => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-telemetry-no-node-modules-'))
+
+    try {
+      let storage = new TelemetryStorage({projectRoot: tmpDir})
+      await storage.init()
+      expect(storage.installId).toBeTruthy()
+      expect(await storage.markSuccessfulInvocation('0.0.15')).toEqual({shouldSendInstallSeen: false, fromVersion: undefined})
+      await expect(fsp.access(path.join(tmpDir, 'node_modules'))).rejects.toBeTruthy()
+    } finally {
       await fsp.rm(tmpDir, {recursive: true, force: true})
     }
   })

--- a/cli/telemetry/README.md
+++ b/cli/telemetry/README.md
@@ -10,11 +10,13 @@ Telemetry is enabled when:
 
 The default endpoint is `https://app.graphenedata.com/cli-telemetry`. Tests and local development can override it with `GRAPHENE_TELEMETRY_ENDPOINT`.
 
+Telemetry state persistence is best-effort. State is stored in the current project's `node_modules/.graphene/telemetry.json` when `node_modules` already exists. If the project cache cannot be read or written, command behavior should not change and install or upgrade lifecycle events are skipped.
+
 ## Common fields
 
 Every event includes these fields:
 
-- `install_id`: A random UUID generated once and persisted in the local Graphene config store. It identifies a CLI installation, not a user account or machine owner.
+- `install_id`: A random UUID generated once and persisted in the local Graphene project cache. It identifies a project-local CLI installation, not a user account or machine owner.
 - `project_hash`: A SHA-256 hash of the nearest `package.json` `name`, prefixed with `graphene:` before hashing. This lets us distinguish projects without sending the raw package name.
 - `cli_version`: The Graphene CLI version.
 - `timestamp`: The event time in ISO-8601 format.

--- a/cli/telemetry/index.ts
+++ b/cli/telemetry/index.ts
@@ -17,7 +17,7 @@ const SAFE_FLAG_NAMES: Partial<Record<TelemetryCommand, Record<string, string[]>
 }
 
 export class CliTelemetry {
-  private storage = new TelemetryStorage()
+  private storage: TelemetryStorage
   private installId = ''
   private projectHash?: string
   private enabled = true
@@ -30,12 +30,14 @@ export class CliTelemetry {
     this.cfg = cfg
     this.cliVersion = cliVersion
     this.endpoint = endpoint
+    this.storage = new TelemetryStorage({projectRoot: cfg.root})
   }
 
   async init(cwd = process.cwd()) {
     this.enabled = isTelemetryEnabled(this.cfg, this.endpoint)
     if (!this.enabled) return
 
+    await this.storage.init()
     this.installId = this.storage.installId
     this.projectHash = await getProjectHash(cwd)
   }
@@ -50,11 +52,11 @@ export class CliTelemetry {
     })
   }
 
-  commandCompleted(command: TelemetryCommand, event: Omit<CliCommandCompletedEvent, keyof ReturnType<CliTelemetry['commonFields']> | 'event' | 'command'>) {
+  async commandCompleted(command: TelemetryCommand, event: Omit<CliCommandCompletedEvent, keyof ReturnType<CliTelemetry['commonFields']> | 'event' | 'command'>) {
     if (!this.enabled) return
 
     if (event.success) {
-      let {shouldSendInstallSeen, fromVersion} = this.storage.markSuccessfulInvocation(this.cliVersion)
+      let {shouldSendInstallSeen, fromVersion} = await this.storage.markSuccessfulInvocation(this.cliVersion)
       if (shouldSendInstallSeen) this.send({...this.commonFields(), event: 'cli_install_seen'})
       if (fromVersion) {
         this.send({

--- a/cli/telemetry/storage.ts
+++ b/cli/telemetry/storage.ts
@@ -1,35 +1,106 @@
-import Conf from 'conf'
 import {randomUUID} from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import path from 'node:path'
 
 import type {TelemetryState} from './types.ts'
 
+interface TelemetryStorageOptions {
+  projectRoot?: string
+}
+
 export class TelemetryStorage {
-  private store = new Conf<TelemetryState>({
-    configName: 'telemetry',
-    defaults: {
-      installId: randomUUID(),
-      installSeenVersions: [],
-    },
-    projectName: 'graphene',
-  })
+  private state = defaultState()
+  private options: TelemetryStorageOptions
+  private nodeModulesPath?: string
+
+  constructor(options: TelemetryStorageOptions = {}) {
+    this.options = options
+  }
+
+  async init() {
+    this.nodeModulesPath = await getNodeModulesPath(this.options)
+    let filePath = this.telemetryFilePath()
+
+    try {
+      if (filePath) this.state = normalizeState(JSON.parse(await fs.readFile(filePath, 'utf-8')), this.state)
+    } catch {
+      // Telemetry storage is best-effort; corrupt or unreadable state should not affect commands.
+    }
+  }
 
   read(): TelemetryState {
-    return this.store.store
+    return this.state
   }
 
   get installId() {
-    return this.store.get('installId')
+    return this.state.installId
   }
 
-  markSuccessfulInvocation(cliVersion: string) {
+  async markSuccessfulInvocation(cliVersion: string) {
     let state = this.read()
     let hasSeenVersion = state.installSeenVersions.includes(cliVersion)
     let shouldSendInstallSeen = !state.lastSeenVersion && state.installSeenVersions.length == 0
     let fromVersion = !hasSeenVersion && state.lastSeenVersion && state.lastSeenVersion != cliVersion ? state.lastSeenVersion : undefined
 
-    this.store.set('lastSeenVersion', cliVersion)
-    this.store.set('installSeenVersions', [...new Set([...state.installSeenVersions, cliVersion])])
+    let nextState = {
+      ...state,
+      lastSeenVersion: cliVersion,
+      installSeenVersions: [...new Set([...state.installSeenVersions, cliVersion])],
+    }
+    if (!(await this.write(nextState))) return {shouldSendInstallSeen: false, fromVersion: undefined}
 
     return {shouldSendInstallSeen, fromVersion}
+  }
+
+  private async write(state: TelemetryState) {
+    let filePath = this.telemetryFilePath()
+    if (!filePath) return false
+
+    let tmpPath = `${filePath}.tmp-${randomUUID()}`
+    try {
+      // Do not create node_modules solely for telemetry; only use the project cache if it already exists.
+      if (this.nodeModulesPath && !(await fs.stat(this.nodeModulesPath)).isDirectory()) return false
+      await fs.mkdir(path.dirname(filePath), {recursive: true})
+      await fs.writeFile(tmpPath, JSON.stringify(state, null, 2) + '\n')
+      await fs.rename(tmpPath, filePath)
+      this.state = state
+      return true
+    } catch {
+      try {
+        await fs.unlink(tmpPath)
+      } catch {
+        // Nothing to clean up if the temp file was never created.
+      }
+      return false
+    }
+  }
+
+  private telemetryFilePath() {
+    if (this.nodeModulesPath) return path.join(this.nodeModulesPath, '.graphene', 'telemetry.json')
+  }
+}
+
+function defaultState(): TelemetryState {
+  return {installId: randomUUID(), installSeenVersions: []}
+}
+
+async function getNodeModulesPath(options: TelemetryStorageOptions) {
+  if (!options.projectRoot) return
+
+  let nodeModules = path.join(options.projectRoot, 'node_modules')
+  try {
+    if (!(await fs.stat(nodeModules)).isDirectory()) return
+  } catch {
+    return
+  }
+
+  return nodeModules
+}
+
+function normalizeState(state: Partial<TelemetryState>, fallback: TelemetryState): TelemetryState {
+  return {
+    installId: typeof state.installId == 'string' && state.installId ? state.installId : fallback.installId,
+    installSeenVersions: Array.isArray(state.installSeenVersions) ? state.installSeenVersions.filter(version => typeof version == 'string') : fallback.installSeenVersions,
+    ...(typeof state.lastSeenVersion == 'string' ? {lastSeenVersion: state.lastSeenVersion} : {}),
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,9 +110,6 @@ importers:
       commander:
         specifier: ^11.0.0
         version: 11.1.0
-      conf:
-        specifier: ^15.1.0
-        version: 15.1.0
       debounce:
         specifier: ^1.2.1
         version: 1.2.1
@@ -1668,19 +1665,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
-
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1733,9 +1719,6 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  atomically@2.1.1:
-    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
 
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
@@ -1857,10 +1840,6 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
-  conf@15.1.0:
-    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
-    engines: {node: '>=20'}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1879,10 +1858,6 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
-
-  debounce-fn@6.0.0:
-    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
-    engines: {node: '>=18'}
 
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
@@ -1942,10 +1917,6 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
-  dot-prop@10.1.0:
-    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
-    engines: {node: '>=20'}
-
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
@@ -1988,10 +1959,6 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
-
-  env-paths@3.0.0:
-    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -2137,9 +2104,6 @@ packages:
 
   fast-string-width@1.1.0:
     resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
-
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
@@ -2423,12 +2387,6 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
-
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -2530,10 +2488,6 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
-
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -2737,10 +2691,6 @@ packages:
   request-light@0.7.0:
     resolution: {integrity: sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==}
 
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
-
   requireindex@1.2.0:
     resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
     engines: {node: '>=0.10.5'}
@@ -2855,12 +2805,6 @@ packages:
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
-  stubborn-fs@2.0.0:
-    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
-
-  stubborn-utils@1.0.2:
-    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
-
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
@@ -2876,10 +2820,6 @@ packages:
   svelte@5.55.3:
     resolution: {integrity: sha512-dS1N+i3bA1v+c4UDb750MlN5vCO82G6vxh8HeTsPsTdJ1BLsN1zxSyDlIdBBqUjqZ/BxEwM8UrFf98aaoVnZFQ==}
     engines: {node: '>=18'}
-
-  tagged-tag@1.0.0:
-    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
-    engines: {node: '>=20'}
 
   teeny-request@10.1.0:
     resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
@@ -2939,10 +2879,6 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-fest@5.5.0:
-    resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
-    engines: {node: '>=20'}
-
   typescript-eslint@8.56.1:
     resolution: {integrity: sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2954,10 +2890,6 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  uint8array-extras@1.5.0:
-    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
-    engines: {node: '>=18'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -3130,9 +3062,6 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
-
-  when-exit@2.1.5:
-    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4904,23 +4833,12 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv-formats@3.0.1(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
-
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.18.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -4963,11 +4881,6 @@ snapshots:
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
-
-  atomically@2.1.1:
-    dependencies:
-      stubborn-fs: 2.0.0
-      when-exit: 2.1.5
 
   axios@1.15.0:
     dependencies:
@@ -5067,18 +4980,6 @@ snapshots:
 
   commander@11.1.0: {}
 
-  conf@15.1.0:
-    dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      atomically: 2.1.1
-      debounce-fn: 6.0.0
-      dot-prop: 10.1.0
-      env-paths: 3.0.0
-      json-schema-typed: 8.0.2
-      semver: 7.7.4
-      uint8array-extras: 1.5.0
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5096,10 +4997,6 @@ snapshots:
       internmap: 1.0.1
 
   data-uri-to-buffer@4.0.1: {}
-
-  debounce-fn@6.0.0:
-    dependencies:
-      mimic-function: 5.0.1
 
   debounce@1.2.1: {}
 
@@ -5148,10 +5045,6 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
-  dot-prop@10.1.0:
-    dependencies:
-      type-fest: 5.5.0
-
   dotenv@17.3.1: {}
 
   dunder-proto@1.0.1:
@@ -5196,8 +5089,6 @@ snapshots:
   entities@4.5.0: {}
 
   entities@7.0.1: {}
-
-  env-paths@3.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -5381,8 +5272,6 @@ snapshots:
   fast-string-width@1.1.0:
     dependencies:
       fast-string-truncated-width: 1.2.1
-
-  fast-uri@3.1.0: {}
 
   fast-wrap-ansi@0.1.6:
     dependencies:
@@ -5688,10 +5577,6 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
-  json-schema-traverse@1.0.0: {}
-
-  json-schema-typed@8.0.2: {}
-
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
@@ -5797,8 +5682,6 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mimic-function@5.0.1: {}
 
   minimalistic-assert@1.0.1: {}
 
@@ -5987,8 +5870,6 @@ snapshots:
 
   request-light@0.7.0: {}
 
-  require-from-string@2.0.2: {}
-
   requireindex@1.2.0: {}
 
   retry-request@8.0.2:
@@ -6153,12 +6034,6 @@ snapshots:
 
   strnum@2.2.3: {}
 
-  stubborn-fs@2.0.0:
-    dependencies:
-      stubborn-utils: 1.0.2
-
-  stubborn-utils@1.0.2: {}
-
   stubs@3.0.0: {}
 
   svelte-eslint-parser@1.6.0(svelte@5.55.3(@typescript-eslint/types@8.56.1)):
@@ -6193,8 +6068,6 @@ snapshots:
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
-
-  tagged-tag@1.0.0: {}
 
   teeny-request@10.1.0:
     dependencies:
@@ -6244,10 +6117,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@5.5.0:
-    dependencies:
-      tagged-tag: 1.0.0
-
   typescript-eslint@8.56.1(eslint@10.2.0)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3)
@@ -6260,8 +6129,6 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
-
-  uint8array-extras@1.5.0: {}
 
   undici-types@6.21.0: {}
 
@@ -6476,8 +6343,6 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   web-streams-polyfill@3.3.3: {}
-
-  when-exit@2.1.5: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
When testing with a realistic install, I ran into an issue where failure to persist telemetry-related state (e.g. installed versions seen) would bubble up to the user. That was an easy fix but revealed a problem with the initial implementation: It used the [conf](https://www.npmjs.com/package/conf) package for this storage, which defaults to a platform-appropriate config dir like `~/Library/Preferences`, and there's a good chance users will run agents without full access in which case the CLI cannot write to that directory. This PR updates the telemetry persistence for tracking seen versions to write to `./node_modules/.graphene/telemetry.json` as this is likely to be writable (at the cost of perhaps being less durable).