### PR TITLE
Refactor where we dynamically import peers

### DIFF
--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -1,11 +1,7 @@
-import type * as BigQueryTypes from '@google-cloud/bigquery'
+import {BigQuery, BigQueryDate, BigQueryTimestamp, type BigQueryOptions} from '@google-cloud/bigquery'
 
 import {config} from '../../lang/config.ts'
 import {type QueryConnection, type QueryResult, type SchemaColumn, type QueryParams} from './types.ts'
-
-type BigQueryModule = typeof BigQueryTypes
-type BigQueryClient = InstanceType<BigQueryModule['BigQuery']>
-type BigQueryOptions = ConstructorParameters<BigQueryModule['BigQuery']>[0]
 
 // BigQuery identifiers can contain letters, numbers, underscores, and hyphens
 function validateBigQueryIdent(ident: string) {
@@ -13,9 +9,7 @@ function validateBigQueryIdent(ident: string) {
 }
 
 export class BigQueryConnection implements QueryConnection {
-  private ready: Promise<void>
-  private client!: BigQueryClient
-  private module!: BigQueryModule
+  private readonly client: BigQuery
   private readonly projectId: string
   private readonly defaultNamespace?: string
 
@@ -23,17 +17,11 @@ export class BigQueryConnection implements QueryConnection {
     options.projectId ||= config.bigquery?.projectId
     if (!options.projectId) throw new Error('projectId must be set in config or provided in service account credentials')
     this.projectId = options.projectId
+    this.client = new BigQuery({...options, userAgent: 'Graphene'})
     this.defaultNamespace = config.defaultNamespace
-    this.ready = this.initialize(options)
-  }
-
-  private async initialize(options: BigQueryOptions) {
-    this.module = await loadBigQuery()
-    this.client = new this.module.BigQuery({...options, userAgent: 'Graphene'})
   }
 
   async runQuery(sql: string, params?: QueryParams): Promise<QueryResult> {
-    await this.ready
     let [job] = await this.client.createQueryJob({query: sql, useLegacySql: false, params})
     let [rows] = await job.getQueryResults({maxResults: 10000})
     let metadata = job.metadata || (await job.getMetadata())[0]
@@ -41,8 +29,8 @@ export class BigQueryConnection implements QueryConnection {
 
     rows.forEach(r => {
       Object.entries(r).forEach(([k, v]) => {
-        if (v instanceof this.module.BigQueryTimestamp) r[k] = v.value
-        if (v instanceof this.module.BigQueryDate) r[k] = v.value
+        if (v instanceof BigQueryTimestamp) r[k] = v.value
+        if (v instanceof BigQueryDate) r[k] = v.value
       })
     })
 
@@ -50,7 +38,6 @@ export class BigQueryConnection implements QueryConnection {
   }
 
   async listDatasets(): Promise<string[]> {
-    await this.ready
     let [datasets] = await this.client.getDatasets()
     return datasets.map(d => String(d.id || d.metadata.datasetReference?.datasetId || '').toLowerCase())
   }
@@ -92,11 +79,4 @@ export class BigQueryConnection implements QueryConnection {
   }
 
   async close(): Promise<void> {}
-}
-
-let bigQueryModule: BigQueryModule | null = null
-
-async function loadBigQuery(): Promise<BigQueryModule> {
-  bigQueryModule ||= await import('@google-cloud/bigquery')
-  return bigQueryModule
 }

--- a/cli/connections/clickhouse.ts
+++ b/cli/connections/clickhouse.ts
@@ -1,4 +1,4 @@
-import type * as ClickHouseTypes from '@clickhouse/client'
+import {createClient, type ClickHouseClient} from '@clickhouse/client'
 
 import {type QueryConnection, type QueryResult, type QueryParams, type SchemaColumn} from './types.ts'
 
@@ -9,22 +9,13 @@ export interface ClickHouseOptions {
   database?: string
 }
 
-type ClickHouseModule = typeof ClickHouseTypes
-type ClickHouseClient = ReturnType<ClickHouseModule['createClient']>
-
 export class ClickHouseConnection implements QueryConnection {
-  private ready: Promise<void>
-  private client!: ClickHouseClient
+  private client: ClickHouseClient
   private defaultDatabase: string
 
   constructor(options: ClickHouseOptions) {
     this.defaultDatabase = options.database || 'default'
-    this.ready = this.initialize(options)
-  }
-
-  private async initialize(options: ClickHouseOptions) {
-    let mod = await loadClickHouse()
-    this.client = mod.createClient({
+    this.client = createClient({
       url: options.url,
       username: options.username,
       password: options.password,
@@ -34,7 +25,6 @@ export class ClickHouseConnection implements QueryConnection {
   }
 
   async runQuery(sql: string, _params?: QueryParams): Promise<QueryResult> {
-    await this.ready
     let result = await this.client.query({query: sql, format: 'JSONEachRow'})
     let rows = (await result.json()) as Array<Record<string, unknown>>
     return {rows, totalRows: rows.length}
@@ -77,18 +67,10 @@ export class ClickHouseConnection implements QueryConnection {
   }
 
   async close(): Promise<void> {
-    await this.ready
     await this.client.close()
   }
 }
 
 function escapeClickHouseString(value: string) {
   return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
-}
-
-let clickhouseModule: ClickHouseModule | null = null
-
-async function loadClickHouse(): Promise<ClickHouseModule> {
-  clickhouseModule ||= await import('@clickhouse/client')
-  return clickhouseModule
 }

--- a/cli/connections/duckdb.ts
+++ b/cli/connections/duckdb.ts
@@ -1,5 +1,4 @@
-import type * as DuckDBTypes from '@duckdb/node-api'
-
+import {DuckDBTimestampValue, DuckDBInstance, DuckDBDateValue, DuckDBDecimalValue, type DuckDBConnection as InnerConnection} from '@duckdb/node-api'
 import {promises as fs} from 'fs'
 import path from 'path'
 
@@ -10,14 +9,10 @@ interface DuckDbOptions {
   path?: string
 }
 
-type DuckDBModule = typeof DuckDBTypes
-type InnerConnection = Awaited<ReturnType<InstanceType<DuckDBModule['DuckDBInstance']>['connect']>>
-
 export class DuckDBConnection implements QueryConnection {
   options: DuckDbOptions
   ready: Promise<void>
   connection: InnerConnection | null = null
-  module!: DuckDBModule
 
   constructor(options?: DuckDbOptions) {
     this.options = options || {}
@@ -25,7 +20,6 @@ export class DuckDBConnection implements QueryConnection {
   }
 
   private async initialize() {
-    this.module = await loadDuckDB()
     let dbPath = this.options.path || config.duckdb?.path
     if (!dbPath) {
       let files = await fs.readdir(config.root)
@@ -34,7 +28,7 @@ export class DuckDBConnection implements QueryConnection {
     }
     if (!path.isAbsolute(dbPath)) dbPath = path.resolve(config.root, dbPath)
 
-    let db = await this.module.DuckDBInstance.create(':memory:')
+    let db = await DuckDBInstance.create(':memory:')
     this.connection = await db.connect()
     let escapedPath = dbPath.replace(/'/g, "''")
     // Attach the project DuckDB file in read-only mode and make it the active schema
@@ -50,9 +44,9 @@ export class DuckDBConnection implements QueryConnection {
       for (let [k, v] of Object.entries(record)) {
         if (typeof v === 'bigint') out[k] = Number(v)
         else if (v === null) out[k] = null
-        else if (v instanceof this.module.DuckDBTimestampValue) out[k] = new Date(Number(v.micros / 1000n)).toUTCString()
-        else if (v instanceof this.module.DuckDBDateValue) out[k] = v.toString()
-        else if (v instanceof this.module.DuckDBDecimalValue) out[k] = v.toDouble()
+        else if (v instanceof DuckDBTimestampValue) out[k] = new Date(Number(v.micros / 1000n)).toUTCString()
+        else if (v instanceof DuckDBDateValue) out[k] = v.toString()
+        else if (v instanceof DuckDBDecimalValue) out[k] = v.toDouble()
         else if (typeof v === 'object') throw new Error(`Unsupported datatype ${v.constructor?.name}`)
         else out[k] = v
       }
@@ -98,11 +92,4 @@ export class DuckDBConnection implements QueryConnection {
     await this.ready
     this.connection?.closeSync()
   }
-}
-
-let duckdbModule: DuckDBModule | null = null
-
-async function loadDuckDB(): Promise<DuckDBModule> {
-  duckdbModule ||= await import('@duckdb/node-api')
-  return duckdbModule
 }

--- a/cli/connections/index.ts
+++ b/cli/connections/index.ts
@@ -4,19 +4,12 @@ import {config} from '../../lang/config.ts'
 import {authenticatedFetch} from '../auth.ts'
 import {type QueryResult, type QueryConnection, type QueryParams} from './types.ts'
 
-const warehouseClients = {
-  bigquery: '@google-cloud/bigquery',
-  clickhouse: '@clickhouse/client',
-  duckdb: '@duckdb/node-api',
-  snowflake: 'snowflake-sdk',
-} as const
-
 // Reads credentials from environment variables and passes them to the connection constructors.
 // The connection classes themselves have no env-reading logic — this keeps the cloud server
 // from accidentally picking up local env vars instead of database-stored credentials.
 export async function getConnection(): Promise<QueryConnection> {
   if (config.dialect === 'bigquery') {
-    let mod = await importWarehouseConnection(() => import('./bigQuery.ts'), warehouseClients.bigquery, 'BigQuery')
+    let mod = await import('./bigQuery.ts')
     let options: any = {}
     if (process.env.GOOGLE_CREDENTIALS_CONTENT) {
       // the actual json as an env var
@@ -29,10 +22,10 @@ export async function getConnection(): Promise<QueryConnection> {
     }
     return new mod.BigQueryConnection(options)
   } else if (config.dialect === 'duckdb') {
-    let mod = await importWarehouseConnection(() => import('./duckdb.ts'), warehouseClients.duckdb, 'DuckDB')
+    let mod = await import('./duckdb.ts')
     return new mod.DuckDBConnection({})
   } else if (config.dialect === 'clickhouse') {
-    let mod = await importWarehouseConnection(() => import('./clickhouse.ts'), warehouseClients.clickhouse, 'ClickHouse')
+    let mod = await import('./clickhouse.ts')
     let url = config.clickhouse?.url || process.env.CLICKHOUSE_URL
     let username = config.clickhouse?.username || process.env.CLICKHOUSE_USERNAME
     let password = process.env.CLICKHOUSE_PASSWORD
@@ -44,7 +37,7 @@ export async function getConnection(): Promise<QueryConnection> {
       database: config.clickhouse?.database || config.defaultNamespace || 'default',
     })
   } else if (config.dialect === 'snowflake') {
-    let mod = await importWarehouseConnection(() => import('./snowflake.ts'), warehouseClients.snowflake, 'Snowflake')
+    let mod = await import('./snowflake.ts')
     return new mod.SnowflakeConnection({
       privateKeyPath: process.env.SNOWFLAKE_PRI_KEY_PATH,
       privateKey: process.env.SNOWFLAKE_PRI_KEY,
@@ -54,21 +47,6 @@ export async function getConnection(): Promise<QueryConnection> {
   } else {
     throw new Error(`Unsupported dialect: ${config.dialect}`)
   }
-}
-
-async function importWarehouseConnection<T>(load: () => Promise<T>, packageName: string, warehouseLabel: string): Promise<T> {
-  try {
-    return await load()
-  } catch (err) {
-    if (!isMissingWarehouseClientError(err, packageName)) throw err
-    // eslint-disable-next-line preserve-caught-error
-    throw new Error(`${warehouseLabel} support requires installing ${packageName}. Add it to your project dependencies, for example: npm install ${packageName}`)
-  }
-}
-
-function isMissingWarehouseClientError(err: unknown, packageName: string): boolean {
-  let error = err as NodeJS.ErrnoException | undefined
-  return error?.code === 'ERR_MODULE_NOT_FOUND' && String(error.message || '').includes(packageName)
 }
 
 export async function runQuery(sql: string, params?: QueryParams): Promise<QueryResult> {

--- a/cli/connections/index.ts
+++ b/cli/connections/index.ts
@@ -9,7 +9,7 @@ import {type QueryResult, type QueryConnection, type QueryParams} from './types.
 // from accidentally picking up local env vars instead of database-stored credentials.
 export async function getConnection(): Promise<QueryConnection> {
   if (config.dialect === 'bigquery') {
-    let mod = await import('./bigQuery.ts')
+    let mod = await importConnection(() => import('./bigQuery.ts'), '@google-cloud/bigquery', 'BigQuery')
     let options: any = {}
     if (process.env.GOOGLE_CREDENTIALS_CONTENT) {
       // the actual json as an env var
@@ -22,10 +22,10 @@ export async function getConnection(): Promise<QueryConnection> {
     }
     return new mod.BigQueryConnection(options)
   } else if (config.dialect === 'duckdb') {
-    let mod = await import('./duckdb.ts')
+    let mod = await importConnection(() => import('./duckdb.ts'), '@duckdb/node-api', 'DuckDB')
     return new mod.DuckDBConnection({})
   } else if (config.dialect === 'clickhouse') {
-    let mod = await import('./clickhouse.ts')
+    let mod = await importConnection(() => import('./clickhouse.ts'), '@clickhouse/client', 'ClickHouse')
     let url = config.clickhouse?.url || process.env.CLICKHOUSE_URL
     let username = config.clickhouse?.username || process.env.CLICKHOUSE_USERNAME
     let password = process.env.CLICKHOUSE_PASSWORD
@@ -37,7 +37,7 @@ export async function getConnection(): Promise<QueryConnection> {
       database: config.clickhouse?.database || config.defaultNamespace || 'default',
     })
   } else if (config.dialect === 'snowflake') {
-    let mod = await import('./snowflake.ts')
+    let mod = await importConnection(() => import('./snowflake.ts'), 'snowflake-sdk', 'Snowflake')
     return new mod.SnowflakeConnection({
       privateKeyPath: process.env.SNOWFLAKE_PRI_KEY_PATH,
       privateKey: process.env.SNOWFLAKE_PRI_KEY,
@@ -46,6 +46,20 @@ export async function getConnection(): Promise<QueryConnection> {
     })
   } else {
     throw new Error(`Unsupported dialect: ${config.dialect}`)
+  }
+}
+
+// Import connection, with a nice error message about what to do if a peer dep is missing.
+async function importConnection<T>(load: () => Promise<T>, packageName: string, warehouseLabel: string): Promise<T> {
+  try {
+    return await load()
+  } catch (err: any) {
+    let depMissing = err.code == 'ERR_MODULE_NOT_FOUND' || (err.message || '').includes(packageName)
+    if (depMissing) {
+      throw new Error(`${warehouseLabel} support requires installing ${packageName}.\nAdd it to your project dependencies, for example:\nnpm install ${packageName}`, {cause: err})
+    } else {
+      throw err
+    }
   }
 }
 

--- a/cli/connections/snowflake.ts
+++ b/cli/connections/snowflake.ts
@@ -1,6 +1,5 @@
-import type * as SnowflakeTypes from 'snowflake-sdk'
-
 import {createPrivateKey} from 'node:crypto'
+import snowflake from 'snowflake-sdk'
 
 import {config} from '../../lang/config.ts'
 import {type QueryConnection, type QueryResult, type SchemaColumn, type QueryParams} from './types.ts'
@@ -14,9 +13,6 @@ interface SnowflakeOptions {
   logLevel?: string
 }
 
-type SnowflakeModule = typeof SnowflakeTypes
-type SnowflakeConnectionType = ReturnType<SnowflakeModule['createConnection']>
-
 // Raw notes on setting up a new user:
 // * create a `demouser` with a new `demorole`. It should have
 // That role needs `operate` and `usage` on a warehouse, and `usage` on the relevant db or schema
@@ -27,14 +23,13 @@ type SnowflakeConnectionType = ReturnType<SnowflakeModule['createConnection']>
 
 export class SnowflakeConnection implements QueryConnection {
   private ready: Promise<void>
-  private connection!: SnowflakeConnectionType
+  private connection!: snowflake.Connection
 
   constructor(opts: SnowflakeOptions) {
     this.ready = this.initialize(opts || {})
   }
 
   async initialize(opts: SnowflakeOptions) {
-    let snowflake = await loadSnowflake()
     let privateKeyPath = opts.privateKeyPath || config.snowflake?.privateKeyPath
 
     let authOptions: any = {}
@@ -160,14 +155,4 @@ export class SnowflakeConnection implements QueryConnection {
 function snowflakeIdent(value: string) {
   if (!value) throw new Error('Snowflake identifiers cannot be empty')
   return `"${value.replace(/"/g, '""')}"`
-}
-
-let snowflakeModule: SnowflakeModule | null = null
-
-async function loadSnowflake(): Promise<SnowflakeModule> {
-  if (!snowflakeModule) {
-    let mod = await import('snowflake-sdk')
-    snowflakeModule = ((mod as any).default || mod) as SnowflakeModule
-  }
-  return snowflakeModule
 }

--- a/cli/esbuild.mjs
+++ b/cli/esbuild.mjs
@@ -19,8 +19,11 @@ let makeAllPackagesExternalPlugin = {
 await build({
   // cli build
   entryPoints: [path.resolve(__dirname, 'cli.ts')],
-  outfile: path.resolve(__dirname, 'dist/cli/cli.js'), // the extra `/cli/` keeps deployed dev relative paths the same between cli and ui
+  outdir: path.resolve(__dirname, 'dist/cli'), // the extra `/cli/` keeps deployed dev relative paths the same between cli and ui
+  entryNames: '[name]',
+  chunkNames: '[name]-[hash]',
   bundle: true,
+  splitting: true,
   platform: 'node',
   format: 'esm',
   target: 'node20',


### PR DESCRIPTION
#256 made db sdks peer dependencies, which is great!

But for cloud, they're not peers, and having the async module loading in the connection classes is extra complexity that we don't need.

This is basically the same as #281, but I had an agent do a more targeted revert.