### PR TITLE
Fix table colors to fit with new palette and theme

### DIFF
--- a/ui/component-utilities/themeStores.ts
+++ b/ui/component-utilities/themeStores.ts
@@ -27,10 +27,10 @@ const DEFAULT_THEME: Theme = {
     'base-300': '#e5e7eb',
     'base-content': '#1f2937',
     'base-content-muted': '#6b7280',
-    primary: '#2563eb',
-    positive: '#16a34a',
-    negative: '#dc2626',
-    warning: '#d97706',
+    primary: '#3D6B7E',
+    positive: '#87A68C',
+    negative: '#B87470',
+    warning: '#D4A94C',
   },
   colorPalettes: {
     default: DEFAULT_PALETTE,
@@ -92,6 +92,15 @@ export const resolveColorsObject = (input: Record<string, unknown> | string | un
   return readable(Object.fromEntries(entries))
 }
 
+// A single color makes a flat scale; expand to a bg→color gradient so heatmaps work.
+// Kept in sync with --color-bg in app.css; chroma.scale needs a real color (CSS vars don't work).
+const PAGE_BG = '#fafaf9'
+const finalizePalette = (values: string[]): string[] => {
+  if (values.length === 0) return DEFAULT_PALETTE
+  if (values.length === 1) return [PAGE_BG, values[0]]
+  return values
+}
+
 export const resolveColorPalette = (input: unknown): Readable<string[] | undefined> => {
   if (isReadable<string[] | undefined>(input)) return input
   if (input == null) return readable(DEFAULT_PALETTE)
@@ -104,7 +113,7 @@ export const resolveColorPalette = (input: unknown): Readable<string[] | undefin
       let parsed = parseJson(key)
       if (Array.isArray(parsed)) {
         let values = parsed.map(item => normalizeColor(item)).filter(Boolean) as string[]
-        return readable(values.length ? values : DEFAULT_PALETTE)
+        return readable(finalizePalette(values))
       }
     }
     if (key.includes(',')) {
@@ -112,15 +121,15 @@ export const resolveColorPalette = (input: unknown): Readable<string[] | undefin
         .split(',')
         .map(part => normalizeColor(part))
         .filter(Boolean) as string[]
-      return readable(values.length ? values : DEFAULT_PALETTE)
+      return readable(finalizePalette(values))
     }
     let normalized = normalizeColor(key)
-    return readable(normalized ? [normalized] : DEFAULT_PALETTE)
+    return readable(normalized ? finalizePalette([normalized]) : DEFAULT_PALETTE)
   }
 
   if (Array.isArray(input)) {
     let values = input.map(item => normalizeColor(item)).filter(Boolean) as string[]
-    return readable(values.length ? values : DEFAULT_PALETTE)
+    return readable(finalizePalette(values))
   }
 
   return readable(DEFAULT_PALETTE)

--- a/ui/component-utilities/themeStores.ts
+++ b/ui/component-utilities/themeStores.ts
@@ -92,12 +92,16 @@ export const resolveColorsObject = (input: Record<string, unknown> | string | un
   return readable(Object.fromEntries(entries))
 }
 
+const cssVar = (name: string): string | undefined => {
+  if (typeof document === 'undefined' || typeof getComputedStyle === 'undefined') return undefined
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || undefined
+}
+
 // A single color makes a flat scale; expand to a bg→color gradient so heatmaps work.
-// Kept in sync with --color-bg in app.css; chroma.scale needs a real color (CSS vars don't work).
-const PAGE_BG = '#fafaf9'
+// chroma.scale needs a real color, so resolve the CSS var before building the palette.
 const finalizePalette = (values: string[]): string[] => {
   if (values.length === 0) return DEFAULT_PALETTE
-  if (values.length === 1) return [PAGE_BG, values[0]]
+  if (values.length === 1) return [cssVar('--color-bg') ?? DEFAULT_THEME.colors['base-100'], values[0]]
   return values
 }
 

--- a/ui/components/InlineDelta.svelte
+++ b/ui/components/InlineDelta.svelte
@@ -71,7 +71,11 @@
     $theme.colors['base-content-muted'],
   ))
 
-  let chipClass = $derived(pickColor('delta-chip--positive', 'delta-chip--negative', 'delta-chip--neutral'))
+  let chipClass = $derived(pickColor(
+    downIsGood ? 'delta-chip--negative' : 'delta-chip--positive',
+    downIsGood ? 'delta-chip--positive' : 'delta-chip--negative',
+    'delta-chip--neutral',
+  ))
 
   let deltaClass = $derived((() => {
     let classes = ['delta']
@@ -143,13 +147,13 @@
   }
 
   .delta-chip--positive {
-    background: rgba(22, 163, 74, 0.1);
-    border-color: rgba(22, 163, 74, 0.2);
+    background: rgba(135, 166, 140, 0.15);
+    border-color: rgba(135, 166, 140, 0.3);
   }
 
   .delta-chip--negative {
-    background: rgba(220, 38, 38, 0.1);
-    border-color: rgba(220, 38, 38, 0.2);
+    background: rgba(184, 116, 112, 0.15);
+    border-color: rgba(184, 116, 112, 0.3);
   }
 
   .delta-chip--neutral {

--- a/ui/components/InlineDelta.svelte
+++ b/ui/components/InlineDelta.svelte
@@ -54,11 +54,6 @@
     return neutral
   }
 
-  let symbol = $derived((() => {
-    if (status === 'positive') return '▲'
-    if (status === 'negative') return '▼'
-    return '–'
-  })())
   let symbolColor = $derived(pickColor(
     downIsGood ? $theme.colors.negative : $theme.colors.positive,
     downIsGood ? $theme.colors.positive : $theme.colors.negative,
@@ -97,19 +92,33 @@
   }
 </script>
 
+{#snippet deltaSymbol()}
+  {#if showSymbol}
+    <span class="delta-symbol" style={`color:${symbolColor}`} aria-hidden="true">
+      {#if status === 'positive'}
+        <svg viewBox="0 0 16 16" focusable="false">
+          <path d="M8 3 14 13H2Z" fill="currentColor" />
+        </svg>
+      {:else if status === 'negative'}
+        <svg viewBox="0 0 16 16" focusable="false">
+          <path d="M2 3h12L8 13Z" fill="currentColor" />
+        </svg>
+      {:else}
+        <span class="delta-symbol__neutral">–</span>
+      {/if}
+    </span>
+  {/if}
+{/snippet}
+
 <span class={deltaClass} style={`text-align:${resolvedAlign}`}>
   {#if symbolPosition === 'left'}
-    {#if showSymbol}
-      <span class="delta-symbol" style={`color:${symbolColor}`}>{symbol}</span>
-    {/if}
+    {@render deltaSymbol()}
   {/if}
   {#if showValue}
     <span class="delta-value" style={`color:${textColor}`}>{renderValue()}</span>
   {/if}
   {#if symbolPosition === 'right'}
-    {#if showSymbol}
-      <span class="delta-symbol" style={`color:${symbolColor}`}>{symbol}</span>
-    {/if}
+    {@render deltaSymbol()}
   {/if}
   {#if text}
     <span class="delta-text">{text}</span>
@@ -129,6 +138,22 @@
   }
 
   .delta-symbol {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 0.75em;
+    height: 0.75em;
+    line-height: 1;
+    flex: 0 0 0.75em;
+  }
+
+  .delta-symbol svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .delta-symbol__neutral {
     font-size: 0.75em;
     line-height: 1;
   }

--- a/ui/components/TableHeader.svelte
+++ b/ui/components/TableHeader.svelte
@@ -68,7 +68,7 @@
       {#if rowNumbers}
         <th class={`header-index ${compact ? 'header-index--compact' : ''}`} style:background-color={headerColor}></th>
       {/if}
-      {#each columnsWithGroupSpan as column (column.id)}
+      {#each columnsWithGroupSpan as column (column.identifier ?? column.id)}
         {#if column.colGroup && column.isNewGroup}
           <th class="header-group" colspan={column.span}>
             <div class="header-group__label">{column.colGroup}</div>
@@ -92,7 +92,7 @@
         style:color={headerFontColor}
       ></th>
     {/if}
-    {#each orderedColumns as column (column.id)}
+    {#each orderedColumns as column (column.identifier ?? column.id)}
       <th
         role="columnheader"
         class={`header-cell ${column.type ?? ''} ${compact ? 'header-cell--compact' : ''}`}

--- a/ui/tests/snapshots/table.test.ts/colorscale-single-color-heatmap.png
+++ b/ui/tests/snapshots/table.test.ts/colorscale-single-color-heatmap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50accb5b8b16fbdd231312281c333eee6063170f9c79c80deab7d235bd85355b
+size 7943

--- a/ui/tests/snapshots/table.test.ts/delta-columns.png
+++ b/ui/tests/snapshots/table.test.ts/delta-columns.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3323340f8d2e85f32f8db99732f27fe0a1f884fd32d6bf5a4ca5b3dd9d5568cb
+size 10092

--- a/ui/tests/snapshots/table.test.ts/delta-columns.png
+++ b/ui/tests/snapshots/table.test.ts/delta-columns.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3323340f8d2e85f32f8db99732f27fe0a1f884fd32d6bf5a4ca5b3dd9d5568cb
-size 10092
+oid sha256:04cb389f9623e80dc1f0ec119726c8aaa0ee6d8b6d8e8f3685982965a520c92f
+size 10100

--- a/ui/tests/table.test.ts
+++ b/ui/tests/table.test.ts
@@ -106,6 +106,34 @@ test('colorscale with colorBreakpoints applies correct background colors', async
   await expect(component.locator('.table-container')).screenshot('colorscale-breakpoints')
 })
 
+test('delta columns render positive, negative, neutral, and down-is-good states', async ({mount}) => {
+  let rows = [
+    {metric: 'Revenue', change: 12, churn_change: -3, neutral_change: 0},
+    {metric: 'Costs', change: -7, churn_change: 4, neutral_change: 0.2},
+    {metric: 'Flat', change: 0, churn_change: 0, neutral_change: -0.2},
+  ]
+  let fields = [
+    {name: 'metric', type: 'string'},
+    {name: 'change', type: 'number'},
+    {name: 'churn_change', type: 'number'},
+    {name: 'neutral_change', type: 'number'},
+  ]
+
+  let component = await mount('components/TableHarness.svelte', {
+    data: {rows, fields},
+    tableProps: {rows: 'all'},
+    columns: [
+      {id: 'metric', title: 'Metric'},
+      {id: 'change', title: 'Change', contentType: 'delta'},
+      {id: 'churn_change', title: 'Churn', contentType: 'delta', downIsGood: true, chip: true},
+      {id: 'neutral_change', title: 'Within Band', contentType: 'delta', neutralMin: -0.5, neutralMax: 0.5, chip: true},
+    ],
+  })
+
+  await component.locator('table tr:has(td)').first().waitFor()
+  await expect(component.locator('.table-container')).screenshot('delta-columns')
+})
+
 test('single-color colorscale renders as a heatmap from the page background', async ({mount}) => {
   let rows = [
     {carrier: 'WN', score: 0.95},

--- a/ui/tests/table.test.ts
+++ b/ui/tests/table.test.ts
@@ -106,6 +106,32 @@ test('colorscale with colorBreakpoints applies correct background colors', async
   await expect(component.locator('.table-container')).screenshot('colorscale-breakpoints')
 })
 
+test('single-color colorscale renders as a heatmap from the page background', async ({mount}) => {
+  let rows = [
+    {carrier: 'WN', score: 0.95},
+    {carrier: 'AA', score: 0.72},
+    {carrier: 'UA', score: 0.48},
+    {carrier: 'AS', score: 0.24},
+    {carrier: 'B6', score: 0.05},
+  ]
+  let fields = [
+    {name: 'carrier', type: 'string'},
+    {name: 'score', type: 'number', metadata: {ratio: true}},
+  ]
+
+  let component = await mount('components/TableHarness.svelte', {
+    data: {rows, fields},
+    tableProps: {rows: 'all'},
+    columns: [
+      {id: 'carrier', title: 'Carrier'},
+      {id: 'score', title: 'Score', contentType: 'colorscale', colorScale: '#3D6B7E'},
+    ],
+  })
+
+  await component.locator('table tr:has(td)').first().waitFor()
+  await expect(component.locator('.table-container')).screenshot('colorscale-single-color-heatmap')
+})
+
 test('colorBreakpoints work when all column values are identical', async ({mount}) => {
   let rows = [
     {carrier: 'AA', val: 1},


### PR DESCRIPTION
- Map semantic names to Graphene colors
- Fix gradients with `colorScale` (they weren't working)
- Fix a bug where if two <Column>s pointed to the same id, the whole app broke
- Fix the "chip" style delta background color to respect `downIsGood`