### PR TITLE
Avoid splitting an attr if the comma is in a function call.

### DIFF
--- a/ui/component-utilities/inputUtils.ts
+++ b/ui/component-utilities/inputUtils.ts
@@ -25,16 +25,51 @@ export function serializeValue(value: unknown): string {
 }
 
 // Parse a comma-separated list into an array of trimmed strings.
-// - Strings are split on commas; whitespace trimmed; empty entries removed.
+// - Strings are split on top-level commas, ignoring commas inside calls and quoted strings.
 // - Arrays are normalized by trimming string items and String()-ing non-strings.
 // - null/undefined -> []
 export function parseCommaList(value: unknown): string[] {
   if (value === undefined || value === null) return []
   if (Array.isArray(value)) return value.map(v => (typeof v === 'string' ? v.trim() : String(v))).filter(v => v.length > 0)
-  if (typeof value === 'string')
-    return value
-      .split(',')
-      .map(v => v.trim())
-      .filter(v => v.length > 0)
-  return [String(value).trim()].filter(v => v.length > 0)
+  if (typeof value !== 'string') return [String(value).trim()].filter(v => v.length > 0)
+
+  let parts: string[] = []
+  let current = ''
+  let quote: string | undefined
+  let depth = 0
+
+  for (let i = 0; i < value.length; i++) {
+    let char = value[i]
+
+    if (quote) {
+      current += char
+      if (char === quote) {
+        if (quote === "'" && value[i + 1] === "'") current += value[++i]
+        else quote = undefined
+      }
+      continue
+    }
+
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char
+      current += char
+      continue
+    }
+
+    if (char === '(' || char === '[' || char === '{') depth++
+    if ((char === ')' || char === ']' || char === '}') && depth > 0) depth--
+
+    if (char === ',' && depth === 0) {
+      let trimmed = current.trim()
+      if (trimmed) parts.push(trimmed)
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  let trimmed = current.trim()
+  if (trimmed) parts.push(trimmed)
+  return parts
 }

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-expression-fields-with-commas.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-expression-fields-with-commas.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d98dfc73fc4c715bdc63902188d2cc8dbaa16b4a2a69681d878c10fa1c838b9d
+size 7314

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -124,6 +124,23 @@ test('bar chart supports multiple y fields', async ({mount, chart}) => {
   await expect(chart.el).screenshot('bar-chart-multiple-y')
 })
 
+test('bar chart supports expression fields with commas', async ({mount, chart}) => {
+  let data = {
+    rows: [
+      {"date_trunc('month', dep_time)": '2024-01-01', 'count()': 10},
+      {"date_trunc('month', dep_time)": '2024-02-01', 'count()': 14},
+      {"date_trunc('month', dep_time)": '2024-03-01', 'count()': 8},
+    ],
+    fields: [
+      {name: "date_trunc('month', dep_time)", type: scalarType('date'), metadata: {timeGrain: 'month'}},
+      {name: 'count()', type: scalarType('number'), metadata: {units: 'count'}},
+    ],
+  }
+
+  await mount('components/BarChart.svelte', {data, x: "date_trunc('month', dep_time)", y: 'count()', title: 'Monthly Flights'})
+  await expect(chart.el).screenshot('bar-chart-expression-fields-with-commas')
+})
+
 test('bar chart formats very small values on y axis', async ({mount, chart}) => {
   let data = singleDim()
   data.rows = data.rows.map(row => ({...row, value: row.value / 1e12}))


### PR DESCRIPTION
`x="date_trunc('month', dep_time)"` was being interpreted by charts as two columns to plot: `date_trunc('month'` and `dep_time)"`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>