### PR TITLE
`create` script enhancements

### DIFF
--- a/create/cli.ts
+++ b/create/cli.ts
@@ -5,6 +5,7 @@ import {runCreate} from './create.ts'
 await runCreate({
   argv: process.argv.slice(2),
   cwd: process.cwd(),
+  env: process.env,
   stdin: process.stdin,
   stdout: process.stdout,
   stderr: process.stderr,

--- a/create/create.test.ts
+++ b/create/create.test.ts
@@ -143,10 +143,52 @@ describe('runCreate', () => {
 
     await runCreate({argv: ['demo-app', '--yes', '--install'], cwd: root, stdin: process.stdin, stdout: stdout.stream, stderr: stderr.stream})
 
-    expect(taskLogMock).toHaveBeenCalledWith({title: 'Installing dependencies...', retainLog: true})
+    expect(spawnMock).toHaveBeenCalledWith('npm', ['install', '--no-fund'], expect.objectContaining({cwd: path.join(root, 'demo-app')}))
+    expect(taskLogMock).toHaveBeenCalledWith({title: 'Installing dependencies with npm...', retainLog: true})
     expect(taskLogState.message).toHaveBeenNthCalledWith(1, 'added 10 packages')
     expect(taskLogState.message).toHaveBeenNthCalledWith(2, 'funding info')
     expect(taskLogState.success).toHaveBeenCalledWith('Dependencies installed', {showLog: true})
+  })
+
+  it('uses the invoking package manager for install and generated metadata', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
+    let {runCreate} = await import('./create.ts')
+
+    spawnMock.mockImplementation(() => createChild())
+
+    await runCreate({
+      argv: ['demo-app', '--yes', '--install'],
+      cwd: root,
+      env: {npm_config_user_agent: 'pnpm/10.1.0 npm/? node/v24.0.0 darwin arm64'},
+      stdin: process.stdin,
+      stdout: streamSink().stream,
+      stderr: streamSink().stream,
+    })
+
+    let pkg = JSON.parse(await readFile(path.join(root, 'demo-app', 'package.json'), 'utf8'))
+    expect(pkg.packageManager).toBe('pnpm@10.1.0')
+    expect(spawnMock).toHaveBeenCalledWith('pnpm', ['install'], expect.objectContaining({cwd: path.join(root, 'demo-app')}))
+    expect(taskLogMock).toHaveBeenCalledWith({title: 'Installing dependencies with pnpm...', retainLog: true})
+  })
+
+  it('names the detected package manager in the install prompt', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
+    let {runCreate} = await import('./create.ts')
+
+    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
+    selectMock.mockResolvedValue('duckdb')
+    confirmMock.mockResolvedValue(false)
+
+    await runCreate({
+      argv: [],
+      cwd: root,
+      env: {npm_config_user_agent: 'yarn/4.12.0 npm/? node/v24.0.0 darwin arm64'},
+      stdin: process.stdin,
+      stdout: streamSink().stream,
+      stderr: streamSink().stream,
+    })
+
+    expect(confirmMock).toHaveBeenCalledWith(expect.objectContaining({message: 'Install dependencies with yarn now?'}))
   })
 
   it('marks install failures without clearing the log', async () => {

--- a/create/create.test.ts
+++ b/create/create.test.ts
@@ -1,5 +1,5 @@
 import {EventEmitter} from 'node:events'
-import {mkdtemp, mkdir, readFile, writeFile} from 'node:fs/promises'
+import {mkdtemp, mkdir, readFile, readlink, writeFile} from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import {Writable} from 'node:stream'
@@ -90,7 +90,7 @@ describe('runCreate', () => {
     let stderr = streamSink()
 
     textMock.mockResolvedValueOnce('my-analytics').mockResolvedValueOnce('MY_DB.ANALYTICS').mockResolvedValueOnce('myorg-myaccount').mockResolvedValueOnce('graphene_user')
-    selectMock.mockResolvedValue('snowflake')
+    selectMock.mockResolvedValueOnce('snowflake').mockResolvedValueOnce('none')
     pathMock.mockResolvedValue(keyPath)
     passwordMock.mockResolvedValue('secret')
     spawnMock.mockImplementation(() => createChild())
@@ -123,7 +123,7 @@ describe('runCreate', () => {
     let {runCreate} = await import('./create.ts')
 
     textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
-    selectMock.mockResolvedValue('duckdb')
+    selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('none')
     spawnMock.mockImplementation(() => createChild())
 
     await runCreate({argv: [], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
@@ -176,7 +176,7 @@ describe('runCreate', () => {
     let {runCreate} = await import('./create.ts')
 
     textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
-    selectMock.mockResolvedValue('duckdb')
+    selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('none')
     spawnMock.mockImplementation(() => createChild())
 
     await runCreate({
@@ -190,6 +190,20 @@ describe('runCreate', () => {
 
     expect(confirmMock).not.toHaveBeenCalled()
     expect(spawnMock).toHaveBeenCalledWith('yarn', ['install'], expect.any(Object))
+  })
+
+  it('symlinks the Graphene skill into the selected agent folder', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
+    let {runCreate} = await import('./create.ts')
+
+    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
+    selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('.agents')
+    spawnMock.mockImplementation(() => createChild())
+
+    await runCreate({argv: [], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
+
+    let linkTarget = await readlink(path.join(root, 'demo-app/.agents/skills/graphene'))
+    expect(linkTarget).toBe('../../node_modules/@graphenedata/cli/dist/skills/graphene')
   })
 
   it('skips dependency installation with --no-install', async () => {

--- a/create/create.test.ts
+++ b/create/create.test.ts
@@ -93,7 +93,7 @@ describe('runCreate', () => {
     selectMock.mockResolvedValue('snowflake')
     pathMock.mockResolvedValue(keyPath)
     passwordMock.mockResolvedValue('secret')
-    confirmMock.mockResolvedValue(false)
+    spawnMock.mockImplementation(() => createChild())
 
     await runCreate({argv: [], cwd: root, stdin: process.stdin, stdout: stdout.stream, stderr: stderr.stream})
 
@@ -124,7 +124,7 @@ describe('runCreate', () => {
 
     textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
     selectMock.mockResolvedValue('duckdb')
-    confirmMock.mockResolvedValue(false)
+    spawnMock.mockImplementation(() => createChild())
 
     await runCreate({argv: [], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
 
@@ -141,7 +141,7 @@ describe('runCreate', () => {
 
     spawnMock.mockImplementation(() => createChild({stdout: 'added 10 packages\nfunding info\n'}))
 
-    await runCreate({argv: ['demo-app', '--yes', '--install'], cwd: root, stdin: process.stdin, stdout: stdout.stream, stderr: stderr.stream})
+    await runCreate({argv: ['demo-app', '--yes'], cwd: root, stdin: process.stdin, stdout: stdout.stream, stderr: stderr.stream})
 
     expect(spawnMock).toHaveBeenCalledWith('npm', ['install', '--no-fund'], expect.objectContaining({cwd: path.join(root, 'demo-app')}))
     expect(taskLogMock).toHaveBeenCalledWith({title: 'Installing dependencies with npm...', retainLog: true})
@@ -157,7 +157,7 @@ describe('runCreate', () => {
     spawnMock.mockImplementation(() => createChild())
 
     await runCreate({
-      argv: ['demo-app', '--yes', '--install'],
+      argv: ['demo-app', '--yes'],
       cwd: root,
       env: {npm_config_user_agent: 'pnpm/10.1.0 npm/? node/v24.0.0 darwin arm64'},
       stdin: process.stdin,
@@ -171,13 +171,13 @@ describe('runCreate', () => {
     expect(taskLogMock).toHaveBeenCalledWith({title: 'Installing dependencies with pnpm...', retainLog: true})
   })
 
-  it('names the detected package manager in the install prompt', async () => {
+  it('does not prompt before installing dependencies', async () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
     textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
     selectMock.mockResolvedValue('duckdb')
-    confirmMock.mockResolvedValue(false)
+    spawnMock.mockImplementation(() => createChild())
 
     await runCreate({
       argv: [],
@@ -188,7 +188,17 @@ describe('runCreate', () => {
       stderr: streamSink().stream,
     })
 
-    expect(confirmMock).toHaveBeenCalledWith(expect.objectContaining({message: 'Install dependencies with yarn now?'}))
+    expect(confirmMock).not.toHaveBeenCalled()
+    expect(spawnMock).toHaveBeenCalledWith('yarn', ['install'], expect.any(Object))
+  })
+
+  it('skips dependency installation with --no-install', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
+    let {runCreate} = await import('./create.ts')
+
+    await runCreate({argv: ['demo-app', '--yes', '--no-install'], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
+
+    expect(spawnMock).not.toHaveBeenCalled()
   })
 
   it('marks install failures without clearing the log', async () => {
@@ -197,7 +207,7 @@ describe('runCreate', () => {
 
     spawnMock.mockImplementation(() => createChild({exitCode: 1, stderr: 'npm ERR! failed\n'}))
 
-    await expect(runCreate({argv: ['demo-app', '--yes', '--install'], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})).rejects.toThrow('npm ERR! failed')
+    await expect(runCreate({argv: ['demo-app', '--yes'], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})).rejects.toThrow('npm ERR! failed')
     expect(taskLogState.error).toHaveBeenCalledWith('npm install failed', {showLog: true})
   })
 })

--- a/create/create.test.ts
+++ b/create/create.test.ts
@@ -131,6 +131,7 @@ describe('runCreate', () => {
     let pkg = JSON.parse(await readFile(path.join(root, 'demo-app', 'package.json'), 'utf8'))
     expect(pkg.graphene).toEqual({dialect: 'duckdb'})
     expect(pkg.dependencies['@duckdb/node-api']).toBe('1.3.2-alpha.26')
+    expect(await readFile(path.join(root, 'demo-app', 'AGENTS.md'), 'utf8')).toContain('npx graphene check')
   })
 
   it('streams install output into the task log and keeps line breaks on success', async () => {

--- a/create/create.test.ts
+++ b/create/create.test.ts
@@ -1,5 +1,5 @@
 import {EventEmitter} from 'node:events'
-import {mkdtemp, mkdir, readFile, readlink, writeFile} from 'node:fs/promises'
+import {lstat, mkdtemp, mkdir, readFile, readlink, writeFile} from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import {Writable} from 'node:stream'
@@ -171,6 +171,19 @@ describe('runCreate', () => {
     expect(taskLogMock).toHaveBeenCalledWith({title: 'Installing dependencies with pnpm...', retainLog: true})
   })
 
+  it('skips skill linking by default in --yes mode', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
+    let {runCreate} = await import('./create.ts')
+
+    spawnMock.mockImplementation(() => createChild())
+
+    await runCreate({argv: ['demo-app', '--yes'], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
+
+    expect(spawnMock).toHaveBeenCalled()
+    expect(await lstat(path.join(root, 'demo-app/.agents/skills/graphene')).catch(() => null)).toBeNull()
+    expect(await lstat(path.join(root, 'demo-app/.claude/skills/graphene')).catch(() => null)).toBeNull()
+  })
+
   it('does not prompt before installing dependencies', async () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
@@ -203,6 +216,20 @@ describe('runCreate', () => {
     await runCreate({argv: [], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
 
     let linkTarget = await readlink(path.join(root, 'demo-app/.agents/skills/graphene'))
+    expect(linkTarget).toBe('../../node_modules/@graphenedata/cli/dist/skills/graphene')
+  })
+
+  it('symlinks the Graphene skill into the selected Claude folder', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
+    let {runCreate} = await import('./create.ts')
+
+    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
+    selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('.claude')
+    spawnMock.mockImplementation(() => createChild())
+
+    await runCreate({argv: [], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
+
+    let linkTarget = await readlink(path.join(root, 'demo-app/.claude/skills/graphene'))
     expect(linkTarget).toBe('../../node_modules/@graphenedata/cli/dist/skills/graphene')
   })
 

--- a/create/create.ts
+++ b/create/create.ts
@@ -2,7 +2,7 @@ import type {Readable, Writable} from 'node:stream'
 
 import * as clack from '@clack/prompts'
 import {spawn} from 'node:child_process'
-import {access, mkdir, readFile, readdir, writeFile} from 'node:fs/promises'
+import {access, mkdir, readFile, readlink, readdir, symlink, writeFile} from 'node:fs/promises'
 import path from 'node:path'
 
 import cliPackageJson from '../cli/package.json' with {type: 'json'}
@@ -17,6 +17,7 @@ interface CliPackageJson {
 
 type Database = 'duckdb' | 'snowflake' | 'bigquery'
 type WarehouseClient = '@duckdb/node-api' | '@google-cloud/bigquery' | 'snowflake-sdk'
+type SkillLinkTarget = '.agents' | '.claude' | 'none'
 
 interface CreateOptions {
   yes: boolean
@@ -88,6 +89,7 @@ interface ScaffoldAnswers {
   snowflakePassphrase?: string
   bigqueryProjectId?: string
   bigqueryKeyPath?: string
+  skillLinkTarget: SkillLinkTarget
 }
 
 interface InstallResult {
@@ -330,6 +332,7 @@ async function collectAnswers({options, packageManager, input, output}: {options
       projectName: options.name || defaultProjectName(targetDir),
       packageManager,
       database: 'duckdb',
+      skillLinkTarget: 'none',
     }
   }
 
@@ -373,6 +376,7 @@ async function collectAnswers({options, packageManager, input, output}: {options
     packageManager,
     database,
     defaultNamespace: defaultNamespace || undefined,
+    skillLinkTarget: 'none',
   }
 
   if (database === 'duckdb') {
@@ -422,6 +426,20 @@ async function collectAnswers({options, packageManager, input, output}: {options
       }),
     )
     answers.bigqueryKeyPath = await promptExistingFilePath({message: 'Path to service account .json key file', expectedExtension: '.json', input, output})
+  }
+
+  if (options.install) {
+    answers.skillLinkTarget = unwrapPrompt(
+      await clack.select<SkillLinkTarget>({
+        message: 'Add the Graphene skill for agents?',
+        options: [
+          {value: '.agents', label: '.agents/skills/graphene'},
+          {value: '.claude', label: '.claude/skills/graphene'},
+          {value: 'none', label: 'Skip'},
+        ],
+        ...promptOptions(input, output),
+      }),
+    )
   }
 
   return answers
@@ -485,6 +503,24 @@ async function installDeps(targetDir: string, packageManager: PackageManager, en
   return {code, stderr}
 }
 
+async function symlinkGrapheneSkill(targetDir: string, skillLinkTarget: SkillLinkTarget): Promise<void> {
+  if (skillLinkTarget === 'none') return
+
+  let sourcePath = path.join(targetDir, 'node_modules/@graphenedata/cli/dist/skills/graphene')
+  let linkPath = path.join(targetDir, skillLinkTarget, 'skills/graphene')
+  let relativeSourcePath = path.relative(path.dirname(linkPath), sourcePath)
+
+  await mkdir(path.dirname(linkPath), {recursive: true})
+  try {
+    await symlink(relativeSourcePath, linkPath, 'dir')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
+    let existingTarget = await readlink(linkPath).catch(() => null)
+    if (existingTarget === relativeSourcePath) return
+    throw new Error(`Cannot link Graphene skill because ${linkPath} already exists`, {cause: err})
+  }
+}
+
 // Resolve answers, write the starter, and install dependencies unless explicitly skipped.
 export async function runCreate({argv, cwd, env = {}, stdin, stdout}: CreateContext): Promise<void> {
   let options = parseArgs(argv)
@@ -507,6 +543,7 @@ export async function runCreate({argv, cwd, env = {}, stdin, stdout}: CreateCont
     if (options.install) {
       let install = await installDeps(targetDir, packageManager, env)
       if (install.code !== 0) throw new Error(install.stderr.trim() || `${packageManager.name} install failed with code ${install.code}`)
+      await symlinkGrapheneSkill(targetDir, answers.skillLinkTarget)
     }
 
     clack.outro('Done!', {output: stdout})

--- a/create/create.ts
+++ b/create/create.ts
@@ -20,7 +20,7 @@ type WarehouseClient = '@duckdb/node-api' | '@google-cloud/bigquery' | 'snowflak
 
 interface CreateOptions {
   yes: boolean
-  install: boolean | undefined
+  install: boolean
   name: string | undefined
   targetDir: string | undefined
   help: boolean
@@ -88,7 +88,6 @@ interface ScaffoldAnswers {
   snowflakePassphrase?: string
   bigqueryProjectId?: string
   bigqueryKeyPath?: string
-  install: boolean
 }
 
 interface InstallResult {
@@ -118,15 +117,11 @@ class CreateCancelled extends Error {
 
 // Parse the small CLI surface directly so the initializer stays dependency-light.
 export function parseArgs(argv: string[]): CreateOptions {
-  let options: CreateOptions = {yes: false, install: undefined, name: undefined, targetDir: undefined, help: false}
+  let options: CreateOptions = {yes: false, install: true, name: undefined, targetDir: undefined, help: false}
   for (let i = 0; i < argv.length; i++) {
     let arg = argv[i]
     if (arg === '--yes' || arg === '-y') {
       options.yes = true
-      continue
-    }
-    if (arg === '--install') {
-      options.install = true
       continue
     }
     if (arg === '--no-install') {
@@ -261,12 +256,11 @@ export async function writeTemplate(targetDir: string, files: TemplateFiles): Pr
 function printHelp(stdout: Writable): void {
   stdout.write(
     [
-      'Usage: npm create @graphenedata [target-dir] [-- --yes] [--name <project-name>] [--install|--no-install]',
+      'Usage: npm create @graphenedata [target-dir] [-- --yes] [--name <project-name>] [--no-install]',
       '',
       'Options:',
       '  -y, --yes        Skip prompts and accept defaults',
       '  --name <name>    Set the generated package name',
-      '  --install        Install dependencies after scaffolding',
       '  --no-install     Skip dependency installation',
     ].join('\n') + '\n',
   )
@@ -336,7 +330,6 @@ async function collectAnswers({options, packageManager, input, output}: {options
       projectName: options.name || defaultProjectName(targetDir),
       packageManager,
       database: 'duckdb',
-      install: options.install ?? false,
     }
   }
 
@@ -380,7 +373,6 @@ async function collectAnswers({options, packageManager, input, output}: {options
     packageManager,
     database,
     defaultNamespace: defaultNamespace || undefined,
-    install: false,
   }
 
   if (database === 'duckdb') {
@@ -431,16 +423,6 @@ async function collectAnswers({options, packageManager, input, output}: {options
     )
     answers.bigqueryKeyPath = await promptExistingFilePath({message: 'Path to service account .json key file', expectedExtension: '.json', input, output})
   }
-
-  answers.install =
-    options.install ??
-    unwrapPrompt(
-      await clack.confirm({
-        message: `Install dependencies with ${packageManager.name} now?`,
-        initialValue: true,
-        ...promptOptions(input, output),
-      }),
-    )
 
   return answers
 }
@@ -503,7 +485,7 @@ async function installDeps(targetDir: string, packageManager: PackageManager, en
   return {code, stderr}
 }
 
-// Resolve answers, write the starter, and optionally install dependencies.
+// Resolve answers, write the starter, and install dependencies unless explicitly skipped.
 export async function runCreate({argv, cwd, env = {}, stdin, stdout}: CreateContext): Promise<void> {
   let options = parseArgs(argv)
   if (options.help) {
@@ -522,7 +504,7 @@ export async function runCreate({argv, cwd, env = {}, stdin, stdout}: CreateCont
     let cliVersion = packageJson.version || '0.0.15'
     await writeTemplate(targetDir, renderTemplate({answers, cliVersion}))
 
-    if (answers.install) {
+    if (options.install) {
       let install = await installDeps(targetDir, packageManager, env)
       if (install.code !== 0) throw new Error(install.stderr.trim() || `${packageManager.name} install failed with code ${install.code}`)
     }

--- a/create/create.ts
+++ b/create/create.ts
@@ -210,6 +210,7 @@ export function renderTemplate({answers, cliVersion}: {answers: ScaffoldAnswers;
   let files: TemplateFiles = {
     'package.json': JSON.stringify(pkg, null, 2) + '\n',
     '.gitignore': ['node_modules', '.env', '*.duckdb'].join('\n') + '\n',
+    'AGENTS.md': renderAgents(answers),
     'index.md': renderIndex(answers),
   }
 
@@ -217,6 +218,27 @@ export function renderTemplate({answers, cliVersion}: {answers: ScaffoldAnswers;
   if (envFile) files['.env'] = envFile
 
   return files
+}
+
+function grapheneCommand(packageManager: PackageManager | undefined, args: string): string {
+  if (packageManager?.name === 'pnpm') return `pnpm graphene ${args}`
+  if (packageManager?.name === 'yarn') return `yarn graphene ${args}`
+  if (packageManager?.name === 'bun') return `bun run graphene ${args}`
+  return `npx graphene ${args}`
+}
+
+function renderAgents(answers: ScaffoldAnswers): string {
+  return (
+    [
+      '## Graphene Reference',
+      '',
+      'Common commands:',
+      '',
+      `- ${grapheneCommand(answers.packageManager, 'check')} - check the project for syntax and analysis errors`,
+      `- ${grapheneCommand(answers.packageManager, 'run index.md')} - execute the index page`,
+      `- ${grapheneCommand(answers.packageManager, 'serve --bg')} - start or restart the local dev server`,
+    ].join('\n') + '\n'
+  )
 }
 
 function renderIndex(answers: ScaffoldAnswers): string {

--- a/create/create.ts
+++ b/create/create.ts
@@ -232,6 +232,8 @@ function renderAgents(answers: ScaffoldAnswers): string {
     [
       '## Graphene Reference',
       '',
+      `Assume all ${databaseLabel(answers.database)} functions are available when writing GSQL.`,
+      '',
       'Common commands:',
       '',
       `- ${grapheneCommand(answers.packageManager, 'check')} - check the project for syntax and analysis errors`,
@@ -241,11 +243,14 @@ function renderAgents(answers: ScaffoldAnswers): string {
   )
 }
 
+function databaseLabel(database: Database) {
+  if (database === 'snowflake') return 'Snowflake'
+  if (database === 'bigquery') return 'BigQuery'
+  return 'DuckDB'
+}
+
 function renderIndex(answers: ScaffoldAnswers): string {
-  let dialectLabel = 'DuckDB'
-  if (answers.database === 'snowflake') dialectLabel = 'Snowflake'
-  else if (answers.database === 'bigquery') dialectLabel = 'BigQuery'
-  return [`# ${answers.projectName}`, '', `This Graphene project is configured for ${dialectLabel}.`, '', 'Start by adding models and queries to this project.'].join('\n') + '\n'
+  return [`# ${answers.projectName}`, '', `This Graphene project is configured for ${databaseLabel(answers.database)}.`, '', 'Start by adding models and queries to this project.'].join('\n') + '\n'
 }
 
 function renderEnvFile(answers: ScaffoldAnswers): string | null {

--- a/create/create.ts
+++ b/create/create.ts
@@ -50,6 +50,7 @@ interface GrapheneTemplateConfig {
 interface TemplatePackageJson {
   name: string
   version: string
+  packageManager?: string
   scripts: {
     graphene: string
     serve: string
@@ -63,14 +64,21 @@ interface TemplatePackageJson {
 interface CreateContext {
   argv: string[]
   cwd: string
+  env?: NodeJS.ProcessEnv
   stdin: Readable
   stdout: Writable
   stderr: Writable
 }
 
+interface PackageManager {
+  name: 'npm' | 'pnpm' | 'yarn' | 'bun'
+  version?: string
+}
+
 interface ScaffoldAnswers {
   targetDir: string
   projectName: string
+  packageManager?: PackageManager
   database: Database
   defaultNamespace?: string
   duckdbPath?: string
@@ -158,6 +166,19 @@ export function defaultProjectName(targetDir: string): string {
   return normalized || 'graphene-app'
 }
 
+// Create commands are normally launched by a package manager, which exposes its identity in npm-compatible env vars.
+export function detectPackageManager(env: NodeJS.ProcessEnv = {}): PackageManager {
+  let userAgent = env.npm_config_user_agent || env.NPM_CONFIG_USER_AGENT || ''
+  let userAgentMatch = userAgent.match(/(?:^|\s)(npm|pnpm|yarn|bun)\/([^\s]+)/)
+  if (userAgentMatch) return {name: userAgentMatch[1] as PackageManager['name'], version: userAgentMatch[2]}
+
+  let execPath = path.basename(env.npm_execpath || env.NPM_EXEC_PATH || '').toLowerCase()
+  if (execPath.includes('pnpm')) return {name: 'pnpm'}
+  if (execPath.includes('yarn')) return {name: 'yarn'}
+  if (execPath.includes('bun')) return {name: 'bun'}
+  return {name: 'npm'}
+}
+
 export function renderTemplate({answers, cliVersion}: {answers: ScaffoldAnswers; cliVersion: string}): TemplateFiles {
   let graphene: GrapheneTemplateConfig = {dialect: answers.database}
   if (answers.defaultNamespace) graphene.defaultNamespace = answers.defaultNamespace
@@ -172,6 +193,7 @@ export function renderTemplate({answers, cliVersion}: {answers: ScaffoldAnswers;
   let pkg: TemplatePackageJson = {
     name: answers.projectName,
     version: '0.0.1',
+    packageManager: answers.packageManager?.version ? `${answers.packageManager.name}@${answers.packageManager.version}` : undefined,
     scripts: {
       graphene: 'graphene',
       serve: 'graphene serve',
@@ -184,6 +206,7 @@ export function renderTemplate({answers, cliVersion}: {answers: ScaffoldAnswers;
     },
     graphene,
   }
+  if (!pkg.packageManager) delete pkg.packageManager
   let warehouseClient = getWarehouseClient(answers.database)
   pkg.dependencies[warehouseClient] = getWarehouseClientVersion(warehouseClient)
 
@@ -243,7 +266,7 @@ function printHelp(stdout: Writable): void {
       'Options:',
       '  -y, --yes        Skip prompts and accept defaults',
       '  --name <name>    Set the generated package name',
-      '  --install        Run npm install after scaffolding',
+      '  --install        Install dependencies after scaffolding',
       '  --no-install     Skip dependency installation',
     ].join('\n') + '\n',
   )
@@ -305,12 +328,13 @@ function getWarehouseClientVersion(packageName: WarehouseClient): string {
   return version
 }
 
-async function collectAnswers({options, input, output}: {options: CreateOptions; input: Readable; output: Writable}): Promise<ScaffoldAnswers> {
+async function collectAnswers({options, packageManager, input, output}: {options: CreateOptions; packageManager: PackageManager; input: Readable; output: Writable}): Promise<ScaffoldAnswers> {
   if (options.yes) {
     let targetDir = options.targetDir || 'graphene-app'
     return {
       targetDir,
       projectName: options.name || defaultProjectName(targetDir),
+      packageManager,
       database: 'duckdb',
       install: options.install ?? false,
     }
@@ -353,6 +377,7 @@ async function collectAnswers({options, input, output}: {options: CreateOptions;
   let answers: ScaffoldAnswers = {
     targetDir,
     projectName,
+    packageManager,
     database,
     defaultNamespace: defaultNamespace || undefined,
     install: false,
@@ -411,7 +436,7 @@ async function collectAnswers({options, input, output}: {options: CreateOptions;
     options.install ??
     unwrapPrompt(
       await clack.confirm({
-        message: 'Install dependencies now?',
+        message: `Install dependencies with ${packageManager.name} now?`,
         initialValue: true,
         ...promptOptions(input, output),
       }),
@@ -420,14 +445,20 @@ async function collectAnswers({options, input, output}: {options: CreateOptions;
   return answers
 }
 
-async function installDeps(targetDir: string): Promise<InstallResult> {
-  let task = clack.taskLog({title: 'Installing dependencies...', retainLog: true})
-  let child = spawn('npm', ['install', '--no-fund'], {
+function installCommand(packageManager: PackageManager): [string, string[]] {
+  if (packageManager.name === 'npm') return ['npm', ['install', '--no-fund']]
+  return [packageManager.name, ['install']]
+}
+
+async function installDeps(targetDir: string, packageManager: PackageManager, env: NodeJS.ProcessEnv): Promise<InstallResult> {
+  let [command, args] = installCommand(packageManager)
+  let task = clack.taskLog({title: `Installing dependencies with ${packageManager.name}...`, retainLog: true})
+  let child = spawn(command, args, {
     cwd: targetDir,
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: {...process.env, FORCE_COLOR: '1', npm_config_color: 'always'},
+    env: {...env, FORCE_COLOR: '1', npm_config_color: 'always'},
   })
-  if (!child.stdout || !child.stderr) throw new Error('npm install pipes were not created')
+  if (!child.stdout || !child.stderr) throw new Error(`${command} install pipes were not created`)
   let stderr = ''
   child.stdout.setEncoding('utf8')
   child.stderr.setEncoding('utf8')
@@ -467,13 +498,13 @@ async function installDeps(targetDir: string): Promise<InstallResult> {
   flush('stderr')
 
   if (code === 0) task.success('Dependencies installed', {showLog: true})
-  else task.error('npm install failed', {showLog: true})
+  else task.error(`${command} install failed`, {showLog: true})
 
   return {code, stderr}
 }
 
 // Resolve answers, write the starter, and optionally install dependencies.
-export async function runCreate({argv, cwd, stdin, stdout}: CreateContext): Promise<void> {
+export async function runCreate({argv, cwd, env = {}, stdin, stdout}: CreateContext): Promise<void> {
   let options = parseArgs(argv)
   if (options.help) {
     printHelp(stdout)
@@ -483,7 +514,8 @@ export async function runCreate({argv, cwd, stdin, stdout}: CreateContext): Prom
   clack.intro('Create a new Graphene project', {output: stdout})
 
   try {
-    let answers = await collectAnswers({options, input: stdin, output: stdout})
+    let packageManager = detectPackageManager(env)
+    let answers = await collectAnswers({options, packageManager, input: stdin, output: stdout})
     let targetDir = path.resolve(cwd, answers.targetDir)
 
     await ensureEmptyDir(targetDir)
@@ -491,8 +523,8 @@ export async function runCreate({argv, cwd, stdin, stdout}: CreateContext): Prom
     await writeTemplate(targetDir, renderTemplate({answers, cliVersion}))
 
     if (answers.install) {
-      let install = await installDeps(targetDir)
-      if (install.code !== 0) throw new Error(install.stderr.trim() || `npm install failed with code ${install.code}`)
+      let install = await installDeps(targetDir, packageManager, env)
+      if (install.code !== 0) throw new Error(install.stderr.trim() || `${packageManager.name} install failed with code ${install.code}`)
     }
 
     clack.outro('Done!', {output: stdout})

--- a/create/helpers.test.ts
+++ b/create/helpers.test.ts
@@ -48,6 +48,9 @@ describe('create helpers', () => {
     expect(pkg.dependencies['@graphenedata/cli']).toBe('0.0.15')
     expect(pkg.dependencies['@duckdb/node-api']).toBe('1.3.2-alpha.26')
     expect(pkg.graphene).toEqual({dialect: 'duckdb', duckdb: {path: './data.duckdb'}})
+    expect(files['AGENTS.md']).toContain('pnpm graphene check')
+    expect(files['AGENTS.md']).toContain('pnpm graphene run index.md')
+    expect(files['AGENTS.md']).toContain('pnpm graphene serve --bg')
     expect(files['.gitignore']).toContain('*.duckdb')
     expect(files['.env']).toBeUndefined()
     expect(files['index.md']).toContain('configured for DuckDB')
@@ -67,6 +70,21 @@ describe('create helpers', () => {
 
     expect(pkg.graphene).toEqual({dialect: 'duckdb'})
     expect(pkg.dependencies['@duckdb/node-api']).toBe('1.3.2-alpha.26')
+    expect(files['AGENTS.md']).toContain('npx graphene check')
+  })
+
+  it('renders AGENTS.md commands for yarn and bun projects', () => {
+    let yarnFiles = renderTemplate({
+      cliVersion: '0.0.15',
+      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'yarn', version: '4.12.0'}, database: 'duckdb', skillLinkTarget: 'none'},
+    })
+    let bunFiles = renderTemplate({
+      cliVersion: '0.0.15',
+      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'bun', version: '1.3.0'}, database: 'duckdb', skillLinkTarget: 'none'},
+    })
+
+    expect(yarnFiles['AGENTS.md']).toContain('yarn graphene check')
+    expect(bunFiles['AGENTS.md']).toContain('bun run graphene check')
   })
 
   it('renders a snowflake project with .env auth vars', () => {

--- a/create/helpers.test.ts
+++ b/create/helpers.test.ts
@@ -51,6 +51,7 @@ describe('create helpers', () => {
     expect(files['AGENTS.md']).toContain('pnpm graphene check')
     expect(files['AGENTS.md']).toContain('pnpm graphene run index.md')
     expect(files['AGENTS.md']).toContain('pnpm graphene serve --bg')
+    expect(files['AGENTS.md']).toContain('Assume all DuckDB functions are available when writing GSQL.')
     expect(files['.gitignore']).toContain('*.duckdb')
     expect(files['.env']).toBeUndefined()
     expect(files['index.md']).toContain('configured for DuckDB')
@@ -109,6 +110,7 @@ describe('create helpers', () => {
       defaultNamespace: 'MY_DB.ANALYTICS',
       snowflake: {account: 'myorg-myaccount', username: 'graphene_user'},
     })
+    expect(files['AGENTS.md']).toContain('Assume all Snowflake functions are available when writing GSQL.')
     expect(pkg.dependencies['snowflake-sdk']).toBeTruthy()
     expect(files['.env']).toContain('SNOWFLAKE_PRI_KEY_PATH=/Users/me/.ssh/graphene_snowflake_key.p8')
     expect(files['.env']).toContain('SNOWFLAKE_PRI_PASSPHRASE=secret')
@@ -134,6 +136,7 @@ describe('create helpers', () => {
       defaultNamespace: 'my-project.analytics',
       bigquery: {projectId: 'my-project-123'},
     })
+    expect(files['AGENTS.md']).toContain('Assume all BigQuery functions are available when writing GSQL.')
     expect(pkg.dependencies['@google-cloud/bigquery']).toBe('^8.2.0')
     expect(files['.env']).toContain('GOOGLE_APPLICATION_CREDENTIALS=/Users/me/.ssh/graphene-bq-key.json')
   })

--- a/create/helpers.test.ts
+++ b/create/helpers.test.ts
@@ -38,6 +38,7 @@ describe('create helpers', () => {
         packageManager: {name: 'pnpm', version: '10.1.0'},
         database: 'duckdb',
         duckdbPath: './data.duckdb',
+        skillLinkTarget: 'none',
       },
     })
     let pkg = JSON.parse(files['package.json'])
@@ -59,6 +60,7 @@ describe('create helpers', () => {
         targetDir: 'demo-app',
         projectName: 'demo-app',
         database: 'duckdb',
+        skillLinkTarget: 'none',
       },
     })
     let pkg = JSON.parse(files['package.json'])
@@ -79,6 +81,7 @@ describe('create helpers', () => {
         snowflakeUsername: 'graphene_user',
         snowflakeKeyPath: '/Users/me/.ssh/graphene_snowflake_key.p8',
         snowflakePassphrase: 'secret',
+        skillLinkTarget: 'none',
       },
     })
     let pkg = JSON.parse(files['package.json'])
@@ -103,6 +106,7 @@ describe('create helpers', () => {
         defaultNamespace: 'my-project.analytics',
         bigqueryProjectId: 'my-project-123',
         bigqueryKeyPath: '/Users/me/.ssh/graphene-bq-key.json',
+        skillLinkTarget: 'none',
       },
     })
     let pkg = JSON.parse(files['package.json'])

--- a/create/helpers.test.ts
+++ b/create/helpers.test.ts
@@ -4,9 +4,9 @@ import {defaultProjectName, detectPackageManager, parseArgs, renderTemplate} fro
 
 describe('create helpers', () => {
   it('parses the supported CLI arguments', () => {
-    expect(parseArgs(['demo', '--yes', '--name', 'demo-app', '--install'])).toEqual({
+    expect(parseArgs(['demo', '--yes', '--name', 'demo-app', '--no-install'])).toEqual({
       help: false,
-      install: true,
+      install: false,
       name: 'demo-app',
       targetDir: 'demo',
       yes: true,
@@ -38,7 +38,6 @@ describe('create helpers', () => {
         packageManager: {name: 'pnpm', version: '10.1.0'},
         database: 'duckdb',
         duckdbPath: './data.duckdb',
-        install: false,
       },
     })
     let pkg = JSON.parse(files['package.json'])
@@ -60,7 +59,6 @@ describe('create helpers', () => {
         targetDir: 'demo-app',
         projectName: 'demo-app',
         database: 'duckdb',
-        install: false,
       },
     })
     let pkg = JSON.parse(files['package.json'])
@@ -81,7 +79,6 @@ describe('create helpers', () => {
         snowflakeUsername: 'graphene_user',
         snowflakeKeyPath: '/Users/me/.ssh/graphene_snowflake_key.p8',
         snowflakePassphrase: 'secret',
-        install: true,
       },
     })
     let pkg = JSON.parse(files['package.json'])
@@ -106,7 +103,6 @@ describe('create helpers', () => {
         defaultNamespace: 'my-project.analytics',
         bigqueryProjectId: 'my-project-123',
         bigqueryKeyPath: '/Users/me/.ssh/graphene-bq-key.json',
-        install: true,
       },
     })
     let pkg = JSON.parse(files['package.json'])

--- a/create/helpers.test.ts
+++ b/create/helpers.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {defaultProjectName, parseArgs, renderTemplate} from './create.ts'
+import {defaultProjectName, detectPackageManager, parseArgs, renderTemplate} from './create.ts'
 
 describe('create helpers', () => {
   it('parses the supported CLI arguments', () => {
@@ -22,12 +22,20 @@ describe('create helpers', () => {
     expect(defaultProjectName('___')).toBe('___')
   })
 
+  it('detects the invoking package manager from npm-compatible env vars', () => {
+    expect(detectPackageManager({npm_config_user_agent: 'pnpm/10.1.0 npm/? node/v24.0.0 darwin arm64'})).toEqual({name: 'pnpm', version: '10.1.0'})
+    expect(detectPackageManager({npm_config_user_agent: 'yarn/4.12.0 npm/? node/v24.0.0 darwin arm64'})).toEqual({name: 'yarn', version: '4.12.0'})
+    expect(detectPackageManager({npm_execpath: '/usr/local/lib/node_modules/bun/bin/bun'})).toEqual({name: 'bun'})
+    expect(detectPackageManager({})).toEqual({name: 'npm'})
+  })
+
   it('renders a duckdb project with a configured path and starter page', () => {
     let files = renderTemplate({
       cliVersion: '0.0.15',
       answers: {
         targetDir: 'demo-app',
         projectName: 'demo-app',
+        packageManager: {name: 'pnpm', version: '10.1.0'},
         database: 'duckdb',
         duckdbPath: './data.duckdb',
         install: false,
@@ -36,6 +44,7 @@ describe('create helpers', () => {
     let pkg = JSON.parse(files['package.json'])
 
     expect(pkg.name).toBe('demo-app')
+    expect(pkg.packageManager).toBe('pnpm@10.1.0')
     expect(pkg.dependencies['@graphenedata/cli']).toBe('0.0.15')
     expect(pkg.dependencies['@duckdb/node-api']).toBe('1.3.2-alpha.26')
     expect(pkg.graphene).toEqual({dialect: 'duckdb', duckdb: {path: './data.duckdb'}})


### PR DESCRIPTION
This PR does a pass at the `create` command to address most of #299. Specifically:

- It detects the package manager used to invoke the create command, and uses that to install the Graphene CLI (it does not prompt but does still honor an explicit `--no-install` flag).
- It generates a (pretty bare) `AGENTS.md` which gives some example Graphene commands using said package manager. This should be expanded.
- Prompts to symlink the bundled Graphene skill into either `.agents` or `.claude`.

I will handle merging in the modeling skill and any other changes in a separate PR.