### PR TITLE
Error on unknown chart props

### DIFF
--- a/examples/ecomm/index.md
+++ b/examples/ecomm/index.md
@@ -28,10 +28,10 @@ from order_items select products.category, revenue, gross_profit, gross_margin_p
 from order_items select users.state, revenue, units_sold as units order by 2 desc limit 25
 ```
 
-<BarChart data="revenue_by_state" title="Top States by Revenue" x="state" y="revenue" swapXY="true" />
+<BarChart data="revenue_by_state" title="Top States by Revenue" x="revenue" y="state" />
 
 <Row>
-  <BarChart data="revenue_by_category" title="Revenue by Category" x="category" y="revenue" swapXY="true" />
+  <BarChart data="revenue_by_category" title="Revenue by Category" x="revenue" y="category" />
   <PieChart data="revenue_by_category" title="Category Revenue Share" category="category" value="revenue" />
 </Row>
 

--- a/examples/ecomm/product-explorer.md
+++ b/examples/ecomm/product-explorer.md
@@ -45,6 +45,6 @@ group by 1 order by 2 desc limit 20
 ```
 
 <Row>
-  <BarChart data="category_breakdown" title="Units by Category" x="category" y="units" swapXY="true"/>
+  <BarChart data="category_breakdown" title="Units by Category" x="units" y="category"/>
   <PieChart data="category_breakdown" title="Revenue Share by Category" category="category" value="revenue"/>
 </Row>

--- a/examples/flights/carrier_detail.md
+++ b/examples/flights/carrier_detail.md
@@ -154,7 +154,7 @@ select
 order by sort_key
 ```
 
-<BarChart data=delay_dist x=bucket y=flights sort="sort_key asc" title="Departure Delay Distribution" yFmt=num0 emptySet=warn />
+<BarChart data=delay_dist x=bucket y=flights sort="sort_key asc" title="Departure Delay Distribution" />
 
 ```sql fleet_aircraft
 from aircraft

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -124,8 +124,10 @@ class AnalysisSession implements Analyzer {
       navigation: {symbols: [], references: []},
       virtualContents: parsed.virtualContents,
       virtualToMarkdownOffset: parsed.virtualToMarkdownOffset,
+      parsedDiagnostics: parsed.diagnostics,
     } as FileInfo
     next.tree!.fileInfo = next
+    this.recordParsedDiagnostics(next, parsed.diagnostics || [])
     return next
   }
 
@@ -1491,6 +1493,29 @@ class AnalysisSession implements Analyzer {
     fi.tree!.topNode.cursor().iterate(node => {
       if (node.type.isError) this.diag(node.node, 'Syntax error')
     })
+  }
+
+  private recordParsedDiagnostics(fi: FileInfo, diagnostics: {message: string; from: number; to: number}[]) {
+    for (let diagnostic of diagnostics) {
+      let from = this.sourcePosition(diagnostic.from, fi)
+      let to = this.sourcePosition(diagnostic.to, fi)
+      this.diagnostics.push({severity: 'error', message: diagnostic.message, file: toRelativePath(fi.path), from, to, frame: buildFrame(from, to)})
+    }
+  }
+
+  private sourcePosition(offset: number, file: FileInfo) {
+    let lines = file.contents.split(/\r?\n/)
+    let acc = 0
+    for (let i = 0; i < lines.length; i++) {
+      let lineText = lines[i]
+      let nextAcc = acc + lineText.length + 1
+      if (offset < nextAcc || i === lines.length - 1) {
+        let col = Math.max(0, offset - acc)
+        return {offset, line: i, col, lineStart: acc, lineText}
+      }
+      acc = nextAcc
+    }
+    return {offset, line: 0, col: 0, lineText: ''}
   }
 
   diag<T>(node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -1650,6 +1650,52 @@ describe('lang', () => {
     )
   })
 
+  it('validates unquoted chart attributes and extracts splitBy and sort fields', () => {
+    expect(`
+      \`\`\`gsql test
+        from users select name, age, email, created_at
+      \`\`\`
+      <BarChart data=test x=name y=age splitBy=email sort="created_at asc" />
+    `).toRenderSql(
+      'with test as ( select users.name as name, users.age as age, users.email as email, users.created_at as created_at from users as users ) select test.name as name, test.age as age, test.email as email, test.created_at as created_at from test as test',
+    )
+
+    analyze('<BarChart data=users x=name y=age sort="name asc" />', 'md')
+    expect(getDiagnostics().filter(d => d.severity === 'error')).toEqual([])
+  })
+
+  it('reports unsupported chart wrapper props with migration hints', () => {
+    analyze('<BarChart data=users x=name y=age series=email />', 'md')
+    expect(getDiagnostics().some(d => /Unsupported prop "series" on BarChart\. Use splitBy instead\./.test(d.message))).toBe(true)
+
+    analyze('<AreaChart data=users x=name y=age type=stacked100 />', 'md')
+    expect(getDiagnostics().some(d => /Unsupported prop "type" on AreaChart\. Use arrange="stack100" instead\./.test(d.message))).toBe(true)
+
+    analyze('<PieChart data=users category=name value=age emptySet=warn />', 'md')
+    expect(getDiagnostics().some(d => /Unsupported prop "emptySet" on PieChart\. emptySet is not supported/.test(d.message))).toBe(true)
+  })
+
+  it('allows PieChart subtitle but rejects subtitle on other chart wrappers', () => {
+    analyze('<PieChart data=users category=name value=age subtitle="Age split" />', 'md')
+    expect(getDiagnostics().filter(d => d.severity === 'error')).toEqual([])
+
+    analyze('<BarChart data=users x=name y=age subtitle="Age split" />', 'md')
+    expect(getDiagnostics().some(d => /subtitle is only valid on PieChart/.test(d.message))).toBe(true)
+  })
+
+  it('ignores chart-looking tags inside fenced code blocks', () => {
+    expect(`
+      \`\`\`markdown
+      <BarChart data=users x=name y=age series=email />
+      \`\`\`
+    `).toHaveNoErrors()
+  })
+
+  it('does not validate LineChart y2 in markdown yet', () => {
+    analyze('<LineChart data=users x=name y=age y2=total_orders />', 'md')
+    expect(getDiagnostics().filter(d => d.severity === 'error')).toEqual([])
+  })
+
   it('handles params in a md code fence', () => {
     let queries = analyze('```gsql test\nfrom users where age > $cutoff\n```\n<BarChart data="test" x="name" y="avg(age)" />', 'md')
     let sql = toSql(queries[0], {cutoff: 20})

--- a/lang/markdown.ts
+++ b/lang/markdown.ts
@@ -1,6 +1,7 @@
 import type {ParsedFileArtifacts, ParsedFileDiagnostic, WorkspaceFileInput} from './types.ts'
 
 import {parser} from './parser.js'
+import {extractSveltishAttributes, type SveltishAttribute} from './sveltish.ts'
 
 // This parser turns Graphene md files into the equivalent gsql, and then parses that gsql.
 // Code fences are turned in to table definitions, while Component calls are turned into queries.
@@ -61,18 +62,9 @@ interface FenceMatch {
 interface ComponentMatch {
   start: number
   end: number
-  data: AttrMatch | null
-  attributes: Partial<Record<ComponentAttributeKey, AttrMatch>>
+  data: SveltishAttribute | null
+  attributes: Partial<Record<ComponentAttributeKey, SveltishAttribute>>
   diagnostics: ParsedFileDiagnostic[]
-}
-
-interface AttrMatch {
-  value: string
-  start: number
-  end: number
-  key: string
-  keyStart: number
-  keyEnd: number
 }
 
 export function parseMarkdown(file: WorkspaceFileInput): ParsedFileArtifacts {
@@ -161,7 +153,7 @@ export function parseMarkdown(file: WorkspaceFileInput): ParsedFileArtifacts {
       appendMapped(data.value, (i: number) => data.start + i, {reset: data.start - 1})
       appendMapped(' select ', () => component.start)
 
-      let previousAttr: AttrMatch | null = null
+      let previousAttr: SveltishAttribute | null = null
       let selectedValues = new Set<string>()
       for (let key of COMPONENT_ATTRIBUTE_KEYS) {
         let attribute = attributes[key]
@@ -231,8 +223,8 @@ function collectComponents(source: string, fences: FenceMatch[]): ComponentMatch
     let end = start + match[0].length
     if (isInsideFence(start, fences)) continue
     let componentName = match[1]
-    let attrs = extractAttributes(match[0], start)
-    let attributeMatches: Partial<Record<ComponentAttributeKey, AttrMatch>> = {}
+    let attrs = extractSveltishAttributes(match[0], start)
+    let attributeMatches: Partial<Record<ComponentAttributeKey, SveltishAttribute>> = {}
     for (let key of fieldAttributeKeys(componentName)) {
       if (attrs[key]) attributeMatches[key] = normalizeFieldAttribute(key, attrs[key])
     }
@@ -251,69 +243,7 @@ function extractFenceName(header: string): {name?: string; index?: number} {
   return {}
 }
 
-function extractAttributes(fragment: string, baseStart: number): Record<string, AttrMatch> {
-  let attrs: Record<string, AttrMatch> = {}
-
-  let name = fragment.match(/^<([A-Z][A-Za-z0-9]*)/)?.[1]
-  let i = name ? name.length + 1 : 1
-  while (i < fragment.length) {
-    while (/\s/.test(fragment[i] || '')) i++
-    if (!fragment[i] || fragment[i] == '/' || fragment[i] == '>') break
-
-    if (fragment[i] == '{') {
-      while (fragment[i] && fragment[i] != '}') i++
-      if (fragment[i] == '}') i++
-      continue
-    }
-
-    if (!/[\w:-]/.test(fragment[i])) {
-      i++
-      continue
-    }
-
-    let keyStart = i
-    while (/[\w:-]/.test(fragment[i] || '')) i++
-    let keyEnd = i
-    let key = fragment.slice(keyStart, keyEnd)
-
-    while (/\s/.test(fragment[i] || '')) i++
-
-    let value = 'true'
-    let valueStart = keyStart
-    let valueEnd = keyEnd
-    if (fragment[i] == '=') {
-      i++
-      while (/\s/.test(fragment[i] || '')) i++
-
-      let quote = fragment[i] == '"' || fragment[i] == "'" ? fragment[i] : ''
-      if (quote) {
-        i++
-        valueStart = i
-        while (fragment[i] && fragment[i] != quote) i++
-        valueEnd = i
-        value = fragment.slice(valueStart, valueEnd)
-        if (fragment[i] == quote) i++
-      } else {
-        valueStart = i
-        while (fragment[i] && !/\s/.test(fragment[i]) && fragment[i] != '/' && fragment[i] != '>') i++
-        valueEnd = i
-        value = fragment.slice(valueStart, valueEnd)
-      }
-    }
-
-    attrs[key] = {
-      value,
-      start: baseStart + valueStart,
-      end: baseStart + valueEnd,
-      key,
-      keyStart: baseStart + keyStart,
-      keyEnd: baseStart + keyEnd,
-    }
-  }
-  return attrs
-}
-
-function normalizeFieldAttribute(key: ComponentAttributeKey, attr: AttrMatch): AttrMatch {
+function normalizeFieldAttribute(key: ComponentAttributeKey, attr: SveltishAttribute): SveltishAttribute {
   if (key != 'sort') return attr
   let match = attr.value.match(/\S+/)
   if (!match) return attr
@@ -321,7 +251,7 @@ function normalizeFieldAttribute(key: ComponentAttributeKey, attr: AttrMatch): A
   return {...attr, value: match[0], start: attr.start + offset, end: attr.start + offset + match[0].length}
 }
 
-function validateChartProps(componentName: string, attrs: Record<string, AttrMatch>): ParsedFileDiagnostic[] {
+function validateChartProps(componentName: string, attrs: Record<string, SveltishAttribute>): ParsedFileDiagnostic[] {
   let allowed = CHART_PROPS[componentName]
   if (!allowed) return []
 
@@ -334,7 +264,7 @@ function validateChartProps(componentName: string, attrs: Record<string, AttrMat
   return diagnostics
 }
 
-function unsupportedPropHint(attr: AttrMatch) {
+function unsupportedPropHint(attr: SveltishAttribute) {
   if (attr.key == 'type' && attr.value == 'stacked100') return 'Use arrange="stack100" instead.'
   return OBSOLETE_PROP_MESSAGES[attr.key] || 'Use ECharts for custom chart configuration.'
 }

--- a/lang/markdown.ts
+++ b/lang/markdown.ts
@@ -1,4 +1,4 @@
-import type {ParsedFileArtifacts, WorkspaceFileInput} from './types.ts'
+import type {ParsedFileArtifacts, ParsedFileDiagnostic, WorkspaceFileInput} from './types.ts'
 
 import {parser} from './parser.js'
 
@@ -16,12 +16,36 @@ import {parser} from './parser.js'
 //
 // Only components with a `data` attribute get turned into queries, and only attributes in a static list are fields to select.
 
-const COMPONENT_ATTRIBUTE_KEYS = ['x', 'y', 'y2', 'series', 'value', 'category'] as const
+const COMPONENT_ATTRIBUTE_KEYS = ['x', 'y', 'y2', 'value', 'category', 'splitBy', 'sort'] as const
 type ComponentAttributeKey = (typeof COMPONENT_ATTRIBUTE_KEYS)[number]
+const DEFAULT_FIELD_ATTRIBUTE_KEYS: ComponentAttributeKey[] = ['x', 'y', 'y2', 'value', 'category']
+const COMPONENT_FIELD_ATTRIBUTE_KEYS: Record<string, ComponentAttributeKey[]> = {
+  BarChart: ['x', 'y', 'y2', 'splitBy', 'sort'],
+  AreaChart: ['x', 'y', 'splitBy', 'sort'],
+  PieChart: ['category', 'value'],
+  LineChart: ['x', 'y', 'y2', 'splitBy', 'sort'],
+}
 
-const GSQL_FENCE = /^([ \t]*)(`{3,})g?sql[^\n]*\n([\s\S]*?)^\1\2[ \t]*$/gim
+const FENCE = /^([ \t]*)(`{3,})([^\n]*)\n([\s\S]*?)^\1\2[ \t]*$/gim
 const COMPONENT_TAG = /<([A-Z][A-Za-z0-9]*)\s+(?:[^>"']|"[^"]*"|'[^']*')*\/>/g
-const ATTRIBUTE = /(\w+)="([^"]*)"/g
+
+const CHART_PROPS: Record<string, Set<string>> = {
+  BarChart: new Set(['data', 'x', 'y', 'y2', 'splitBy', 'arrange', 'label', 'sort', 'title', 'height', 'width']),
+  AreaChart: new Set(['data', 'x', 'y', 'splitBy', 'arrange', 'sort', 'title', 'height', 'width']),
+  PieChart: new Set(['data', 'category', 'value', 'title', 'subtitle', 'height', 'width']),
+}
+
+const OBSOLETE_PROP_MESSAGES: Record<string, string> = {
+  series: 'Use splitBy instead.',
+  chartAreaHeight: 'Use height instead.',
+  swapXY: 'Swap the x and y mappings for horizontal bars instead.',
+  xFmt: 'Use field metadata or ECharts for custom formatting.',
+  yFmt: 'Use field metadata or ECharts for custom formatting.',
+  y2Fmt: 'Use field metadata or ECharts for custom formatting.',
+  subtitle: 'subtitle is only valid on PieChart. Use ECharts for chart subtext.',
+  emptySet: 'emptySet is not supported on chart wrappers.',
+  emptyMessage: 'emptyMessage is not supported on chart wrappers.',
+}
 
 interface FenceMatch {
   start: number
@@ -29,6 +53,7 @@ interface FenceMatch {
   headerLength: number
   contentStart: number
   content: string
+  gsql: boolean
   name?: string
   nameStart?: number
 }
@@ -38,18 +63,25 @@ interface ComponentMatch {
   end: number
   data: AttrMatch | null
   attributes: Partial<Record<ComponentAttributeKey, AttrMatch>>
+  diagnostics: ParsedFileDiagnostic[]
 }
 
 interface AttrMatch {
   value: string
   start: number
+  end: number
+  key: string
+  keyStart: number
+  keyEnd: number
 }
 
 export function parseMarkdown(file: WorkspaceFileInput): ParsedFileArtifacts {
   let source = file.contents
   let fences = collectFences(source)
+  let gsqlFences = fences.filter(f => f.gsql)
   let components = collectComponents(source, fences)
-  let events = [...fences, ...components].sort((a, b) => a.start - b.start)
+  let events = [...gsqlFences, ...components].sort((a, b) => a.start - b.start)
+  let diagnostics = components.flatMap(component => component.diagnostics)
 
   let virtual: string[] = []
   let mapping: number[] = []
@@ -130,15 +162,18 @@ export function parseMarkdown(file: WorkspaceFileInput): ParsedFileArtifacts {
       appendMapped(' select ', () => component.start)
 
       let previousAttr: AttrMatch | null = null
+      let selectedValues = new Set<string>()
       for (let key of COMPONENT_ATTRIBUTE_KEYS) {
         let attribute = attributes[key]
         if (!attribute) continue
+        if (selectedValues.has(attribute.value)) continue
         if (previousAttr) {
           let prevEnd = previousAttr.start + previousAttr.value.length
           appendMapped(', ', () => prevEnd)
         }
         appendMapped(attribute.value, (i: number) => attribute.start + i, {reset: attribute.start - 1})
         previousAttr = attribute
+        selectedValues.add(attribute.value)
       }
 
       let lastAttr = previousAttr
@@ -163,23 +198,26 @@ export function parseMarkdown(file: WorkspaceFileInput): ParsedFileArtifacts {
     tree: parser.parse(doc),
     virtualContents: doc,
     virtualToMarkdownOffset: [...mapping, source.length],
+    diagnostics,
   }
 }
 
 function collectFences(source: string): FenceMatch[] {
   let matches: FenceMatch[] = []
-  GSQL_FENCE.lastIndex = 0
+  FENCE.lastIndex = 0
   let match: RegExpExecArray | null
-  while ((match = GSQL_FENCE.exec(source))) {
+  while ((match = FENCE.exec(source))) {
     let start = match.index ?? 0
     let full = match[0]
     let headerLength = full.indexOf('\n')
     if (headerLength === -1) continue
     headerLength += 1
-    let content = match[3] || ''
+    let language = (match[3] || '').trim().split(/\s+/)[0]?.toLowerCase()
+    let gsql = language == 'sql' || language == 'gsql'
+    let content = match[4] || ''
     let contentStart = start + headerLength
     let {name, index} = extractFenceName(full.slice(0, headerLength))
-    matches.push({start, end: start + full.length, headerLength, contentStart, content, name, nameStart: index == null ? undefined : start + index})
+    matches.push({start, end: start + full.length, headerLength, contentStart, content, gsql, name, nameStart: index == null ? undefined : start + index})
   }
   return matches
 }
@@ -192,14 +230,19 @@ function collectComponents(source: string, fences: FenceMatch[]): ComponentMatch
     let start = match.index ?? 0
     let end = start + match[0].length
     if (isInsideFence(start, fences)) continue
+    let componentName = match[1]
     let attrs = extractAttributes(match[0], start)
     let attributeMatches: Partial<Record<ComponentAttributeKey, AttrMatch>> = {}
-    for (let key of COMPONENT_ATTRIBUTE_KEYS) {
-      if (attrs[key]) attributeMatches[key] = attrs[key]
+    for (let key of fieldAttributeKeys(componentName)) {
+      if (attrs[key]) attributeMatches[key] = normalizeFieldAttribute(key, attrs[key])
     }
-    matches.push({start, end, data: attrs.data || null, attributes: attributeMatches})
+    matches.push({start, end, data: attrs.data || null, attributes: attributeMatches, diagnostics: validateChartProps(componentName, attrs)})
   }
   return matches
+}
+
+function fieldAttributeKeys(componentName: string): ComponentAttributeKey[] {
+  return COMPONENT_FIELD_ATTRIBUTE_KEYS[componentName] || DEFAULT_FIELD_ATTRIBUTE_KEYS
 }
 
 function extractFenceName(header: string): {name?: string; index?: number} {
@@ -210,15 +253,90 @@ function extractFenceName(header: string): {name?: string; index?: number} {
 
 function extractAttributes(fragment: string, baseStart: number): Record<string, AttrMatch> {
   let attrs: Record<string, AttrMatch> = {}
-  ATTRIBUTE.lastIndex = 0
-  let match: RegExpExecArray | null
-  while ((match = ATTRIBUTE.exec(fragment))) {
-    let key = match[1]
-    let value = match[2]
-    let valueStart = baseStart + match.index + key.length + 2
-    attrs[key] = {value, start: valueStart}
+
+  let name = fragment.match(/^<([A-Z][A-Za-z0-9]*)/)?.[1]
+  let i = name ? name.length + 1 : 1
+  while (i < fragment.length) {
+    while (/\s/.test(fragment[i] || '')) i++
+    if (!fragment[i] || fragment[i] == '/' || fragment[i] == '>') break
+
+    if (fragment[i] == '{') {
+      while (fragment[i] && fragment[i] != '}') i++
+      if (fragment[i] == '}') i++
+      continue
+    }
+
+    if (!/[\w:-]/.test(fragment[i])) {
+      i++
+      continue
+    }
+
+    let keyStart = i
+    while (/[\w:-]/.test(fragment[i] || '')) i++
+    let keyEnd = i
+    let key = fragment.slice(keyStart, keyEnd)
+
+    while (/\s/.test(fragment[i] || '')) i++
+
+    let value = 'true'
+    let valueStart = keyStart
+    let valueEnd = keyEnd
+    if (fragment[i] == '=') {
+      i++
+      while (/\s/.test(fragment[i] || '')) i++
+
+      let quote = fragment[i] == '"' || fragment[i] == "'" ? fragment[i] : ''
+      if (quote) {
+        i++
+        valueStart = i
+        while (fragment[i] && fragment[i] != quote) i++
+        valueEnd = i
+        value = fragment.slice(valueStart, valueEnd)
+        if (fragment[i] == quote) i++
+      } else {
+        valueStart = i
+        while (fragment[i] && !/\s/.test(fragment[i]) && fragment[i] != '/' && fragment[i] != '>') i++
+        valueEnd = i
+        value = fragment.slice(valueStart, valueEnd)
+      }
+    }
+
+    attrs[key] = {
+      value,
+      start: baseStart + valueStart,
+      end: baseStart + valueEnd,
+      key,
+      keyStart: baseStart + keyStart,
+      keyEnd: baseStart + keyEnd,
+    }
   }
   return attrs
+}
+
+function normalizeFieldAttribute(key: ComponentAttributeKey, attr: AttrMatch): AttrMatch {
+  if (key != 'sort') return attr
+  let match = attr.value.match(/\S+/)
+  if (!match) return attr
+  let offset = match.index ?? 0
+  return {...attr, value: match[0], start: attr.start + offset, end: attr.start + offset + match[0].length}
+}
+
+function validateChartProps(componentName: string, attrs: Record<string, AttrMatch>): ParsedFileDiagnostic[] {
+  let allowed = CHART_PROPS[componentName]
+  if (!allowed) return []
+
+  let diagnostics: ParsedFileDiagnostic[] = []
+  for (let attr of Object.values(attrs)) {
+    if (allowed.has(attr.key)) continue
+    let message = `Unsupported prop "${attr.key}" on ${componentName}. ${unsupportedPropHint(attr)}`
+    diagnostics.push({message, from: attr.keyStart, to: attr.keyEnd})
+  }
+  return diagnostics
+}
+
+function unsupportedPropHint(attr: AttrMatch) {
+  if (attr.key == 'type' && attr.value == 'stacked100') return 'Use arrange="stack100" instead.'
+  return OBSOLETE_PROP_MESSAGES[attr.key] || 'Use ECharts for custom chart configuration.'
 }
 
 function isInsideFence(offset: number, fences: FenceMatch[]) {

--- a/lang/sveltish.test.ts
+++ b/lang/sveltish.test.ts
@@ -1,0 +1,77 @@
+import {expect} from 'vitest'
+
+/// <reference types="vitest/globals" />
+import {extractSveltishAttributes, type SveltishAttribute} from './sveltish.ts'
+
+function attr(fragment: string, key: string, baseStart = 0) {
+  let result = extractSveltishAttributes(fragment, baseStart)[key]
+  expect(result, `expected ${key} to be extracted`).toBeTruthy()
+  return result
+}
+
+function expectAttr(fragment: string, actual: SveltishAttribute, expected: {key: string; value: string; baseStart?: number}) {
+  let baseStart = expected.baseStart || 0
+  let sourceValue = expected.value == 'true' ? expected.key : expected.value
+  expect(actual.key).toBe(expected.key)
+  expect(actual.value).toBe(expected.value)
+  expect(fragment.slice(actual.keyStart - baseStart, actual.keyEnd - baseStart)).toBe(expected.key)
+  expect(fragment.slice(actual.start - baseStart, actual.end - baseStart)).toBe(sourceValue)
+}
+
+describe('extractSveltishAttributes', () => {
+  it('extracts unquoted, double-quoted, single-quoted, and boolean attributes', () => {
+    let fragment = '<BarChart data=orders x="month" y=\'sum(revenue)\' label sort=rank />'
+    let attrs = extractSveltishAttributes(fragment, 0)
+
+    expect(Object.keys(attrs)).toEqual(['data', 'x', 'y', 'label', 'sort'])
+    expectAttr(fragment, attrs.data, {key: 'data', value: 'orders'})
+    expectAttr(fragment, attrs.x, {key: 'x', value: 'month'})
+    expectAttr(fragment, attrs.y, {key: 'y', value: 'sum(revenue)'})
+    expectAttr(fragment, attrs.label, {key: 'label', value: 'true'})
+    expectAttr(fragment, attrs.sort, {key: 'sort', value: 'rank'})
+  })
+
+  it('returns absolute offsets based on the markdown fragment start', () => {
+    let baseStart = 120
+    let fragment = '<BarChart data=sales_by_month x="month" y=revenue />'
+
+    expectAttr(fragment, attr(fragment, 'data', baseStart), {key: 'data', value: 'sales_by_month', baseStart})
+    expectAttr(fragment, attr(fragment, 'x', baseStart), {key: 'x', value: 'month', baseStart})
+    expectAttr(fragment, attr(fragment, 'y', baseStart), {key: 'y', value: 'revenue', baseStart})
+  })
+
+  it('allows whitespace around equals and stops unquoted values at the tag close', () => {
+    let fragment = '<Chart data = sales width = 500 height=320/>'
+    let attrs = extractSveltishAttributes(fragment, 0)
+
+    expectAttr(fragment, attrs.data, {key: 'data', value: 'sales'})
+    expectAttr(fragment, attrs.width, {key: 'width', value: '500'})
+    expectAttr(fragment, attrs.height, {key: 'height', value: '320'})
+  })
+
+  it('skips standalone Svelte expressions and spread props', () => {
+    let fragment = '<BarChart data=orders {...chartProps} {visible} x=month />'
+    let attrs = extractSveltishAttributes(fragment, 0)
+
+    expect(Object.keys(attrs)).toEqual(['data', 'x'])
+    expectAttr(fragment, attrs.data, {key: 'data', value: 'orders'})
+    expectAttr(fragment, attrs.x, {key: 'x', value: 'month'})
+  })
+
+  it('supports Svelte-style colon and dashed attribute names in the static subset', () => {
+    let fragment = '<Input data-test="brand-filter" bind:value=brand disabled />'
+    let attrs = extractSveltishAttributes(fragment, 0)
+
+    expectAttr(fragment, attrs['data-test'], {key: 'data-test', value: 'brand-filter'})
+    expectAttr(fragment, attrs['bind:value'], {key: 'bind:value', value: 'brand'})
+    expectAttr(fragment, attrs.disabled, {key: 'disabled', value: 'true'})
+  })
+
+  it('keeps the last value when the same static attribute appears more than once', () => {
+    let fragment = '<BarChart data=old data=new x=month />'
+    let attrs = extractSveltishAttributes(fragment, 0)
+
+    expectAttr(fragment, attrs.data, {key: 'data', value: 'new'})
+    expectAttr(fragment, attrs.x, {key: 'x', value: 'month'})
+  })
+})

--- a/lang/sveltish.ts
+++ b/lang/sveltish.ts
@@ -1,0 +1,92 @@
+export interface SveltishAttribute {
+  key: string
+  keyStart: number
+  keyEnd: number
+  value: string
+  start: number
+  end: number
+}
+
+/**
+ * Extract attributes from the self-closing Svelte-ish component tags we support in markdown.
+ *
+ * This is intentionally a small scanner rather than a full Svelte parser. The markdown analysis path
+ * only needs static attributes from tags like `<BarChart data=foo x="month" label />` so it can:
+ * - translate chart field props into virtual GSQL and map field errors back to the prop value
+ * - report unsupported wrapper props and underline the prop name
+ *
+ * A regex used to be enough when we only supported `key="value"`, but real markdown commonly uses
+ * unquoted props, single-quoted props, and boolean props. We also skip `{...}` / `{expr}` chunks so
+ * dynamic Svelte syntax does not get mistaken for a static attribute. This is not intended to validate
+ * arbitrary Svelte syntax; it just recognizes the static subset Graphene can analyze.
+ */
+export function extractSveltishAttributes(fragment: string, baseStart: number): Record<string, SveltishAttribute> {
+  let attrs: Record<string, SveltishAttribute> = {}
+
+  let name = fragment.match(/^<([A-Z][A-Za-z0-9]*)/)?.[1]
+  let i = name ? name.length + 1 : 1
+  while (i < fragment.length) {
+    i = skipWhitespace(fragment, i)
+    if (!fragment[i] || fragment[i] == '/' || fragment[i] == '>') break
+
+    if (fragment[i] == '{') {
+      i = skipSvelteExpression(fragment, i)
+      continue
+    }
+
+    if (!/[\w:-]/.test(fragment[i])) {
+      i++
+      continue
+    }
+
+    let key = readAttributeKey(fragment, i)
+    i = skipWhitespace(fragment, key.end)
+    let value = readAttributeValue(fragment, i, key.start, key.end)
+    i = value.next
+
+    attrs[key.value] = {
+      key: key.value,
+      keyStart: baseStart + key.start,
+      keyEnd: baseStart + key.end,
+      value: value.value,
+      start: baseStart + value.start,
+      end: baseStart + value.end,
+    }
+  }
+  return attrs
+}
+
+function skipWhitespace(fragment: string, i: number) {
+  while (/\s/.test(fragment[i] || '')) i++
+  return i
+}
+
+function skipSvelteExpression(fragment: string, i: number) {
+  while (fragment[i] && fragment[i] != '}') i++
+  return fragment[i] == '}' ? i + 1 : i
+}
+
+function readAttributeKey(fragment: string, start: number) {
+  let end = start
+  while (/[\w:-]/.test(fragment[end] || '')) end++
+  return {value: fragment.slice(start, end), start, end}
+}
+
+function readAttributeValue(fragment: string, i: number, keyStart: number, keyEnd: number) {
+  if (fragment[i] != '=') return {value: 'true', start: keyStart, end: keyEnd, next: i}
+
+  i = skipWhitespace(fragment, i + 1)
+  let quote = fragment[i] == '"' || fragment[i] == "'" ? fragment[i] : ''
+  if (!quote) return readUnquotedValue(fragment, i)
+
+  let start = i + 1
+  let end = start
+  while (fragment[end] && fragment[end] != quote) end++
+  return {value: fragment.slice(start, end), start, end, next: fragment[end] == quote ? end + 1 : end}
+}
+
+function readUnquotedValue(fragment: string, start: number) {
+  let end = start
+  while (fragment[end] && !/\s/.test(fragment[end]) && fragment[end] != '/' && fragment[end] != '>') end++
+  return {value: fragment.slice(start, end), start, end, next: end}
+}

--- a/lang/testHelpers.ts
+++ b/lang/testHelpers.ts
@@ -125,6 +125,7 @@ export function analyze(contents?: string, contentType?: 'gsql' | 'md') {
         tree: analyzed.tree!,
         virtualContents: analyzed.virtualContents,
         virtualToMarkdownOffset: analyzed.virtualToMarkdownOffset,
+        diagnostics: analyzed.parsedDiagnostics,
       },
     }
   })

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -38,6 +38,13 @@ export interface ParsedFileArtifacts {
   tree: Tree
   virtualContents?: string
   virtualToMarkdownOffset?: number[]
+  diagnostics?: ParsedFileDiagnostic[]
+}
+
+export interface ParsedFileDiagnostic {
+  message: string
+  from: number
+  to: number
 }
 
 export type {FieldType, FieldMeta, GrapheneError, Position, ScalarField, ArrayField, TimeGrain, TimeOrdinal}
@@ -350,4 +357,5 @@ export interface FileInfo {
   navigation: FileNavigation
   virtualContents?: string
   virtualToMarkdownOffset?: number[]
+  parsedDiagnostics?: ParsedFileDiagnostic[]
 }

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -74,6 +74,19 @@ from flights select 1 as origin, not_a_function() as explode
   )
 })
 
+test('check with mdFile reports unsupported chart wrapper props', async () => {
+  mockFileMap['mock.md'] = trimIndentation(`
+    \`\`\`sql chart_data
+    from flights select carrier, distance
+    \`\`\`
+    <BarChart data=chart_data x=carrier y=distance yFmt=num0 />
+  `)
+
+  let result = await check({fileArg: 'mock.md', log})
+  expect(result).toBe(false)
+  expect(outputLines()).toContain('ERROR: mock.md line 4: Unsupported prop "yFmt" on BarChart. Use field metadata or ECharts for custom formatting.')
+})
+
 test('cli run with md file reports runtime query errors', async ({server, page}) => {
   expectConsoleError('Failed to load resource')
   server.mockFile(


### PR DESCRIPTION
I think the most common issue I've had the agent run into is chart misconfiguration due to it passing non-existent props and thinking they are affecting the chart. This PR updates the check command to validate props/attributes passed to our chart wrappers, and includes some prop-specific diagnostics for some common cases (`x/yFmt`, `series` vs `splitBy`). I made these diagnostics errors though I could see a case for making them warnings.