### PR TITLE
ensure no newline before SKILL.md frontmatter

### DIFF
--- a/cli/esbuild.mjs
+++ b/cli/esbuild.mjs
@@ -54,7 +54,7 @@ Consult the reference documentation for more detailed information on using Graph
 For semantic modeling with GSQL references, read \`references/model-gsql.md\`.
 
 ${(await readdir(path.resolve(__dirname, '../docs/references'))).map(f => `- references/${f}`).join('\n')}
-`,
+`.trimStart(),
 )
 await cp(path.resolve(__dirname, '../docs/references'), path.resolve(skillDir, 'references'), {recursive: true})
 await cp(path.resolve(__dirname, '../ui'), path.resolve(__dirname, 'dist/ui'), {recursive: true})


### PR DESCRIPTION
Codex won't parse the skill if there's a newline before the frontmatter

<img width="896" height="67" alt="Screenshot 2026-05-01 at 7 46 36 PM" src="https://github.com/user-attachments/assets/0729e398-7df8-494f-84f6-5562ec6e87a5" />
