### PR TITLE
make unknown prop check warn instead of error

### DIFF
--- a/cli/check.ts
+++ b/cli/check.ts
@@ -44,11 +44,13 @@ export async function check(options: CheckOptions): Promise<boolean> {
   }
 
   let result = analyzeWorkspace({config, files})
-  if (result.diagnostics.length > 0) {
-    printDiagnostics(result.diagnostics, log)
+  let errors = result.diagnostics.filter(diag => diag.severity !== 'warn')
+  if (errors.length) {
+    printDiagnostics(errors, log)
     return false
   }
 
+  if (result.diagnostics.length > 0) printDiagnostics(result.diagnostics, log)
   log('No errors found 💎')
   return true
 }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -241,10 +241,12 @@ function getExistingPath(arg: string | undefined): string | null {
 }
 
 function validateInputQuery(analysis: AnalysisResult, exit: (code?: number) => never): Query[] {
-  if (analysis.diagnostics.length) {
-    printDiagnostics(analysis.diagnostics)
+  let errors = analysis.diagnostics.filter(diag => diag.severity !== 'warn')
+  if (errors.length) {
+    printDiagnostics(errors)
     return exit(1)
   }
+  if (analysis.diagnostics.length) printDiagnostics(analysis.diagnostics)
 
   let queries = getFile(analysis, 'input')?.queries || []
   if (queries.length == 0) {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -49,30 +49,33 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
   }
 
   let result = analyzeWorkspace({config, files: files.filter(file => file.path != mdFile).concat({path: mdFile, contents: mdContents, kind: 'md'})}, mdFile)
-  if (result.diagnostics.length > 0) {
-    printDiagnostics(result.diagnostics, log)
+  let analysisErrors = result.diagnostics.filter(diag => diag.severity !== 'warn')
+  if (analysisErrors.length) {
+    printDiagnostics(analysisErrors, log)
     return false
   }
+  if (result.diagnostics.length > 0) printDiagnostics(result.diagnostics, log)
 
   let resp = await sendSocketRequest({mdFile, action: 'check', chart: options.chart, log})
   if (!resp) return false
 
-  let errors = Array.from(resp.errors || []) as GrapheneError[]
+  let reports = Array.from(resp.errors || []) as GrapheneError[]
+  let errors = reports.filter(e => e.severity !== 'warn')
+  let warnings = reports.filter(e => e.severity === 'warn')
   let chartNotFound = !!options.chart && !resp.screenshot
   if (chartNotFound) log(`Could not find chart "${options.chart}" on ${mdFile}`)
 
   if (errors.length) {
     log(styleText('red', 'Runtime errors') + ` in ${mdFile}:`)
-  } else if (!chartNotFound) {
-    log('No errors found 💎')
+    errors.forEach((e: GrapheneError) => printRuntimeReport(e, log))
   }
 
-  errors.forEach((e: GrapheneError) => {
-    if (e.file || e.frame) printDiagnostics([e], log)
-    else if (isComponentPropError(e)) log(`${e.queryId}: ${e.message}`)
-    else if (e.queryId) log(`Query (${e.queryId}): ${e.message}`)
-    else log(e.message)
-  })
+  if (warnings.length) {
+    log(styleText('yellow', 'Runtime warnings') + ` in ${mdFile}:`)
+    warnings.forEach((e: GrapheneError) => printRuntimeReport(e, log))
+  } else if (!errors.length && !chartNotFound) {
+    log('No errors found 💎')
+  }
 
   if (resp?.stillLoading) {
     log('Warning: Queries were still loading when the screenshot was taken')
@@ -87,6 +90,13 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
   }
 
   return errors.length == 0 && !chartNotFound
+}
+
+function printRuntimeReport(e: GrapheneError, log: (...args: any[]) => void) {
+  if (e.file || e.frame) printDiagnostics([e], log)
+  else if (isComponentPropError(e)) log(`${e.queryId}: ${e.message}`)
+  else if (e.queryId) log(`Query (${e.queryId}): ${e.message}`)
+  else log(e.message)
 }
 
 function isComponentPropError(e: GrapheneError) {
@@ -105,8 +115,9 @@ export async function listMdFileQueries(mdArg: string, telemetry?: CliTelemetry,
   let mdContents = process.env.NODE_ENV == 'test' && mockFileMap[mdFile] ? mockFileMap[mdFile] : readFileSync(path.resolve(config.root, mdFile), 'utf-8')
 
   let result = analyzeWorkspace({config, files: files.filter(file => file.path != mdFile).concat({path: mdFile, contents: mdContents, kind: 'md'})}, mdFile)
-  if (result.diagnostics.length > 0) {
-    printDiagnostics(result.diagnostics, log)
+  let errors = result.diagnostics.filter(diag => diag.severity !== 'warn')
+  if (errors.length) {
+    printDiagnostics(errors, log)
     return false
   }
 
@@ -126,16 +137,18 @@ export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: str
   let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
 
   let result = analyzeWorkspace({config, files: files.filter(file => file.path != mdRelativePath).concat({path: mdRelativePath, contents: mdContents, kind: 'md'})}, mdRelativePath)
-  if (result.diagnostics.length > 0) {
-    printDiagnostics(result.diagnostics)
+  let errors = result.diagnostics.filter(diag => diag.severity !== 'warn')
+  if (errors.length) {
+    printDiagnostics(errors)
     return false
   }
 
   let runQueryFence = [mdContents, '', '```sql', `from ${queryName} select *`, '```'].join('\n')
   let queryFiles = toWorkspaceFiles(result)
   let queryResult = analyzeWorkspace({config, files: queryFiles.filter(file => file.path != 'input.md').concat({path: 'input.md', contents: runQueryFence, kind: 'md'})}, 'input.md')
-  if (queryResult.diagnostics.length > 0) {
-    printDiagnostics(queryResult.diagnostics)
+  let queryErrors = queryResult.diagnostics.filter(diag => diag.severity !== 'warn')
+  if (queryErrors.length) {
+    printDiagnostics(queryErrors)
     return false
   }
 

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -159,9 +159,10 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
   updateParsedFiles(result)
 
   let diagnostics = result.diagnostics
-  if (diagnostics.length) {
+  let errors = diagnostics.filter(diag => diag.severity !== 'warn')
+  if (errors.length) {
     res.statusCode = 400
-    res.end(JSON.stringify(diagnostics[0]))
+    res.end(JSON.stringify(errors[0]))
     return
   }
 

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -1495,11 +1495,11 @@ class AnalysisSession implements Analyzer {
     })
   }
 
-  private recordParsedDiagnostics(fi: FileInfo, diagnostics: {message: string; from: number; to: number}[]) {
+  private recordParsedDiagnostics(fi: FileInfo, diagnostics: {message: string; from: number; to: number; severity?: 'error' | 'warn'}[]) {
     for (let diagnostic of diagnostics) {
       let from = this.sourcePosition(diagnostic.from, fi)
       let to = this.sourcePosition(diagnostic.to, fi)
-      this.diagnostics.push({severity: 'error', message: diagnostic.message, file: toRelativePath(fi.path), from, to, frame: buildFrame(from, to)})
+      this.diagnostics.push({severity: diagnostic.severity || 'error', message: diagnostic.message, file: toRelativePath(fi.path), from, to, frame: buildFrame(from, to)})
     }
   }
 

--- a/lang/markdown.ts
+++ b/lang/markdown.ts
@@ -238,7 +238,7 @@ function validateChartProps(componentName: string, attrs: Record<string, Sveltis
   let propValues = Object.fromEntries(Object.values(attrs).map(attr => [attr.key, attr.value]))
   return unsupportedChartProps(componentName, propValues).map(unsupported => {
     let attr = attrs[unsupported.prop]
-    return {message: unsupported.message, from: attr.keyStart, to: attr.keyEnd}
+    return {severity: 'warn', message: unsupported.message, from: attr.keyStart, to: attr.keyEnd}
   })
 }
 

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -45,6 +45,7 @@ export interface ParsedFileDiagnostic {
   message: string
   from: number
   to: number
+  severity?: 'error' | 'warn'
 }
 
 export type {FieldType, FieldMeta, GrapheneError, Position, ScalarField, ArrayField, TimeGrain, TimeOrdinal}

--- a/ui/internal/telemetry.ts
+++ b/ui/internal/telemetry.ts
@@ -23,12 +23,16 @@ export function logError(error: unknown, ctx?: Partial<GrapheneError>) {
   staticErrors.push({message: err.message, stack: err.stack, ...ctx})
 }
 
+export function logWarning(message: string, ctx?: Partial<GrapheneError>) {
+  staticErrors.push({severity: 'warn', message, ...ctx})
+}
+
 // Shared helper for logging when a svelte component is given props it did not expect.
 export function logExtraProps(componentName: string, data: unknown, props: Record<string, unknown>) {
   let queryId = typeof data == 'string' ? `${componentName} (data="${data}")` : componentName
   let internalProps = new Set(['children', '$$slots', '$$events', '$$legacy'])
   for (let prop of Object.keys(props)) {
-    if (!internalProps.has(prop)) logError(`Unsupported prop "${prop}" on ${componentName}.`, {queryId})
+    if (!internalProps.has(prop)) logWarning(`Unsupported prop "${prop}" on ${componentName}.`, {queryId})
   }
 }
 

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -74,7 +74,7 @@ from flights select 1 as origin, not_a_function() as explode
   )
 })
 
-test('check with mdFile reports unsupported chart wrapper props', async () => {
+test('check with mdFile warns about unsupported chart wrapper props', async () => {
   mockFileMap['mock.md'] = trimIndentation(`
     \`\`\`sql chart_data
     from flights select carrier, distance
@@ -83,11 +83,29 @@ test('check with mdFile reports unsupported chart wrapper props', async () => {
   `)
 
   let result = await check({fileArg: 'mock.md', log})
-  expect(result).toBe(false)
-  expect(outputLines()).toContain('ERROR: mock.md line 4: Unsupported prop "yFmt" on BarChart. Use field metadata or ECharts for custom formatting.')
+  expect(result).toBe(true)
+  expect(outputLines()).toContain('WARN: mock.md line 4: Unsupported prop "yFmt" on BarChart. Use field metadata or ECharts for custom formatting.')
+  expect(outputLines()).toContain('No errors found 💎')
 })
 
-test('cli run with md file reports dynamic unsupported chart wrapper props', async ({server, page}) => {
+test('page renders charts with unsupported static chart props', async ({server, page}) => {
+  server.mockFile(
+    '/index.md',
+    `
+    # Static Chart Prop Warning
+    \`\`\`sql chart_data
+    from flights select carrier, distance limit 25
+    \`\`\`
+    <BarChart data="chart_data" x="carrier" y="distance" yFmt="num0" />
+  `,
+  )
+
+  await page.goto(server.url())
+  await page.evaluate(() => window.$GRAPHENE.waitForLoad())
+  await expect(page.locator('.echarts')).toBeVisible()
+})
+
+test('cli run with md file warns about dynamic unsupported chart wrapper props', async ({server, page}) => {
   server.mockFile(
     '/index.md',
     `
@@ -101,17 +119,17 @@ test('cli run with md file reports dynamic unsupported chart wrapper props', asy
 
   await page.goto(server.url())
   let result = await runMdFile({mdArg: 'index.md', log})
-  expect(result).toBe(false)
+  expect(result).toBe(true)
   expect(outputLines()).toEqual(
     trimIndentation(`
-    Runtime errors in index.md:
+    Runtime warnings in index.md:
     BarChart (data="chart_data"): Unsupported prop "yFmt" on BarChart.
     Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
   `),
   )
 })
 
-test('cli run with md file reports dynamic unsupported ECharts top-level props', async ({server, page}) => {
+test('cli run with md file warns about dynamic unsupported ECharts top-level props', async ({server, page}) => {
   server.mockFile(
     '/index.md',
     `
@@ -130,17 +148,17 @@ test('cli run with md file reports dynamic unsupported ECharts top-level props',
 
   await page.goto(server.url())
   let result = await runMdFile({mdArg: 'index.md', log})
-  expect(result).toBe(false)
+  expect(result).toBe(true)
   expect(outputLines()).toEqual(
     trimIndentation(`
-    Runtime errors in index.md:
+    Runtime warnings in index.md:
     ECharts (data="chart_data"): Unsupported prop "chartAreaHeight" on ECharts.
     Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
   `),
   )
 })
 
-test('cli run with md file reports multiple dynamic unsupported chart props', async ({server, page}) => {
+test('cli run with md file warns about multiple dynamic unsupported chart props', async ({server, page}) => {
   server.mockFile(
     '/index.md',
     `
@@ -154,10 +172,10 @@ test('cli run with md file reports multiple dynamic unsupported chart props', as
 
   await page.goto(server.url())
   let result = await runMdFile({mdArg: 'index.md', log})
-  expect(result).toBe(false)
+  expect(result).toBe(true)
   expect(outputLines()).toEqual(
     trimIndentation(`
-    Runtime errors in index.md:
+    Runtime warnings in index.md:
     BarChart (data="chart_data"): Unsupported prop "yFmt" on BarChart.
     BarChart (data="chart_data"): Unsupported prop "emptySet" on BarChart.
     Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
@@ -189,8 +207,9 @@ test('cli run with md file reports runtime chart prop and render errors together
   expect(outputLines()).toEqual(
     trimIndentation(`
     Runtime errors in index.md:
-    ECharts (data="chart_data"): Unsupported prop "chartAreaHeight" on ECharts.
     Query (data="chart_data" x="x_value" y="bad_category"): Horizontal charts do not support a value or time-based x-axis
+    Runtime warnings in index.md:
+    ECharts (data="chart_data"): Unsupported prop "chartAreaHeight" on ECharts.
     Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
   `),
   )


### PR DESCRIPTION
This PR updates the unknown prop checking from #331 to make extra props warnings instead of errors, and prevents them from blocking chart rendering