### PR TITLE
move `graphene run` screenshots into project dir

### DIFF
--- a/cli/run.ts
+++ b/cli/run.ts
@@ -2,7 +2,6 @@ import fs from 'fs-extra'
 import {type IncomingMessage, type ServerResponse} from 'http'
 import {readFileSync} from 'node:fs'
 import {styleText} from 'node:util'
-import os from 'os'
 import path from 'path'
 import {type PluginOption, type ViteDevServer} from 'vite'
 import {WebSocketServer, type WebSocket} from 'ws'
@@ -14,7 +13,7 @@ import {analyzeWorkspace, getFile, loadWorkspace, toSql} from '../lang/core.ts'
 import {type AnalysisResult, type WorkspaceFileInput} from '../lang/types.ts'
 import {pollFor} from '../lang/util.ts'
 import {openInBrowser} from './auth.ts'
-import {isServerRunning, runServeInBackground} from './background.ts'
+import {getGrapheneCache, isServerRunning, runServeInBackground} from './background.ts'
 import {runQuery} from './connections/index.ts'
 import {mockFileMap} from './mockFiles.ts'
 import {normalizeFile} from './normalizeFile.ts'
@@ -78,9 +77,11 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
   }
 
   if (resp?.screenshot) {
-    let filename = `graphene-screenshot-${new Date().toISOString().replace(/[:.]/g, '-')}.png`
-    let screenshotPath = path.join(os.tmpdir(), filename)
+    let filename = `${new Date().toISOString().replace(/[:.]/g, '-')}.png`
+    let screenshotDir = path.join(getGrapheneCache(config.root), 'screenshots')
+    let screenshotPath = path.join(screenshotDir, filename)
     let base64Data = resp.screenshot.replace(/^data:image\/png;base64,/, '')
+    await fs.ensureDir(screenshotDir)
     await fs.writeFile(screenshotPath, base64Data, 'base64')
     log('Screenshot saved to', screenshotPath)
   }

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -14,8 +14,11 @@ function log(...args: any[]) {
 }
 
 function outputLines() {
-  let normalized = logs.replace(/graphene-screenshot-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.png/g, 'graphene-screenshot-<timestamp>.png')
-  normalized = normalized.replace(/Screenshot saved to[^\n]*graphene-screenshot-<timestamp>\.png/g, 'Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png')
+  let normalized = logs.replace(/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.png/g, '<timestamp>.png')
+  normalized = normalized.replace(
+    /Screenshot saved to[^\n]*node_modules\/\.graphene\/screenshots\/<timestamp>\.png/g,
+    'Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png',
+  )
   return stripAnsi(normalized.trim())
 }
 
@@ -106,7 +109,7 @@ test('cli run with md file reports dynamic unsupported chart wrapper props', asy
     trimIndentation(`
     Runtime errors in index.md:
     BarChart (data="chart_data" x="carrier" y="distance"): Unsupported prop "yFmt" on BarChart.
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
   )
 })
@@ -135,7 +138,7 @@ test('cli run with md file reports dynamic unsupported ECharts top-level props',
     trimIndentation(`
     Runtime errors in index.md:
     ECharts (data="chart_data" x="carrier" y="distance"): Unsupported prop "chartAreaHeight" on ECharts.
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
   )
 })
@@ -159,7 +162,7 @@ test('cli run with md file reports multiple dynamic unsupported chart props', as
     trimIndentation(`
     Runtime errors in index.md:
     BarChart (data="chart_data" x="carrier" y="distance"): Unsupported prop "yFmt" on BarChart. Unsupported prop "emptySet" on BarChart.
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
   )
 })
@@ -189,7 +192,7 @@ test('cli run with md file reports runtime chart prop and render errors together
     trimIndentation(`
     Runtime errors in index.md:
     ECharts (data="chart_data" x="x_value" y="bad_category"): Horizontal charts do not support a value or time-based x-axis
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
   )
 })
@@ -213,7 +216,7 @@ test('cli run with md file reports runtime query errors', async ({server, page})
     trimIndentation(`
     Runtime errors in index.md:
     BarChart (data="runtime_error_query" x="origin" y="explode"): Out of Range Error: cannot take square root of a negative number
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
   )
 })
@@ -242,7 +245,7 @@ test('cli run with md file reports runtime chart configuration errors', async ({
     trimIndentation(`
     Runtime errors in index.md:
     ECharts (data="chart_data" x="x_value" y="bad_category"): Horizontal charts do not support a value or time-based x-axis
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
   )
 })
@@ -265,7 +268,7 @@ test('cli run with md file reports table configuration errors', async ({server, 
     trimIndentation(`
     Runtime errors in index.md:
     DataTable: not_a_column is not a column in the dataset. sort should contain one column name and optionally a direction (asc or desc).
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
 `),
   )
 })
@@ -289,7 +292,7 @@ test('cli run with md file reports big value query errors', async ({server, page
     trimIndentation(`
     Runtime errors in index.md:
     BigValue (data="big_value_data" value="value"): Out of Range Error: cannot take square root of a negative number
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
 `),
   )
 })
@@ -333,7 +336,7 @@ test('cli run with --chart captures a single chart screenshot', async ({server, 
   expect(outputLines()).toEqual(
     trimIndentation(`
     No errors found 💎
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
   )
 })
@@ -360,7 +363,7 @@ test('cli run with --chart captures an ECharts screenshot by title', async ({ser
   expect(outputLines()).toEqual(
     trimIndentation(`
     No errors found 💎
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
   )
 })
@@ -400,7 +403,7 @@ test('cli run with --chart captures a chart screenshot by component ID', async (
   expect(outputLines()).toEqual(
     trimIndentation(`
     No errors found 💎
-    Screenshot saved to /tmp/graphene-screenshot-<timestamp>.png
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
   )
 })

--- a/ui/tests/install.test.ts
+++ b/ui/tests/install.test.ts
@@ -161,9 +161,12 @@ limit 10
     let [runCommand, runArgs] = packageManager.graphene(['run', 'chart.md'])
     let runResult = await run(runCommand, runArgs, projectDir, childEnv)
     expectSuccess('graphene run chart.md', runResult)
-    let runOutput = getOutput(runResult).replace(/graphene-screenshot-.*\.png/, 'graphene-screenshot.png')
+    let runOutput = getOutput(runResult).replace(
+      /Screenshot saved to[^\n]*node_modules\/\.graphene\/screenshots\/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.png/,
+      'Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png',
+    )
     expect(runOutput).toContain('No errors found 💎')
-    expect(runOutput).toContain('Screenshot saved to /tmp/graphene-screenshot.png')
+    expect(runOutput).toContain('Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png')
   } finally {
     expectConsoleError(/WebSocket connection to 'ws:\/\/(localhost|127\.0\.0\.1):\d+\/_api\/ws' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED/)
     let [stopCommand, stopArgs] = packageManager.graphene(['stop'])


### PR DESCRIPTION
This PR moves the directory used by `graphene run` for screenshots from the system temp directory to `./node_modules/.graphene/screenshots`, which should allow coding agents with default access perms to save screenshots. Fixes #269