### PR TITLE
input-aware execution for `graphene run`

### DIFF
--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -54,6 +54,20 @@ async function createTelemetryProject(prefix: string) {
   return tmpDir
 }
 
+async function createFlightProject(prefix: string) {
+  let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix))
+  let pkg = {
+    name: prefix,
+    graphene: {
+      dialect: 'duckdb',
+      duckdb: {path: path.join(flightDir, 'flights.duckdb')},
+    },
+  }
+  await fsp.writeFile(path.join(tmpDir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n')
+  await fsp.cp(path.join(flightDir, 'tables'), path.join(tmpDir, 'tables'), {recursive: true})
+  return tmpDir
+}
+
 describe('cli compile', () => {
   it('compiles a basic query (happy path)', async () => {
     let res = await runCli(['compile', 'from flights select carrier'], {cwd: flightDir})
@@ -140,6 +154,82 @@ describe('cli run', () => {
     let res = await runCli(['run', 'index.md', '--query', 'performance_by_year'], {cwd: flightDir})
     expectCliSuccess(res, 'run markdown query')
     expect(res.stdout.toLowerCase()).toContain('flight_count')
+  })
+
+  it('runs a named markdown query with static page input defaults', async () => {
+    let res = await runCli(['run', 'carrier_detail.md', '--query', 'carrier_info'], {cwd: flightDir})
+    expectCliSuccess(res, 'run markdown query with input default')
+    expect(res.stdout).toContain('Southwest')
+    expect(res.stdout).toContain('WN')
+  })
+
+  it('overrides static page input defaults with --input', async () => {
+    let res = await runCli(['run', 'carrier_detail.md', '--query', 'carrier_info', '--input', 'carrier=AA'], {cwd: flightDir})
+    expectCliSuccess(res, 'run markdown query with input override')
+    expect(res.stdout).toContain('American')
+    expect(res.stdout).toContain('AA')
+  })
+
+  it('lists static markdown page inputs', async () => {
+    let res = await runCli(['run', 'carrier_detail.md', '--list-inputs'], {cwd: flightDir})
+    expectCliSuccess(res, 'list markdown inputs')
+    expect(res.stdout).toContain('carrier (Dropdown)')
+    expect(res.stdout).toContain('keys: carrier')
+    expect(res.stdout).toContain('default: WN')
+    expect(res.stdout).toContain('value: WN')
+  })
+
+  it('runs all static component data queries from a markdown file', async () => {
+    let res = await runCli(['run', 'carrier_detail.md', '--all-queries'], {cwd: flightDir})
+    expectCliSuccess(res, 'run all markdown component queries')
+    expect(res.stdout).toContain('All component queries ran successfully')
+  })
+
+  it('uses repeated --input flags as array params', async () => {
+    let tmpDir = await createFlightProject('graphene-cli-input-array-')
+    try {
+      await fsp.writeFile(
+        path.join(tmpDir, 'index.md'),
+        `
+        \`\`\`sql selected_carriers
+        from carriers
+        where code in ($carrier_multi)
+        select code, nickname
+        order by code
+        \`\`\`
+      `,
+      )
+      let res = await runCli(['run', 'index.md', '-q', 'selected_carriers', '--input', 'carrier_multi=AA', '--input', 'carrier_multi=UA'], {cwd: tmpDir})
+      expectCliSuccess(res, 'run markdown query with repeated input')
+      expect(res.stdout).toContain('AA')
+      expect(res.stdout).toContain('UA')
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('reports component context for all-query failures', async () => {
+    let tmpDir = await createFlightProject('graphene-cli-all-queries-error-')
+    try {
+      await fsp.writeFile(
+        path.join(tmpDir, 'index.md'),
+        `
+        \`\`\`sql chart_data
+        from flights select carrier
+        \`\`\`
+
+        <BarChart data=chart_data x=carrier y=missing title="Broken" />
+      `,
+      )
+      let res = await runCli(['run', 'index.md', '--all-queries'], {cwd: tmpDir})
+      expect(res.code).toBe(1)
+      expect(res.stdout).toContain('BarChart (data="chart_data" x="carrier" y="missing")')
+      expect(res.stdout).toContain('index.md:')
+      expect(res.stdout).toContain('data="chart_data" fields="carrier, missing"')
+      expect(res.stdout.toLowerCase()).toContain('missing')
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
   })
 
   it('uses a configured duckdb path when present', async () => {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -55,21 +55,37 @@ program
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
   .option('-c, --chart <chartTitleOrComponentId>', 'Title or component ID of a specific chart to capture')
   .option('-q, --query <queryName>', 'Query or table name to run from a markdown page')
+  .option('--input <name=value>', 'Input value for markdown page queries; repeat for arrays', (value, previous: string[]) => previous.concat(value), [])
+  .option('--list-inputs', 'List static markdown page inputs and defaults')
+  .option('--all-queries', 'Run all static component data queries from a markdown page')
   .action(
-    withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; query?: string}) => {
-      if (options.chart && options.query) {
-        console.error('Cannot use --chart and --query together')
+    withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; query?: string; input?: string[]; listInputs?: boolean; allQueries?: boolean}) => {
+      let pageQueryModeCount = [options.query, options.allQueries, options.listInputs].filter(Boolean).length
+      if (options.chart && pageQueryModeCount > 0) {
+        console.error('Cannot use --chart with --query, --all-queries, or --list-inputs')
+        return exit(1)
+      }
+      if (pageQueryModeCount > 1) {
+        console.error('Use only one of --query, --all-queries, or --list-inputs')
         return exit(1)
       }
 
       let inputPath = getExistingPath(input)
       if (inputPath && inputPath.endsWith('.md')) {
-        let res = options.query ? await runNamedQueryFromMd(inputPath, options.query, telemetry) : await runMdFile({mdArg: inputPath, chart: options.chart, telemetry})
+        if (options.input?.length && pageQueryModeCount == 0) {
+          console.error('--input requires --query, --all-queries, or --list-inputs')
+          return exit(1)
+        }
+        let pageOptions = {inputs: options.input || [], allQueries: options.allQueries, listInputs: options.listInputs, telemetry}
+        let res =
+          options.query || options.allQueries || options.listInputs
+            ? await runNamedQueryFromMd(inputPath, options.query || '', pageOptions)
+            : await runMdFile({mdArg: inputPath, chart: options.chart, telemetry})
         return exit(res ? 0 : 1)
       }
 
-      if (options.chart || options.query) {
-        console.error('--chart and --query can only be used with a markdown file path')
+      if (options.chart || pageQueryModeCount > 0 || options.input?.length) {
+        console.error('--chart, --query, --all-queries, --list-inputs, and --input can only be used with a markdown file path')
         return exit(1)
       }
 

--- a/cli/pageRuntime.ts
+++ b/cli/pageRuntime.ts
@@ -1,0 +1,81 @@
+import {collectComponentRequests} from '../lang/componentQueries.ts'
+import {collectSveltishOpeningTags, extractSveltishAttributes, sveltishAttributeValues, type SveltishIgnoredRange} from '../lang/sveltish.ts'
+import {formatSourceLocation} from '../lang/util.ts'
+import {dateRangeDefault, dropdownDefault} from '../ui/component-utilities/pageInputDefaults.ts'
+
+export interface PageFence extends SveltishIgnoredRange {
+  name: string
+  contents: string
+}
+
+export interface PageInput {
+  component: string
+  name: string
+  keys: string[]
+  defaultValue: any
+  effectiveValue: any
+  location: string
+}
+
+const FENCE = /^([ \t]*)(`{3,})([^\n]*)\n([\s\S]*?)^\1\2[ \t]*$/gim
+
+export function buildPageRuntime(contents: string, mdPath: string, overrides: Record<string, any>) {
+  let fences = collectPageFences(contents)
+  let inputs = collectPageInputs(contents, fences, mdPath)
+  let params: Record<string, any> = {}
+  inputs.forEach(input => {
+    if (input.keys.length == 1) {
+      params[input.keys[0]] = input.effectiveValue
+      return
+    }
+    input.keys.forEach(key => (params[key] = input.effectiveValue?.[key.replace(`${input.name}_`, '')] ?? null))
+  })
+
+  Object.assign(params, overrides)
+  inputs.forEach(input => {
+    input.effectiveValue = input.keys.length == 1 ? params[input.keys[0]] : Object.fromEntries(input.keys.map(key => [key, params[key]]))
+  })
+
+  return {fences, inputs, params, componentRequests: collectComponentRequests(contents, fences, mdPath)}
+}
+
+function collectPageFences(contents: string): PageFence[] {
+  let fences: PageFence[] = []
+  FENCE.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = FENCE.exec(contents))) {
+    let header = (match[3] || '').trim()
+    let [language, name] = header.split(/\s+/)
+    if (!name || !['sql', 'gsql'].includes((language || '').toLowerCase())) continue
+    let start = match.index || 0
+    fences.push({name, contents: match[4] || '', start, end: start + match[0].length})
+  }
+  return fences
+}
+
+function collectPageInputs(contents: string, fences: PageFence[], mdPath: string): PageInput[] {
+  let inputs: PageInput[] = []
+  for (let tag of collectSveltishOpeningTags(contents, fences)) {
+    if (!['Dropdown', 'TextInput', 'DateRange'].includes(tag.name)) continue
+    let attrs = extractSveltishAttributes(tag.fragment, tag.start)
+    let name = attrs.name?.value
+    if (!name) continue
+
+    let location = formatSourceLocation(contents, mdPath, tag.start)
+    if (tag.name == 'TextInput') {
+      let value = attrs.defaultValue?.value ?? null
+      inputs.push({component: tag.name, name, keys: [name], defaultValue: value, effectiveValue: value, location})
+    }
+
+    if (tag.name == 'Dropdown') {
+      let value = dropdownDefault(sveltishAttributeValues(attrs))
+      inputs.push({component: tag.name, name, keys: [name], defaultValue: value, effectiveValue: value, location})
+    }
+
+    if (tag.name == 'DateRange') {
+      let value = dateRangeDefault(sveltishAttributeValues(attrs))
+      inputs.push({component: tag.name, name, keys: [`${name}_start`, `${name}_end`], defaultValue: value, effectiveValue: value, location})
+    }
+  }
+  return inputs
+}

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -11,13 +11,14 @@ import type {GrapheneError} from '../lang/index.d.ts'
 
 import {config} from '../lang/config.ts'
 import {analyzeWorkspace, getFile, loadWorkspace, toSql} from '../lang/core.ts'
-import {type AnalysisResult, type WorkspaceFileInput} from '../lang/types.ts'
+import {type WorkspaceFileInput} from '../lang/types.ts'
 import {pollFor} from '../lang/util.ts'
 import {openInBrowser} from './auth.ts'
 import {isServerRunning, runServeInBackground} from './background.ts'
 import {runQuery} from './connections/index.ts'
 import {mockFileMap} from './mockFiles.ts'
 import {normalizeFile} from './normalizeFile.ts'
+import {buildPageRuntime, type PageInput} from './pageRuntime.ts'
 import {printDiagnostics, printTable} from './printer.ts'
 import {getWorkspaceScanCounts, type CliTelemetry} from './telemetry/index.ts'
 
@@ -25,6 +26,13 @@ export interface RunMdFileOptions {
   mdArg: string
   chart?: string
   log?: (...args: any[]) => void
+  telemetry?: CliTelemetry
+}
+
+interface RunPageQueryOptions {
+  inputs?: string[]
+  allQueries?: boolean
+  listInputs?: boolean
   telemetry?: CliTelemetry
 }
 
@@ -114,32 +122,114 @@ export async function listMdFileQueries(mdArg: string, telemetry?: CliTelemetry,
   return true
 }
 
-export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string, telemetry?: CliTelemetry): Promise<boolean> {
+export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string, options: RunPageQueryOptions = {}): Promise<boolean> {
+  let log = console.log
   let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
-  telemetry?.event('workspace_scanned', {command: 'run', ...getWorkspaceScanCounts(files)})
+  options.telemetry?.event('workspace_scanned', {command: 'run', ...getWorkspaceScanCounts(files)})
   let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
   let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
 
+  let page: ReturnType<typeof buildPageRuntime>
+  try {
+    page = buildPageRuntime(mdContents, mdRelativePath, parseInputOverrides(options.inputs || []))
+  } catch (err: any) {
+    log(err.message || String(err))
+    return false
+  }
+
+  if (options.listInputs) {
+    printPageInputs(page.inputs, log)
+    return true
+  }
+
+  if (options.allQueries) return await runComponentQueries({files, page, log})
+
   let result = analyzeWorkspace({config, files: files.filter(file => file.path != mdRelativePath).concat({path: mdRelativePath, contents: mdContents, kind: 'md'})}, mdRelativePath)
   if (result.diagnostics.length > 0) {
-    printDiagnostics(result.diagnostics)
+    printDiagnostics(result.diagnostics, log)
     return false
   }
 
-  let runQueryFence = [mdContents, '', '```sql', `from ${queryName} select *`, '```'].join('\n')
-  let queryFiles = toWorkspaceFiles(result)
-  let queryResult = analyzeWorkspace({config, files: queryFiles.filter(file => file.path != 'input.md').concat({path: 'input.md', contents: runQueryFence, kind: 'md'})}, 'input.md')
-  if (queryResult.diagnostics.length > 0) {
-    printDiagnostics(queryResult.diagnostics)
+  try {
+    let sql = compilePageRequest(files, page, `from ${queryName} select *`)
+    let res = await runQuery(sql)
+    printTable(res.rows)
+    return true
+  } catch (err: any) {
+    log(err.message || String(err))
     return false
   }
+}
 
-  let input = getFile(queryResult, 'input.md')
-  if (!input?.queries.length) return false
-  let sql = toSql(input.queries[input.queries.length - 1])
-  let res = await runQuery(sql)
-  printTable(res.rows)
-  return true
+async function runComponentQueries({files, page, log}: {files: WorkspaceFileInput[]; page: ReturnType<typeof buildPageRuntime>; log: (...args: any[]) => void}) {
+  if (!page.componentRequests.length) {
+    log('No component queries found')
+    return true
+  }
+
+  let failed = false
+  for (let request of page.componentRequests) {
+    let fields = request.fields.length ? Array.from(new Set(request.fields.filter(Boolean))) : ['*']
+    let gsql = `from ${request.source} select ${fields.join(', ')}`
+    try {
+      let sql = compilePageRequest(files, page, gsql)
+      await runQuery(sql)
+    } catch (err: any) {
+      failed = true
+      log(`${request.componentId} (${request.location})`)
+      log(`  data="${request.source}" fields="${fields.join(', ')}"`)
+      log(`  ${err.message || String(err)}`)
+    }
+  }
+
+  if (!failed) log(`All component queries ran successfully (${page.componentRequests.length})`)
+  return !failed
+}
+
+function compilePageRequest(files: WorkspaceFileInput[], page: ReturnType<typeof buildPageRuntime>, query: string) {
+  let gsql = [...page.fences.map(f => `table ${f.name} as (\n${f.contents}\n)`), query].join('\n')
+  let result = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: gsql})}, 'input')
+  if (result.diagnostics.length > 0) throw new Error(result.diagnostics.map(d => d.message).join('\n'))
+
+  let input = getFile(result, 'input')
+  if (!input?.queries.length) throw new Error('No query found to run')
+  return toSql(input.queries[input.queries.length - 1], page.params)
+}
+
+function printPageInputs(inputs: PageInput[], log: (...args: any[]) => void) {
+  if (!inputs.length) {
+    log('No page inputs found')
+    return
+  }
+  inputs.forEach(input => {
+    log(`${input.name} (${input.component})`)
+    log(`  keys: ${input.keys.join(', ')}`)
+    log(`  default: ${formatParamValue(input.defaultValue)}`)
+    log(`  value: ${formatParamValue(input.effectiveValue)}`)
+    log(`  location: ${input.location}`)
+  })
+}
+
+function parseInputOverrides(inputs: string[]) {
+  let params: Record<string, any> = {}
+  inputs.forEach(input => {
+    let idx = input.indexOf('=')
+    if (idx <= 0) throw new Error(`Invalid --input "${input}". Use --input name=value.`)
+    let key = input.slice(0, idx)
+    let value = input.slice(idx + 1)
+    let existing = params[key]
+    if (existing === undefined) params[key] = value
+    else if (Array.isArray(existing)) existing.push(value)
+    else params[key] = [existing, value]
+  })
+  return params
+}
+
+function formatParamValue(value: any) {
+  if (value === null || value === undefined) return 'null'
+  if (Array.isArray(value)) return `[${value.map(formatParamValue).join(', ')}]`
+  if (typeof value == 'object') return JSON.stringify(value)
+  return String(value)
 }
 
 async function sendSocketRequest({mdFile, action, chart, log}: {mdFile: string; action: 'check' | 'list'; chart?: string; log: (...args: any[]) => void}) {
@@ -225,15 +315,6 @@ export async function proxyRunRequest(req: IncomingMessage, res: ServerResponse<
 
   conn.socket.send(JSON.stringify({type: 'check', action, chart, requestId: id}))
   pendingRequests[id] = {response: res}
-}
-
-function toWorkspaceFiles(analysis: AnalysisResult): WorkspaceFileInput[] {
-  return analysis.files.map(file => ({
-    path: file.path,
-    contents: file.contents,
-    kind: file.path.endsWith('.md') ? 'md' : 'gsql',
-    parsed: {tree: file.tree!, virtualContents: file.virtualContents, virtualToMarkdownOffset: file.virtualToMarkdownOffset},
-  }))
 }
 
 export function runVitePlugin(): PluginOption {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,12 @@ graphene run path/to/page.md -c 'Query (data="query_name" x="category" y="total"
 
 # `-q/--query` can target anything usable in a chart `data` prop (for example, a gsql table or a named code-fenced query in the markdown file).
 graphene run path/to/page.md -q query_name # Run a named query/table from the markdown context and print results
+# `--input` can be repeated; repeating the same input name sends an array value.
+graphene run path/to/page.md -q query_name --input carrier=WN # Override a page input for a named query
+
+# `--list-inputs` and `--all-queries` are headless and understand static Dropdown, TextInput, and DateRange defaults.
+graphene run path/to/page.md --list-inputs # List static page inputs and their defaults
+graphene run path/to/page.md --all-queries # Run every statically discoverable component data query
 
 graphene compile "[GSQL]" # Show the compiled, dialect-specific SQL
 

--- a/lang/componentQueries.ts
+++ b/lang/componentQueries.ts
@@ -1,0 +1,134 @@
+import JSON5 from 'json5'
+
+import {parseCommaList} from './inputUtils.ts'
+import {collectSveltishOpeningTags, extractSveltishAttributes, sveltishAttributeValues, type SveltishIgnoredRange} from './sveltish.ts'
+import {formatSourceLocation} from './util.ts'
+
+export const MARKDOWN_COMPONENT_ATTRIBUTE_KEYS = ['x', 'y', 'y2', 'value', 'category', 'splitBy', 'sort'] as const
+export type ComponentQueryAttributeKey = (typeof MARKDOWN_COMPONENT_ATTRIBUTE_KEYS)[number] | 'column' | 'dates' | 'label' | 'labelField' | 'optionLabel'
+
+export interface ComponentRequest {
+  componentId: string
+  source: string
+  fields: string[]
+  location: string
+}
+
+export type ComponentQueryIgnoredRange = SveltishIgnoredRange
+
+type ComponentQueryAttributes = Record<string, string | undefined>
+
+const ECHARTS_TAG = /<ECharts\b((?:[^>"']|"[^"]*"|'[^']*')*)>([\s\S]*?)<\/ECharts>/g
+
+const CHART_COMPONENT_FIELD_KEYS: Record<string, ComponentQueryAttributeKey[]> = {
+  BarChart: ['x', 'y', 'y2', 'splitBy', 'sort'],
+  AreaChart: ['x', 'y', 'y2', 'splitBy', 'sort'],
+  PieChart: ['category', 'value'],
+  LineChart: ['x', 'y', 'y2', 'splitBy', 'sort'],
+  ScatterPlot: ['x', 'y', 'splitBy'],
+}
+
+const DEFAULT_MARKDOWN_FIELD_KEYS: ComponentQueryAttributeKey[] = ['x', 'y', 'y2', 'value', 'category']
+
+export function markdownComponentFieldKeys(componentName: string): ComponentQueryAttributeKey[] {
+  return CHART_COMPONENT_FIELD_KEYS[componentName] || DEFAULT_MARKDOWN_FIELD_KEYS
+}
+
+export function collectComponentRequests(contents: string, ignoredRanges: ComponentQueryIgnoredRange[], mdPath: string): ComponentRequest[] {
+  let requests: ComponentRequest[] = []
+  for (let tag of collectSveltishOpeningTags(contents, ignoredRanges)) {
+    let attrs = sveltishAttributeValues(extractSveltishAttributes(tag.fragment, tag.start))
+    let source = attrs.data
+    if (!source) continue
+    let fields = componentQueryFields(tag.name, attrs)
+    if (!fields) continue
+    requests.push({componentId: componentId(tag.name, attrs), source, fields, location: formatSourceLocation(contents, mdPath, tag.start)})
+  }
+
+  ECHARTS_TAG.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = ECHARTS_TAG.exec(contents))) {
+    let start = match.index || 0
+    if (isInsideRange(start, ignoredRanges)) continue
+    let fragment = `<ECharts${match[1] || ''}>`
+    let attrs = sveltishAttributeValues(extractSveltishAttributes(fragment, start))
+    if (!attrs.data) continue
+    let fields = fieldsForEChartsBody(match[2] || '')
+    requests.push({componentId: componentId('ECharts', attrs, fields), source: attrs.data, fields, location: formatSourceLocation(contents, mdPath, start)})
+  }
+  return dedupeRequests(requests)
+}
+
+function componentQueryFields(componentName: string, attrs: ComponentQueryAttributes): string[] | null {
+  if (componentName == 'Table') return []
+
+  let keys = componentQueryFieldKeys(componentName, attrs)
+  if (!keys) return null
+
+  return keys.flatMap(key => {
+    let value = attrs[key]
+    if (!value) return []
+    if (key == 'sort') return [value.trim().split(/\s+/)[0]]
+    if (key == 'x' || key == 'y' || key == 'y2') return parseCommaList(value)
+    return [value]
+  })
+}
+
+function fieldsForEChartsBody(body: string) {
+  let config: any
+  try {
+    let source = body.trim().startsWith('{') ? body.trim() : `{${body.trim()}}`
+    config = JSON5.parse(source)
+  } catch {
+    return []
+  }
+  let series = Array.isArray(config.series) ? config.series : [config.series]
+  let fields: string[] = series.flatMap((s: any) =>
+    Object.entries(s?.encode || {}).flatMap(([attr, value]) => {
+      if (typeof value != 'string' || !value.trim()) return []
+      if (attr == 'sort') return [value.trim().split(/\s+/)[0]]
+      return [value.trim()]
+    }),
+  )
+  return Array.from(new Set(fields.filter(Boolean)))
+}
+
+function componentQueryFieldKeys(componentName: string, attrs: ComponentQueryAttributes): ComponentQueryAttributeKey[] | null {
+  if (CHART_COMPONENT_FIELD_KEYS[componentName]) return CHART_COMPONENT_FIELD_KEYS[componentName]
+  if (componentName == 'BigValue') return ['value']
+  if (componentName == 'Value') return ['column']
+  if (componentName == 'DateRange') return ['dates']
+  if (componentName != 'Dropdown') return null
+
+  let labelKey: ComponentQueryAttributeKey = 'label'
+  if (attrs.labelField) labelKey = 'labelField'
+  else if (attrs.optionLabel) labelKey = 'optionLabel'
+  return ['value', labelKey]
+}
+
+function componentId(componentName: string, attrs: ComponentQueryAttributes, echartFields?: string[]) {
+  let ids: Record<string, any> = {}
+  if (attrs.data) ids.data = attrs.data
+  ;['x', 'y', 'category', 'value', 'column'].forEach(key => {
+    if (attrs[key]) ids[key] = attrs[key]
+  })
+  if (componentName == 'ECharts') {
+    echartFields?.forEach((field, index) => (ids[index == 0 ? 'field' : `field${index + 1}`] = field))
+  }
+  let parts = Object.entries(ids).map(([key, value]) => `${key}="${value}"`)
+  return `${componentName}${parts.length ? ` (${parts.join(' ')})` : ''}`
+}
+
+function dedupeRequests(requests: ComponentRequest[]) {
+  let seen = new Set<string>()
+  return requests.filter(request => {
+    let key = `${request.componentId}::${request.source}::${request.fields.join(',')}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function isInsideRange(offset: number, ranges: ComponentQueryIgnoredRange[]) {
+  return ranges.some(range => offset >= range.start && offset < range.end)
+}

--- a/lang/inputUtils.ts
+++ b/lang/inputUtils.ts
@@ -1,0 +1,75 @@
+export function toBoolean(value: any): boolean | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') return value !== 0
+  if (typeof value === 'string') {
+    let trimmed = value.trim().toLowerCase()
+    if (trimmed === 'true' || trimmed === 'yes' || trimmed === '1') return true
+    if (trimmed === 'false' || trimmed === 'no' || trimmed === '0' || trimmed === '') return false
+  }
+  return Boolean(value)
+}
+
+export function ensureArray<T>(value: T | T[] | undefined | null): T[] {
+  if (Array.isArray(value)) return value
+  if (value === undefined || value === null) return []
+  return [value]
+}
+
+export function serializeValue(value: unknown): string {
+  if (value === null || value === undefined) return 'NULL'
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value)
+  if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE'
+  let str = String(value)
+  return `'${str.replace(/'/g, "''")}'`
+}
+
+// Parse a comma-separated list into an array of trimmed strings.
+// - Strings are split on top-level commas, ignoring commas inside calls and quoted strings.
+// - Arrays are normalized by trimming string items and String()-ing non-strings.
+// - null/undefined -> []
+export function parseCommaList(value: unknown): string[] {
+  if (value === undefined || value === null) return []
+  if (Array.isArray(value)) return value.map(v => (typeof v === 'string' ? v.trim() : String(v))).filter(v => v.length > 0)
+  if (typeof value !== 'string') return [String(value).trim()].filter(v => v.length > 0)
+
+  let parts: string[] = []
+  let current = ''
+  let quote: string | undefined
+  let depth = 0
+
+  for (let i = 0; i < value.length; i++) {
+    let char = value[i]
+
+    if (quote) {
+      current += char
+      if (char === quote) {
+        if (quote === "'" && value[i + 1] === "'") current += value[++i]
+        else quote = undefined
+      }
+      continue
+    }
+
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char
+      current += char
+      continue
+    }
+
+    if (char === '(' || char === '[' || char === '{') depth++
+    if ((char === ')' || char === ']' || char === '}') && depth > 0) depth--
+
+    if (char === ',' && depth === 0) {
+      let trimmed = current.trim()
+      if (trimmed) parts.push(trimmed)
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  let trimmed = current.trim()
+  if (trimmed) parts.push(trimmed)
+  return parts
+}

--- a/lang/markdown.ts
+++ b/lang/markdown.ts
@@ -1,6 +1,7 @@
 import type {ParsedFileArtifacts, ParsedFileDiagnostic, WorkspaceFileInput} from './types.ts'
 
 import {unsupportedChartProps} from './chartProps.ts'
+import {MARKDOWN_COMPONENT_ATTRIBUTE_KEYS, markdownComponentFieldKeys, type ComponentQueryAttributeKey} from './componentQueries.ts'
 import {parser} from './parser.js'
 import {extractSveltishAttributes, type SveltishAttribute} from './sveltish.ts'
 
@@ -17,17 +18,6 @@ import {extractSveltishAttributes, type SveltishAttribute} from './sveltish.ts'
 // from test_table select name, avg(age)
 //
 // Only components with a `data` attribute get turned into queries, and only attributes in a static list are fields to select.
-
-const COMPONENT_ATTRIBUTE_KEYS = ['x', 'y', 'y2', 'value', 'category', 'splitBy', 'sort'] as const
-type ComponentAttributeKey = (typeof COMPONENT_ATTRIBUTE_KEYS)[number]
-const DEFAULT_FIELD_ATTRIBUTE_KEYS: ComponentAttributeKey[] = ['x', 'y', 'y2', 'value', 'category']
-const COMPONENT_FIELD_ATTRIBUTE_KEYS: Record<string, ComponentAttributeKey[]> = {
-  BarChart: ['x', 'y', 'y2', 'splitBy', 'sort'],
-  AreaChart: ['x', 'y', 'y2', 'splitBy', 'sort'],
-  PieChart: ['category', 'value'],
-  LineChart: ['x', 'y', 'y2', 'splitBy', 'sort'],
-  ScatterPlot: ['x', 'y', 'splitBy'],
-}
 
 const FENCE = /^([ \t]*)(`{3,})([^\n]*)\n([\s\S]*?)^\1\2[ \t]*$/gim
 const COMPONENT_TAG = /<([A-Z][A-Za-z0-9]*)\s+(?:[^>"']|"[^"]*"|'[^']*')*\/>/g
@@ -47,7 +37,7 @@ interface ComponentMatch {
   start: number
   end: number
   data: SveltishAttribute | null
-  attributes: Partial<Record<ComponentAttributeKey, SveltishAttribute>>
+  attributes: Partial<Record<ComponentQueryAttributeKey, SveltishAttribute>>
   diagnostics: ParsedFileDiagnostic[]
 }
 
@@ -131,7 +121,7 @@ export function parseMarkdown(file: WorkspaceFileInput): ParsedFileArtifacts {
 
     let component = event as ComponentMatch
     let {data, attributes} = component
-    let hasComponentAttribute = COMPONENT_ATTRIBUTE_KEYS.some(key => attributes[key] !== undefined)
+    let hasComponentAttribute = MARKDOWN_COMPONENT_ATTRIBUTE_KEYS.some(key => attributes[key] !== undefined)
     if (data && hasComponentAttribute) {
       appendMapped('from ', () => component.start, {reset: component.start - 1})
       appendMapped(data.value, (i: number) => data.start + i, {reset: data.start - 1})
@@ -139,7 +129,7 @@ export function parseMarkdown(file: WorkspaceFileInput): ParsedFileArtifacts {
 
       let previousAttr: SveltishAttribute | null = null
       let selectedValues = new Set<string>()
-      for (let key of COMPONENT_ATTRIBUTE_KEYS) {
+      for (let key of MARKDOWN_COMPONENT_ATTRIBUTE_KEYS) {
         let attribute = attributes[key]
         if (!attribute) continue
         if (selectedValues.has(attribute.value)) continue
@@ -208,17 +198,13 @@ function collectComponents(source: string, fences: FenceMatch[]): ComponentMatch
     if (isInsideFence(start, fences)) continue
     let componentName = match[1]
     let attrs = extractSveltishAttributes(match[0], start)
-    let attributeMatches: Partial<Record<ComponentAttributeKey, SveltishAttribute>> = {}
-    for (let key of fieldAttributeKeys(componentName)) {
+    let attributeMatches: Partial<Record<ComponentQueryAttributeKey, SveltishAttribute>> = {}
+    for (let key of markdownComponentFieldKeys(componentName)) {
       if (attrs[key]) attributeMatches[key] = normalizeFieldAttribute(key, attrs[key])
     }
     matches.push({start, end, data: attrs.data || null, attributes: attributeMatches, diagnostics: validateChartProps(componentName, attrs)})
   }
   return matches
-}
-
-function fieldAttributeKeys(componentName: string): ComponentAttributeKey[] {
-  return COMPONENT_FIELD_ATTRIBUTE_KEYS[componentName] || DEFAULT_FIELD_ATTRIBUTE_KEYS
 }
 
 function extractFenceName(header: string): {name?: string; index?: number} {
@@ -227,7 +213,7 @@ function extractFenceName(header: string): {name?: string; index?: number} {
   return {}
 }
 
-function normalizeFieldAttribute(key: ComponentAttributeKey, attr: SveltishAttribute): SveltishAttribute {
+function normalizeFieldAttribute(key: ComponentQueryAttributeKey, attr: SveltishAttribute): SveltishAttribute {
   if (key != 'sort') return attr
   let match = attr.value.match(/\S+/)
   if (!match) return attr

--- a/lang/package.json
+++ b/lang/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@lezer/common": "^1.2.3",
     "@lezer/lr": "^1.4.2",
-    "glob": "^13.0.1"
+    "glob": "^13.0.1",
+    "json5": "^2.2.3"
   },
   "devDependencies": {
     "@duckdb/node-api": "^1.3.2-alpha.26",

--- a/lang/sveltish.ts
+++ b/lang/sveltish.ts
@@ -7,6 +7,19 @@ export interface SveltishAttribute {
   end: number
 }
 
+export interface SveltishIgnoredRange {
+  start: number
+  end: number
+}
+
+export interface SveltishTag {
+  name: string
+  fragment: string
+  start: number
+}
+
+const COMPONENT_TAG = /<([A-Z][A-Za-z0-9]*)\b(?:[^>"']|"[^"]*"|'[^']*')*(?:\/>|>)/g
+
 /**
  * Extract attributes from the self-closing Svelte-ish component tags we support in markdown.
  *
@@ -54,6 +67,22 @@ export function extractSveltishAttributes(fragment: string, baseStart: number): 
     }
   }
   return attrs
+}
+
+export function sveltishAttributeValues(attrs: Record<string, SveltishAttribute | undefined>): Record<string, string | undefined> {
+  return Object.fromEntries(Object.entries(attrs).map(([key, attr]) => [key, attr?.value]))
+}
+
+export function collectSveltishOpeningTags(contents: string, ignoredRanges: SveltishIgnoredRange[] = []): SveltishTag[] {
+  let tags: SveltishTag[] = []
+  COMPONENT_TAG.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = COMPONENT_TAG.exec(contents))) {
+    let start = match.index || 0
+    if (ignoredRanges.some(range => start >= range.start && start < range.end)) continue
+    tags.push({name: match[1], fragment: match[0], start})
+  }
+  return tags
 }
 
 function skipWhitespace(fragment: string, i: number) {

--- a/lang/util.ts
+++ b/lang/util.ts
@@ -107,6 +107,13 @@ export function buildFrame(from: {line: number; col: number; lineText?: string},
   return `${lineText}\n${' '.repeat(from.col)}${'^'.repeat(caretLen)}`
 }
 
+export function formatSourceLocation(contents: string, path: string, offset: number) {
+  let before = contents.slice(0, offset)
+  let line = before.split('\n').length
+  let col = before.length - before.lastIndexOf('\n')
+  return `${path}:${line}:${col}`
+}
+
 export async function pollFor<T>(fn: () => T, timeoutMs: number, interval?: number): Promise<T | null> {
   let end = Date.now() + timeoutMs
   while (Date.now() < end) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       glob:
         specifier: ^13.0.1
         version: 13.0.6
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
     devDependencies:
       '@duckdb/node-api':
         specifier: ^1.3.2-alpha.26

--- a/ui/component-utilities/pageInputDefaults.ts
+++ b/ui/component-utilities/pageInputDefaults.ts
@@ -1,0 +1,129 @@
+import {parseCommaList, toBoolean} from './inputUtils.ts'
+
+type StaticAttrs = Record<string, string | undefined>
+
+export const DEFAULT_DATE_PRESETS = [
+  'Last 7 Days',
+  'Last 30 Days',
+  'Last 90 Days',
+  'Last 365 Days',
+  'Last Month',
+  'Last Year',
+  'Month to Date',
+  'Month to Today',
+  'Year to Date',
+  'Year to Today',
+  'All Time',
+]
+
+export function dropdownDefault(attrs: StaticAttrs) {
+  if (toBoolean(attrs.noDefault)) return null
+  let value = attrs.defaultValue
+  if (value === undefined) return null
+  if (toBoolean(attrs.multiple)) return parseCommaList(value)
+  return value
+}
+
+export function dateRangeDefault(attrs: StaticAttrs) {
+  let start = normalizeDateInput(attrs.start)
+  let end = normalizeDateInput(attrs.end)
+  let preset = attrs.defaultValue
+  if (preset) {
+    let computed = computeDatePresetStrings(preset, end ? new Date(end) : new Date())
+    if (computed) return computed
+  }
+  return {start, end}
+}
+
+function computeDatePresetStrings(preset: string, baseEndInclusive: Date, options: {domainStart?: string | null; domainEnd?: string | null; today?: Date} = {}) {
+  let range = computeDatePresetRange(preset, baseEndInclusive, options)
+  if (!range) return null
+  return {start: range.start ? formatDate(range.start) : null, end: range.end ? formatDate(range.end) : null}
+}
+
+export function computeDatePresetRange(
+  preset: string,
+  baseEndInclusive: Date,
+  options: {domainStart?: string | null; domainEnd?: string | null; today?: Date} = {},
+): {start: Date | null; end: Date | null} | null {
+  let label = preset.trim()
+  let today = options.today || new Date()
+  let endExclusive = addDays(baseEndInclusive, 1)
+
+  let lastDaysMatch = label.match(/^Last (\d+) Days$/i)
+  if (lastDaysMatch) {
+    let days = parseInt(lastDaysMatch[1], 10)
+    return {start: addDays(endExclusive, -days), end: endExclusive}
+  }
+
+  let lastMonthsMatch = label.match(/^Last (\d+) Months$/i)
+  if (lastMonthsMatch) {
+    let months = parseInt(lastMonthsMatch[1], 10)
+    let monthEnd = startOfMonth(endExclusive)
+    return {start: addMonths(monthEnd, -months), end: monthEnd}
+  }
+
+  if (label === 'Last Month') {
+    let monthEnd = startOfMonth(endExclusive)
+    return {start: addMonths(monthEnd, -1), end: monthEnd}
+  }
+
+  if (label === 'Last Year') {
+    let yearEnd = startOfYear(endExclusive)
+    return {start: addYears(yearEnd, -1), end: yearEnd}
+  }
+
+  if (label === 'Last 365 Days') return {start: addDays(endExclusive, -365), end: endExclusive}
+  if (label === 'Month to Date') return {start: startOfMonth(endExclusive), end: endExclusive}
+  if (label === 'Month to Today') return {start: startOfMonth(today), end: addDays(today, 1)}
+  if (label === 'Year to Date') return {start: startOfYear(endExclusive), end: endExclusive}
+  if (label === 'Year to Today') return {start: startOfYear(today), end: addDays(today, 1)}
+  if (label === 'All Time') {
+    let start = options.domainStart ? new Date(options.domainStart) : null
+    let end = options.domainEnd ? addDays(new Date(options.domainEnd), 1) : endExclusive
+    return {start, end}
+  }
+
+  return null
+}
+
+export function normalizeDateInput(value: string | Date | null | undefined): string | null {
+  if (value === null || value === undefined) return null
+  if (value instanceof Date) return formatDate(value)
+  let parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return null
+  return formatDate(parsed)
+}
+
+export function formatDate(value: Date): string {
+  let year = value.getFullYear()
+  let month = String(value.getMonth() + 1).padStart(2, '0')
+  let day = String(value.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function addDays(value: Date, days: number): Date {
+  let copy = new Date(value)
+  copy.setDate(copy.getDate() + days)
+  return copy
+}
+
+export function addMonths(value: Date, months: number): Date {
+  let copy = new Date(value)
+  copy.setMonth(copy.getMonth() + months)
+  return copy
+}
+
+export function addYears(value: Date, years: number): Date {
+  let copy = new Date(value)
+  copy.setFullYear(copy.getFullYear() + years)
+  return copy
+}
+
+export function startOfMonth(value: Date): Date {
+  return new Date(value.getFullYear(), value.getMonth(), 1)
+}
+
+export function startOfYear(value: Date): Date {
+  return new Date(value.getFullYear(), 0, 1)
+}

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {onMount} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
+  import {DEFAULT_DATE_PRESETS, addDays, computeDatePresetRange, formatDate, normalizeDateInput} from '../component-utilities/pageInputDefaults.ts'
   import {captureInitial, getPageInputs} from '../internal/pageInputs.svelte.ts'
 
   interface Props {
@@ -23,8 +24,6 @@
     dates = undefined, hideDuringPrint = true,
   }: Props = $props()
 
-  const DEFAULT_PRESETS = ['Last 7 Days', 'Last 30 Days', 'Last 90 Days', 'Last 365 Days', 'Last Month', 'Last Year', 'Month to Date', 'Month to Today', 'Year to Date', 'Year to Today', 'All Time']
-
   let mounted = false
   let queryKey = ''
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
@@ -43,14 +42,14 @@
   let presetList = $derived((() => {
     if (Array.isArray(presetRanges)) return presetRanges
     if (presetRanges) return [presetRanges]
-    return DEFAULT_PRESETS
+    return DEFAULT_DATE_PRESETS
   })())
   let displayLabel = $derived(title || label)
 
   onMount(() => {
     mounted = true
-    currentStart = field.hasExternalValue ? field.value.start : normalizeInput(start)
-    currentEnd = field.hasExternalValue ? field.value.end : normalizeInput(end)
+    currentStart = field.hasExternalValue ? field.value.start : normalizeDateInput(start)
+    currentEnd = field.hasExternalValue ? field.value.end : normalizeDateInput(end)
     currentPreset = inferPreset(currentStart, currentEnd)
     if (field.hasExternalValue) updateParams()
     else if (defaultValue && presetList.includes(defaultValue)) applyPreset(defaultValue, false)
@@ -89,7 +88,7 @@
     let handler = (res: {rows?: any[]; error?: any}) => {
       if (!res || res.error || !res.rows?.length) return
       let values = res.rows
-        .map(row => normalizeInput(row[dates]))
+        .map(row => normalizeDateInput(row[dates]))
         .filter((val): val is string => !!val)
       if (!values.length) return
       values.sort()
@@ -113,51 +112,10 @@
     }
   }
 
-  function normalizeInput(value: string | Date | null | undefined): string | null {
-    if (value === null || value === undefined) return null
-    if (value instanceof Date) return formatDate(value)
-    let parsed = new Date(value)
-    if (Number.isNaN(parsed.getTime())) return null
-    return formatDate(parsed)
-  }
-
-  function formatDate(value: Date): string {
-    let year = value.getFullYear()
-    let month = String(value.getMonth() + 1).padStart(2, '0')
-    let day = String(value.getDate()).padStart(2, '0')
-    return `${year}-${month}-${day}`
-  }
-
-  function addDays(value: Date, days: number): Date {
-    let copy = new Date(value) // eslint-disable-line svelte/prefer-svelte-reactivity
-    copy.setDate(copy.getDate() + days)
-    return copy
-  }
-
   function addDaysString(value: string, days: number): string {
     let parsed = new Date(value)
     if (Number.isNaN(parsed.getTime())) return value
     return formatDate(addDays(parsed, days))
-  }
-
-  function startOfMonth(value: Date): Date {
-    return new Date(value.getFullYear(), value.getMonth(), 1)
-  }
-
-  function startOfYear(value: Date): Date {
-    return new Date(value.getFullYear(), 0, 1)
-  }
-
-  function addMonths(value: Date, months: number): Date {
-    let copy = new Date(value) // eslint-disable-line svelte/prefer-svelte-reactivity
-    copy.setMonth(copy.getMonth() + months)
-    return copy
-  }
-
-  function addYears(value: Date, years: number): Date {
-    let copy = new Date(value) // eslint-disable-line svelte/prefer-svelte-reactivity
-    copy.setFullYear(copy.getFullYear() + years)
-    return copy
   }
 
   // We only persist start/end in URL state, so the preset label is inferred by matching
@@ -174,7 +132,7 @@
     })()
     if (Number.isNaN(baseEnd.getTime())) return null
     for (let preset of presetList) {
-      let range = computePresetRange(preset, baseEnd)
+      let range = computeDatePresetRange(preset, baseEnd, {domainStart, domainEnd})
       let presetStart = range?.start ? formatDate(range.start) : null
       let presetEnd = range?.end ? formatDate(range.end) : null
       if (presetStart === startValue && presetEnd === endValue) return preset
@@ -211,79 +169,11 @@
       return new Date()
     })()
     if (Number.isNaN(baseEnd.getTime())) baseEnd = new Date()
-    let range = computePresetRange(preset, baseEnd)
+    let range = computeDatePresetRange(preset, baseEnd, {domainStart, domainEnd})
     if (!range) return
     let startVal = range.start ? formatDate(range.start) : null
     let endVal = range.end ? formatDate(range.end) : null
     setRange(startVal, endVal, preset, {markTouched, persist: true})
-  }
-
-  function computePresetRange(preset: string, baseEndInclusive: Date): {start: Date | null; end: Date | null} | null {
-    let label = preset.trim()
-    let today = new Date()
-    let endExclusive = addDays(baseEndInclusive, 1)
-
-    let lastDaysMatch = label.match(/^Last (\d+) Days$/i)
-    if (lastDaysMatch) {
-      let days = parseInt(lastDaysMatch[1], 10)
-      let startDate = addDays(endExclusive, -days)
-      return {start: startDate, end: endExclusive}
-    }
-
-    let lastMonthsMatch = label.match(/^Last (\d+) Months$/i)
-    if (lastMonthsMatch) {
-      let months = parseInt(lastMonthsMatch[1], 10)
-      let monthEnd = startOfMonth(endExclusive)
-      let startDate = addMonths(monthEnd, -months)
-      return {start: startDate, end: monthEnd}
-    }
-
-    if (label === 'Last Month') {
-      let monthEnd = startOfMonth(endExclusive)
-      let startDate = addMonths(monthEnd, -1)
-      return {start: startDate, end: monthEnd}
-    }
-
-    if (label === 'Last Year') {
-      let yearEnd = startOfYear(endExclusive)
-      let startDate = addYears(yearEnd, -1)
-      return {start: startDate, end: yearEnd}
-    }
-
-    if (label === 'Last 365 Days') {
-      let startDate = addDays(endExclusive, -365)
-      return {start: startDate, end: endExclusive}
-    }
-
-    if (label === 'Month to Date') {
-      let startDate = startOfMonth(endExclusive)
-      return {start: startDate, end: endExclusive}
-    }
-
-    if (label === 'Month to Today') {
-      let startDate = startOfMonth(today)
-      let endDate = addDays(today, 1)
-      return {start: startDate, end: endDate}
-    }
-
-    if (label === 'Year to Date') {
-      let startDate = startOfYear(endExclusive)
-      return {start: startDate, end: endExclusive}
-    }
-
-    if (label === 'Year to Today') {
-      let startDate = startOfYear(today)
-      let endDate = addDays(today, 1)
-      return {start: startDate, end: endDate}
-    }
-
-    if (label === 'All Time') {
-      let startDate = domainStart ? new Date(domainStart) : null
-      let endDate = domainEnd ? addDays(new Date(domainEnd), 1) : endExclusive
-      return {start: startDate, end: endDate}
-    }
-
-    return null
   }
 
   function onPresetChange(event: Event) {


### PR DESCRIPTION
This PR updates `graphene run` to take into account some feedback from using graphene to build an input-heavy dashboard. There were a couple of turns where the dashboard was just completely broken on load, with all components failing. This turned out to be due differences between the result of `graphene run` vs an actually-loaded dashboard with input values. This PR updates the run command to make several changes:

1. By default queries will be run with the default values from their corresponding input components, but can be overriden with `--input`
2. The run command supports a `--list-inputs` flag to print static page inputs, defaults, and locations
3. The run command has a new `--all-queries` flag which will run every query on the page headlessly


This did require refactoring some default-handling code from svelte components into more reusable helpers, but nothing too crazy.