### PR TITLE
rename create package and prepare for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Publish
 # commit has been merged to main. I chose to run this on push instead of on pull_request close to make it a bit
 # safer, but it means our logic to detect publishes is a little more complex.
 # In a nutshell, we need the commit to have [release] in the message, and then we check if there is a tag already for
-# the version in cli/package.json.
+# the version in package.json.
 # The publish runs on the exact sha in the PR, _not_ whatever is on main, ensuring we don't inadvertantly publish changes.
 
 on:
@@ -51,16 +51,16 @@ jobs:
             if (!pr) throw new Error('Missing PR')
 
             core.setOutput('pr_number', String(pr.number))
-            let pkg = await github.rest.repos.getContent({owner: context.repo.owner, repo: context.repo.repo, path: 'cli/package.json', ref: `refs/pull/${pr.number}/head`})
+            let pkg = await github.rest.repos.getContent({owner: context.repo.owner, repo: context.repo.repo, path: 'package.json', ref: `refs/pull/${pr.number}/head`})
 
             if (Array.isArray(pkg.data) || pkg.data.type !== 'file' || !pkg.data.content) {
-              throw new Error('Could not read cli/package.json from PR head commit')
+              throw new Error('Could not read package.json from PR head commit')
             }
 
             let raw = Buffer.from(pkg.data.content, 'base64').toString('utf8')
             let version = JSON.parse(raw).version
             if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
-              throw new Error(`Invalid version in cli/package.json: ${version}`)
+              throw new Error(`Invalid version in package.json: ${version}`)
             }
 
             let tagName = `v${version}`
@@ -79,7 +79,7 @@ jobs:
             let shouldRelease = !tagExists
             // core.info(`changed files: ${changed.join(', ')}`)
             core.info(`merged PR: #${pr.number}`)
-            core.info(`cli version: ${version}`)
+            core.info(`release version: ${version}`)
             core.info(`tag ${tagName} exists: ${tagExists}`)
             core.info(`should release: ${shouldRelease}`)
             core.setOutput('should_release', shouldRelease ? 'true' : 'false')

--- a/create/README.md
+++ b/create/README.md
@@ -1,7 +1,7 @@
-# `@graphenedata/create`
+# `create-graphene`
 
 Scaffolds a new Graphene project.
 
 ```bash
-npm create @graphenedata
+npm create graphene
 ```

--- a/create/create.ts
+++ b/create/create.ts
@@ -285,7 +285,7 @@ export async function writeTemplate(targetDir: string, files: TemplateFiles): Pr
 function printHelp(stdout: Writable): void {
   stdout.write(
     [
-      'Usage: npm create @graphenedata [target-dir] [-- --yes] [--name <project-name>] [--no-install]',
+      'Usage: npm create graphene [target-dir] [-- --yes] [--name <project-name>] [--no-install]',
       '',
       'Options:',
       '  -y, --yes        Skip prompts and accept defaults',

--- a/create/dev.sh
+++ b/create/dev.sh
@@ -21,7 +21,7 @@ echo "Running packed initializer interactively..."
 
 if ! (
   cd "$temp_root" &&
-    npm exec --yes --package "$tarball_path" -- create-graphenedata "$@"
+    npm exec --yes --package "$tarball_path" -- create-graphene "$@"
 ); then
   rm -f "$tarball_path"
   echo ""

--- a/create/package.json
+++ b/create/package.json
@@ -1,10 +1,15 @@
 {
-  "name": "@graphenedata/create",
-  "version": "0.0.15",
+  "name": "create-graphene",
+  "version": "0.0.16",
   "license": "Elastic-2.0",
   "author": "Graphene Systems Inc",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/graphene-data/graphene.git",
+    "directory": "create"
+  },
   "bin": {
-    "create-graphenedata": "./bin.js"
+    "create-graphene": "./bin.js"
   },
   "files": [
     "bin.js",

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -124,7 +124,7 @@ To set up Graphene on a BigQuery connection you will need the following:
 Run the Graphene installer with npm, yarn, or pnpm:
 
 ```bash
-npm create @graphenedata
+npm create graphene
 ```
 
 The installer will walk you through a short series of prompts:

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -13,12 +13,13 @@ $.shell = 'bash'
 if (!process.env.VSCE_PAT) throw new Error('VSCE_PAT required')
 if (!process.env.OVSX_PAT) throw new Error('OVSX_PAT required')
 
-// package.json is authoritative for release version; cli/vscode must match exactly.
+// package.json is authoritative for release version; published packages must match exactly.
 let rootVersion = await readVersion('package.json')
 let cliVersion = await readVersion('cli/package.json')
 let vscodeVersion = await readVersion('vscode/package.json')
-if (rootVersion !== cliVersion || rootVersion !== vscodeVersion) {
-  throw new Error(`Version mismatch: package=${rootVersion}, cli=${cliVersion}, vscode=${vscodeVersion}`)
+let createVersion = await readVersion('create/package.json')
+if (rootVersion !== cliVersion || rootVersion !== vscodeVersion || rootVersion !== createVersion) {
+  throw new Error(`Version mismatch: package=${rootVersion}, cli=${cliVersion}, vscode=${vscodeVersion}, create=${createVersion}`)
 }
 
 let tag = `v${rootVersion}`
@@ -35,6 +36,9 @@ if (remoteTag) throw new Error(`Tag ${tag} already exists on origin`)
 let existingRelease = (await $`gh release view ${tag}`.nothrow()).exitCode === 0
 if (existingRelease) throw new Error(`GitHub release ${tag} already exists`)
 
+let existingCreatePackage = (await $`npm view create-graphene@${rootVersion} version`.nothrow()).exitCode === 0
+if (existingCreatePackage) throw new Error(`create-graphene@${rootVersion} already exists on npm`)
+
 // Tag first so package registries and GitHub release all point to the same immutable version marker.
 await $`git tag ${tag}`
 await $`git push origin ${tag}`
@@ -42,6 +46,8 @@ await $`git push origin ${tag}`
 // Publish package artifacts.
 await $`pnpm -C cli build`
 await $`npm publish cli/dist/npm --access public`
+await $`pnpm -C create build`
+await $`npm publish ./create`
 await $`(cd vscode && npx vsce publish --no-dependencies)`
 await $`(cd vscode && npx ovsx publish --no-dependencies)`
 

--- a/ui/tests/install.test.ts
+++ b/ui/tests/install.test.ts
@@ -68,12 +68,6 @@ async function expectNoSvelteDependency(projectDir: string) {
   expect(pkg.dependencies?.svelte).toBeUndefined()
 }
 
-async function disablePnpmMinimumReleaseAge(projectDir: string, packageManager: PackageManagerTest) {
-  // This smoke test installs freshly packed local artifacts; keep the repo-wide pnpm safety policy out of the temp project.
-  if (packageManager.name !== 'pnpm') return
-  await fsp.writeFile(path.join(projectDir, '.npmrc'), 'minimum-release-age=0\n')
-}
-
 async function installGrapheneAndUseIt(packageManager: PackageManagerTest, page: Page) {
   let testsDir = path.dirname(fileURLToPath(import.meta.url))
   let coreDir = path.resolve(testsDir, '../..')
@@ -105,7 +99,6 @@ async function installGrapheneAndUseIt(packageManager: PackageManagerTest, page:
     let scaffold = await run(createCommand, createArgs, tempRoot, childEnv)
     expectSuccess(`${packageManager.name} create-graphene`, scaffold)
     await expectNoSvelteDependency(projectDir)
-    await disablePnpmMinimumReleaseAge(projectDir, packageManager)
 
     let [installCommand, installArgs] = packageManager.install(cliTarball)
     let installResult = await run(installCommand, installArgs, projectDir, childEnv)
@@ -196,7 +189,7 @@ test.skipIf(!process.env.SLOW_TEST)('install graphene and use it with pnpm', {ti
     {
       name: 'pnpm',
       create: tarball => ['pnpm', ['dlx', '--package', tarball, 'create-graphene', 'demo-app', '--yes', '--no-install']],
-      install: tarball => ['pnpm', ['add', tarball]],
+      install: tarball => ['pnpm', ['add', '--config.minimumReleaseAge=0', tarball]],
       graphene: args => ['pnpm', ['run', 'graphene', '--', ...args]],
     },
     page,

--- a/ui/tests/install.test.ts
+++ b/ui/tests/install.test.ts
@@ -68,6 +68,12 @@ async function expectNoSvelteDependency(projectDir: string) {
   expect(pkg.dependencies?.svelte).toBeUndefined()
 }
 
+async function disablePnpmMinimumReleaseAge(projectDir: string, packageManager: PackageManagerTest) {
+  // This smoke test installs freshly packed local artifacts; keep the repo-wide pnpm safety policy out of the temp project.
+  if (packageManager.name !== 'pnpm') return
+  await fsp.writeFile(path.join(projectDir, '.npmrc'), 'minimum-release-age=0\n')
+}
+
 async function installGrapheneAndUseIt(packageManager: PackageManagerTest, page: Page) {
   let testsDir = path.dirname(fileURLToPath(import.meta.url))
   let coreDir = path.resolve(testsDir, '../..')
@@ -99,6 +105,7 @@ async function installGrapheneAndUseIt(packageManager: PackageManagerTest, page:
     let scaffold = await run(createCommand, createArgs, tempRoot, childEnv)
     expectSuccess(`${packageManager.name} create-graphene`, scaffold)
     await expectNoSvelteDependency(projectDir)
+    await disablePnpmMinimumReleaseAge(projectDir, packageManager)
 
     let [installCommand, installArgs] = packageManager.install(cliTarball)
     let installResult = await run(installCommand, installArgs, projectDir, childEnv)

--- a/ui/tests/install.test.ts
+++ b/ui/tests/install.test.ts
@@ -97,7 +97,7 @@ async function installGrapheneAndUseIt(packageManager: PackageManagerTest, page:
 
     let [createCommand, createArgs] = packageManager.create(createTarball)
     let scaffold = await run(createCommand, createArgs, tempRoot, childEnv)
-    expectSuccess(`${packageManager.name} create-graphenedata`, scaffold)
+    expectSuccess(`${packageManager.name} create-graphene`, scaffold)
     await expectNoSvelteDependency(projectDir)
 
     let [installCommand, installArgs] = packageManager.install(cliTarball)
@@ -176,7 +176,7 @@ test.skipIf(!process.env.SLOW_TEST)('install graphene and use it with npm', {tim
   await installGrapheneAndUseIt(
     {
       name: 'npm',
-      create: tarball => ['npm', ['exec', '--yes', '--package', tarball, '--', 'create-graphenedata', 'demo-app', '--yes', '--no-install']],
+      create: tarball => ['npm', ['exec', '--yes', '--package', tarball, '--', 'create-graphene', 'demo-app', '--yes', '--no-install']],
       install: tarball => ['npm', ['install', tarball]],
       graphene: args => ['npm', ['run', 'graphene', '--', ...args]],
     },
@@ -188,7 +188,7 @@ test.skipIf(!process.env.SLOW_TEST)('install graphene and use it with pnpm', {ti
   await installGrapheneAndUseIt(
     {
       name: 'pnpm',
-      create: tarball => ['pnpm', ['dlx', '--package', tarball, 'create-graphenedata', 'demo-app', '--yes', '--no-install']],
+      create: tarball => ['pnpm', ['dlx', '--package', tarball, 'create-graphene', 'demo-app', '--yes', '--no-install']],
       install: tarball => ['pnpm', ['add', tarball]],
       graphene: args => ['pnpm', ['run', 'graphene', '--', ...args]],
     },
@@ -200,7 +200,7 @@ test.skipIf(!process.env.SLOW_TEST)('install graphene and use it with yarn', {ti
   await installGrapheneAndUseIt(
     {
       name: 'yarn',
-      create: tarball => ['corepack', ['yarn@4.12.0', 'dlx', '--package', tarball, 'create-graphenedata', 'demo-app', '--yes', '--no-install']],
+      create: tarball => ['corepack', ['yarn@4.12.0', 'dlx', '--package', tarball, 'create-graphene', 'demo-app', '--yes', '--no-install']],
       install: tarball => ['corepack', ['yarn@4.12.0', 'add', tarball]],
       graphene: args => ['corepack', ['yarn@4.12.0', 'run', 'graphene', ...args]],
     },


### PR DESCRIPTION
I neglected to wire up the `create/` package to the publish flow, which is just as well because I'm changing the package name in this PR to `create-graphene` to grab that NPM name and allow `npm create graphene`. In the future if we want to we can publish a version to allow `npm create @graphenedata` but there's no risk of that name getting squatted.

My plan is to manually publish the 0.0.16 version of `create-graphene` before merging this PR, then enable trusted publishing for it in NPM and link it to our repo + workflow. Then future versions should publish along with the other packages.