### PR TITLE
add `--input` option to `graphene run`

### DIFF
--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -116,6 +116,13 @@ describe('cli run', () => {
     expect(res.stdout.toLowerCase()).toContain('total')
   })
 
+  it('runs an inline parameterized query with --input', async () => {
+    let res = await runCli(['run', 'from flights where carrier = $carrier select carrier, count() as total group by 1', '--input', 'carrier=AA'], {cwd: flightDir})
+    expectCliSuccess(res, 'run parameterized query')
+    expect(res.stdout).toContain('AA')
+    expect(res.stdout.toLowerCase()).toContain('total')
+  })
+
   it('loads the project config when running from a nested directory', async () => {
     let res = await runCli(['run', 'from flights select count() as total'], {cwd: path.join(flightDir, 'tables')})
     expectCliSuccess(res, 'run query from nested directory')
@@ -140,6 +147,37 @@ describe('cli run', () => {
     let res = await runCli(['run', 'index.md', '--query', 'performance_by_year'], {cwd: flightDir})
     expectCliSuccess(res, 'run markdown query')
     expect(res.stdout.toLowerCase()).toContain('flight_count')
+  })
+
+  it('runs a parameterized named query from a markdown file with --input', async () => {
+    let res = await runCli(['run', 'carrier_detail.md', '--query', 'carrier_info', '--input', 'carrier=AA'], {cwd: flightDir})
+    expectCliSuccess(res, 'run parameterized markdown query')
+    expect(res.stdout).toContain('AA')
+  })
+
+  it('prints a clean error for a missing markdown query input', async () => {
+    let res = await runCli(['run', 'carrier_detail.md', '--query', 'carrier_info'], {cwd: flightDir})
+    expect(res.code).toBe(1)
+    expect(res.stderr.trim()).toBe('Missing param $carrier')
+  })
+
+  it('treats repeated --input values as an array', async () => {
+    let res = await runCli(['run', 'from flights where carrier in ($carrier) select carrier group by 1 order by 1', '--input', 'carrier=AA', '--input', 'carrier=DL'], {cwd: flightDir})
+    expectCliSuccess(res, 'run repeated input query')
+    expect(res.stdout).toContain('AA')
+    expect(res.stdout).toContain('DL')
+  })
+
+  it('rejects --input without key=value syntax', async () => {
+    let res = await runCli(['run', 'from flights select count()', '--input', 'carrier'], {cwd: flightDir})
+    expect(res.code).toBe(1)
+    expect(res.stderr).toContain('Invalid --input "carrier". Expected key=value.')
+  })
+
+  it('rejects --input with an empty key', async () => {
+    let res = await runCli(['run', 'from flights select count()', '--input', '=AA'], {cwd: flightDir})
+    expect(res.code).toBe(1)
+    expect(res.stderr).toContain('Invalid --input "=AA". Expected key=value.')
   })
 
   it('uses a configured duckdb path when present', async () => {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -55,16 +55,18 @@ program
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
   .option('-c, --chart <chartTitleOrComponentId>', 'Title or component ID of a specific chart to capture')
   .option('-q, --query <queryName>', 'Query or table name to run from a markdown page')
+  .option('--input <key=value>', 'Input value to use for parameters; repeat for multiple values', collectInputOption, [])
   .action(
-    withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; query?: string}) => {
+    withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; query?: string; input?: string[]}) => {
       if (options.chart && options.query) {
         console.error('Cannot use --chart and --query together')
         return exit(1)
       }
 
+      let inputs = parseRunInputs(options.input || [], exit)
       let inputPath = getExistingPath(input)
       if (inputPath && inputPath.endsWith('.md')) {
-        let res = options.query ? await runNamedQueryFromMd(inputPath, options.query, telemetry) : await runMdFile({mdArg: inputPath, chart: options.chart, telemetry})
+        let res = options.query ? await runNamedQueryFromMd(inputPath, options.query, {inputs, telemetry}) : await runMdFile({mdArg: inputPath, chart: options.chart, inputs, telemetry})
         return exit(res ? 0 : 1)
       }
 
@@ -83,7 +85,7 @@ program
       let gsql = await readInput(input)
       let analysis = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: gsql})}, 'input')
       let [query] = validateInputQuery(analysis, exit)
-      let sql = toSql(query)
+      let sql = renderSql(query, inputs, exit)
       let res = await runQuery(sql)
       printTable(res.rows)
     }),
@@ -252,6 +254,40 @@ function validateInputQuery(analysis: AnalysisResult, exit: (code?: number) => n
     return exit(1)
   }
   return queries
+}
+
+function collectInputOption(value: string, previous: string[]) {
+  previous.push(value)
+  return previous
+}
+
+function parseRunInputs(values: string[], exit: (code?: number) => never): Record<string, string | string[]> {
+  let inputs = {} as Record<string, string | string[]>
+  for (let value of values) {
+    let index = value.indexOf('=')
+    let key = index >= 0 ? value.slice(0, index) : ''
+    if (index < 0 || !key) {
+      console.error(`Invalid --input "${value}". Expected key=value.`)
+      return exit(1)
+    }
+
+    let next = value.slice(index + 1)
+    let existing = inputs[key]
+    if (existing === undefined) inputs[key] = next
+    else if (Array.isArray(existing)) existing.push(next)
+    else inputs[key] = [existing, next]
+  }
+  return inputs
+}
+
+function renderSql(query: Query, inputs: Record<string, string | string[]>, exit: (code?: number) => never): string {
+  try {
+    return toSql(query, inputs)
+  } catch (err) {
+    if (err instanceof Error) console.error(err.message)
+    else console.error(String(err))
+    return exit(1)
+  }
 }
 
 function findCaseInsensitive(values: string[], needle: string): string | null {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -55,7 +55,7 @@ program
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
   .option('-c, --chart <chartTitleOrComponentId>', 'Title or component ID of a specific chart to capture')
   .option('-q, --query <queryName>', 'Query or table name to run from a markdown page')
-  .option('--input <key=value>', 'Input value to use for parameters; repeat for multiple values', collectInputOption, [])
+  .option('--input <key=value>', 'Input value to use for parameters; repeat for multiple values', (value, previous: string[]) => previous.concat(value), [])
   .action(
     withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; query?: string; input?: string[]}) => {
       if (options.chart && options.query) {
@@ -254,11 +254,6 @@ function validateInputQuery(analysis: AnalysisResult, exit: (code?: number) => n
     return exit(1)
   }
   return queries
-}
-
-function collectInputOption(value: string, previous: string[]) {
-  previous.push(value)
-  return previous
 }
 
 function parseRunInputs(values: string[], exit: (code?: number) => never): Record<string, string | string[]> {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -23,9 +23,12 @@ import {getWorkspaceScanCounts, type CliTelemetry} from './telemetry/index.ts'
 export interface RunMdFileOptions {
   mdArg: string
   chart?: string
+  inputs?: RunInputs
   log?: (...args: any[]) => void
   telemetry?: CliTelemetry
 }
+
+type RunInputs = Record<string, string | string[]>
 
 let browserConnections: {url: string; socket: WebSocket}[] = []
 let pendingRequests: Record<string, {response: ServerResponse<IncomingMessage>}> = {}
@@ -53,7 +56,7 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
     return false
   }
 
-  let resp = await sendSocketRequest({mdFile, action: 'check', chart: options.chart, log})
+  let resp = await sendSocketRequest({mdFile, action: 'check', chart: options.chart, inputs: options.inputs, log})
   if (!resp) return false
 
   let errors = Array.from(resp.errors || []) as GrapheneError[]
@@ -115,9 +118,9 @@ export async function listMdFileQueries(mdArg: string, telemetry?: CliTelemetry,
   return true
 }
 
-export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string, telemetry?: CliTelemetry): Promise<boolean> {
+export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string, options: {inputs?: RunInputs; telemetry?: CliTelemetry} = {}): Promise<boolean> {
   let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
-  telemetry?.event('workspace_scanned', {command: 'run', ...getWorkspaceScanCounts(files)})
+  options.telemetry?.event('workspace_scanned', {command: 'run', ...getWorkspaceScanCounts(files)})
   let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
   let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
 
@@ -137,15 +140,22 @@ export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: str
 
   let input = getFile(queryResult, 'input.md')
   if (!input?.queries.length) return false
-  let sql = toSql(input.queries[input.queries.length - 1])
+  let sql: string
+  try {
+    sql = toSql(input.queries[input.queries.length - 1], options.inputs || {})
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err))
+    return false
+  }
   let res = await runQuery(sql)
   printTable(res.rows)
   return true
 }
 
-async function sendSocketRequest({mdFile, action, chart, log}: {mdFile: string; action: 'check' | 'list'; chart?: string; log: (...args: any[]) => void}) {
+async function sendSocketRequest({mdFile, action, chart, inputs, log}: {mdFile: string; action: 'check' | 'list'; chart?: string; inputs?: RunInputs; log: (...args: any[]) => void}) {
   let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')
   if (pageUrl === '/index') pageUrl = '/'
+  pageUrl = appendInputsToUrl(pageUrl, inputs)
 
   if (process.env.NODE_ENV !== 'test' && !(await isServerRunning())) {
     log('Starting Graphene server...')
@@ -178,6 +188,17 @@ async function sendSocketRequest({mdFile, action, chart, log}: {mdFile: string; 
   }
 
   return resp
+}
+
+function appendInputsToUrl(pageUrl: string, inputs: RunInputs = {}) {
+  let search = new URLSearchParams()
+  Object.entries(inputs).forEach(([name, value]) => {
+    if (Array.isArray(value)) value.forEach(item => search.append(name, item))
+    else search.append(name, value)
+  })
+  let rendered = search.toString()
+  if (!rendered) return pageUrl
+  return `${pageUrl}?${rendered}`
 }
 
 async function fetchSocketRequest({host, pageUrl, action, chart}: {host: string; pageUrl: string; action: 'check' | 'list'; chart?: string}) {

--- a/cli/telemetry.test.ts
+++ b/cli/telemetry.test.ts
@@ -19,7 +19,7 @@ describe('cli telemetry', () => {
   })
 
   it('tracks only safe flag names, not values', () => {
-    expect(getPresentFlags('run', ['run', 'report.md', '--query', 'weekly_trends', '--chart', 'Revenue by Region'])).toEqual(['chart', 'query'])
+    expect(getPresentFlags('run', ['run', 'report.md', '--query', 'weekly_trends', '--chart', 'Revenue by Region', '--input', 'carrier=AA'])).toEqual(['chart', 'input', 'query'])
     expect(getPresentFlags('serve', ['serve', '--bg'])).toEqual(['bg'])
     expect(getPresentFlags('schema', ['schema', 'analytics.orders'])).toEqual([])
   })

--- a/cli/telemetry/index.ts
+++ b/cli/telemetry/index.ts
@@ -12,7 +12,7 @@ export type {TelemetryCommand, TelemetryEventName, TelemetryPayloads} from './ty
 
 const DEFAULT_TELEMETRY_ENDPOINT = 'https://app.graphenedata.com/cli-telemetry'
 const SAFE_FLAG_NAMES: Partial<Record<TelemetryCommand, Record<string, string[]>>> = {
-  run: {chart: ['--chart', '-c'], query: ['--query', '-q']},
+  run: {chart: ['--chart', '-c'], input: ['--input'], query: ['--query', '-q']},
   serve: {bg: ['--bg']},
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,9 +8,11 @@ graphene check path/to/file.gsql # Check diagnostics for one specific gsql file
 graphene check path/to/page.md # Check diagnostics for one specific markdown file
 
 graphene run "from flights select count() as total" # Run inline GSQL and print results
+graphene run 'from flights where carrier = $carrier select count() as total' --input carrier=AA # Provide parameter input values
 graphene run - # Read GSQL from stdin and print results
 
 graphene run path/to/page.md # Run the page and save a full-page screenshot
+graphene run path/to/page.md --input carrier=AA # Run the page with input values, overriding page defaults
 
 # `-c/--chart` can target either a chart title or the chart's `queryId`. For charts without titles use `graphene list` to see the exact IDs for charts on a page.
 graphene run path/to/page.md -c "Chart Title" # Run the page and screenshot one chart by title
@@ -18,6 +20,10 @@ graphene run path/to/page.md -c 'Query (data="query_name" x="category" y="total"
 
 # `-q/--query` can target anything usable in a chart `data` prop (for example, a gsql table or a named code-fenced query in the markdown file).
 graphene run path/to/page.md -q query_name # Run a named query/table from the markdown context and print results
+graphene run path/to/page.md -q query_name --input carrier=AA # Run a parameterized named query/table
+
+# `--input` values are strings. Repeat the flag to pass multiple values for one input.
+graphene run path/to/page.md --input carrier=AA --input carrier=DL
 
 graphene compile "[GSQL]" # Show the compiled, dialect-specific SQL
 

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -4,7 +4,7 @@ import {check} from '../../cli/check.ts'
 import {mockFileMap} from '../../cli/mockFiles.ts'
 import {listMdFileQueries, runMdFile} from '../../cli/run.ts'
 import {trimIndentation} from '../../lang/util.ts'
-import {test, expect} from './fixtures.ts'
+import {test, expect, waitForGrapheneLoad} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
 
 let logs = ''
@@ -333,6 +333,40 @@ test('cli run with --chart captures a single chart screenshot', async ({server, 
 
   await page.goto(server.url())
   await runMdFile({mdArg: 'index.md', chart: 'Carrier Distance', log})
+  expect(outputLines()).toEqual(
+    trimIndentation(`
+    No errors found 💎
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
+  `),
+  )
+})
+
+test('cli run with --input applies inputs to a full page run', async ({server, page}) => {
+  let queryBodies: any[] = []
+  server.mockFile(
+    '/index.md',
+    `
+    # Input Page
+    <TextInput name="carrier" title="Carrier" defaultValue="WN" />
+
+    \`\`\`sql filtered
+    from flights where carrier = $carrier select carrier, count() as total group by 1
+    \`\`\`
+    <Table data="filtered" />
+  `,
+  )
+
+  await page.route('**/_api/query', async route => {
+    queryBodies.push(route.request().postDataJSON())
+    await route.continue()
+  })
+
+  await page.goto(server.url() + '/?carrier=AA')
+  await waitForGrapheneLoad(page)
+  let result = await runMdFile({mdArg: 'index.md', inputs: {carrier: 'AA'}, log})
+
+  expect(result).toBe(true)
+  expect(queryBodies.some(body => JSON.stringify(body.params) == JSON.stringify({carrier: 'AA'}))).toBe(true)
   expect(outputLines()).toEqual(
     trimIndentation(`
     No errors found 💎


### PR DESCRIPTION
Taking another pass at this, much simplified from #358. This PR adds a `--input` option to `graphene run` which can be used to specify input values. This is particularly important for running parameterized queries with `graphene run -q` which previously you couldn't do. This pass I opted to avoid all the bits related to listing inputs and extracting default input values. That was kind of nice, but it added a lot of complexity and I think this should work as an easy loop if the agent hits an "Error: missing param $foo" when attempting to run a query.