### PR TITLE
rework `<GrapheneQuery/>` prop escaping to avoid Svelte interpolation

### DIFF
--- a/cli/mdCompile.test.ts
+++ b/cli/mdCompile.test.ts
@@ -35,6 +35,25 @@ from flights
     expect(code).toContain('<GrapheneQuery name="{`repro`}" code="{`select\\n  format(\'{:.1%}\', 0.5) as pct\\nfrom flights`}"></GrapheneQuery>')
   })
 
+  it('keeps query comparison operators as JavaScript escapes instead of HTML entities', async () => {
+    let src = `
+\`\`\`sql repro
+select * from products
+where created_at >= coalesce($daterange_start, created_at)
+  and created_at <= coalesce($daterange_end, created_at)
+\`\`\`
+`
+
+    let out = await compile(src, {extensions: ['.md'], remarkPlugins, rehypePlugins, filename: '/tmp/repro.md'})
+    if (!out) throw new Error('Expected mdsvex compile output')
+    let code = String(out.code)
+
+    expect(code).toContain('created_at \\u003e= coalesce')
+    expect(code).toContain('created_at \\u003c= coalesce')
+    expect(code).not.toContain('&gt;')
+    expect(code).not.toContain('&lt;')
+  })
+
   it('keeps wrapper components intact across blank lines', async () => {
     let src = `
 <Row>

--- a/cli/mdCompile.test.ts
+++ b/cli/mdCompile.test.ts
@@ -1,5 +1,4 @@
 /// <reference types="vitest/globals" />
-import {Buffer} from 'buffer'
 import {compile} from 'mdsvex'
 
 import {extractFrontmatter, remarkPlugins, rehypePlugins} from './mdCompile.ts'
@@ -33,9 +32,7 @@ from flights
     if (!out) throw new Error('Expected mdsvex compile output')
     let code = String(out.code)
 
-    let expectedCode = Buffer.from("select\n  format('{:.1%}', 0.5) as pct\nfrom flights", 'utf-8').toString('base64')
-    expect(code).toContain(`<GrapheneQuery name="cmVwcm8=" code="${expectedCode}"></GrapheneQuery>`)
-    expect(code).not.toContain('{:.1%}')
+    expect(code).toContain('<GrapheneQuery name="{`repro`}" code="{`select\\n  format(\'{:.1%}\', 0.5) as pct\\nfrom flights`}"></GrapheneQuery>')
   })
 
   it('keeps wrapper components intact across blank lines', async () => {

--- a/cli/mdCompile.test.ts
+++ b/cli/mdCompile.test.ts
@@ -34,7 +34,7 @@ from flights
     let code = String(out.code)
 
     let expectedCode = Buffer.from("select\n  format('{:.1%}', 0.5) as pct\nfrom flights", 'utf-8').toString('base64')
-    expect(code).toContain(`<GrapheneQuery encodedName="cmVwcm8=" encodedCode="${expectedCode}"></GrapheneQuery>`)
+    expect(code).toContain(`<GrapheneQuery name="cmVwcm8=" code="${expectedCode}"></GrapheneQuery>`)
     expect(code).not.toContain('{:.1%}')
   })
 

--- a/cli/mdCompile.test.ts
+++ b/cli/mdCompile.test.ts
@@ -1,4 +1,5 @@
 /// <reference types="vitest/globals" />
+import {Buffer} from 'buffer'
 import {compile} from 'mdsvex'
 
 import {extractFrontmatter, remarkPlugins, rehypePlugins} from './mdCompile.ts'
@@ -19,6 +20,24 @@ describe('extractFrontmatter', () => {
 })
 
 describe('markdown sanitization', () => {
+  it('keeps query code braces inside string literals', async () => {
+    let src = `
+\`\`\`sql repro
+select
+  format('{:.1%}', 0.5) as pct
+from flights
+\`\`\`
+`
+
+    let out = await compile(src, {extensions: ['.md'], remarkPlugins, rehypePlugins, filename: '/tmp/repro.md'})
+    if (!out) throw new Error('Expected mdsvex compile output')
+    let code = String(out.code)
+
+    let expectedCode = Buffer.from("select\n  format('{:.1%}', 0.5) as pct\nfrom flights", 'utf-8').toString('base64')
+    expect(code).toContain(`<GrapheneQuery encodedName="cmVwcm8=" encodedCode="${expectedCode}"></GrapheneQuery>`)
+    expect(code).not.toContain('{:.1%}')
+  })
+
   it('keeps wrapper components intact across blank lines', async () => {
     let src = `
 <Row>

--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -1,5 +1,6 @@
 import type {Plugin} from 'unified'
 
+import {Buffer} from 'buffer'
 import {decodeHTML} from 'entities'
 import fs from 'fs'
 import yaml from 'js-yaml'
@@ -8,8 +9,8 @@ import path from 'path'
 import sanitizeHtml from 'sanitize-html'
 import {visit} from 'unist-util-visit'
 
-function escapeHtml(str: string) {
-  return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+function base64Attr(str: string) {
+  return Buffer.from(str, 'utf-8').toString('base64')
 }
 
 // Takes the contents of a <ECharts> tag, and json5 parses it
@@ -31,7 +32,7 @@ export function extractQueries() {
       if (index === null) return
       let name = typeof node.meta === 'string' ? node.meta : ''
       let code = typeof node.value === 'string' ? node.value.trim() : ''
-      parent.children[index] = {type: 'html', value: `<GrapheneQuery name="${escapeHtml(name)}" code="${escapeHtml(code)}" />`}
+      parent.children[index] = {type: 'html', value: `<GrapheneQuery encodedName="${base64Attr(name)}" encodedCode="${base64Attr(code)}" />`}
     })
   }
 }

--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -8,14 +8,19 @@ import path from 'path'
 import sanitizeHtml from 'sanitize-html'
 import {visit} from 'unist-util-visit'
 
-function escapeHtml(str: string) {
-  return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-}
-
-// Keep SQL inside a Svelte expression string while still surviving HTML attribute parsing.
+// Use JS escapes for HTML-sensitive chars so Svelte restores them before query registration.
 function svelteStringAttr(str: string) {
-  let literal = str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${').replace(/\r/g, '\\r').replace(/\n/g, '\\n')
-  return escapeHtml(`{\`${literal}\`}`)
+  let literal = str
+    .replace(/\\/g, '\\\\')
+    .replace(/`/g, '\\`')
+    .replace(/\$\{/g, '\\${')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/&/g, '\\u0026')
+    .replace(/"/g, '\\u0022')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+  return `{\`${literal}\`}`
 }
 
 // Takes the contents of a <ECharts> tag, and json5 parses it

--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -8,14 +8,14 @@ import path from 'path'
 import sanitizeHtml from 'sanitize-html'
 import {visit} from 'unist-util-visit'
 
-function escapeHtmlAttr(str: string) {
+function escapeHtml(str: string) {
   return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
 // Keep SQL inside a Svelte expression string while still surviving HTML attribute parsing.
 function svelteStringAttr(str: string) {
   let literal = str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${').replace(/\r/g, '\\r').replace(/\n/g, '\\n')
-  return escapeHtmlAttr(`{\`${literal}\`}`)
+  return escapeHtml(`{\`${literal}\`}`)
 }
 
 // Takes the contents of a <ECharts> tag, and json5 parses it

--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -32,7 +32,7 @@ export function extractQueries() {
       if (index === null) return
       let name = typeof node.meta === 'string' ? node.meta : ''
       let code = typeof node.value === 'string' ? node.value.trim() : ''
-      parent.children[index] = {type: 'html', value: `<GrapheneQuery encodedName="${base64Attr(name)}" encodedCode="${base64Attr(code)}" />`}
+      parent.children[index] = {type: 'html', value: `<GrapheneQuery name="${base64Attr(name)}" code="${base64Attr(code)}" />`}
     })
   }
 }

--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -1,6 +1,5 @@
 import type {Plugin} from 'unified'
 
-import {Buffer} from 'buffer'
 import {decodeHTML} from 'entities'
 import fs from 'fs'
 import yaml from 'js-yaml'
@@ -9,8 +8,14 @@ import path from 'path'
 import sanitizeHtml from 'sanitize-html'
 import {visit} from 'unist-util-visit'
 
-function base64Attr(str: string) {
-  return Buffer.from(str, 'utf-8').toString('base64')
+function escapeHtmlAttr(str: string) {
+  return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+// Keep SQL inside a Svelte expression string while still surviving HTML attribute parsing.
+function svelteStringAttr(str: string) {
+  let literal = str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${').replace(/\r/g, '\\r').replace(/\n/g, '\\n')
+  return escapeHtmlAttr(`{\`${literal}\`}`)
 }
 
 // Takes the contents of a <ECharts> tag, and json5 parses it
@@ -32,7 +37,7 @@ export function extractQueries() {
       if (index === null) return
       let name = typeof node.meta === 'string' ? node.meta : ''
       let code = typeof node.value === 'string' ? node.value.trim() : ''
-      parent.children[index] = {type: 'html', value: `<GrapheneQuery name="${base64Attr(name)}" code="${base64Attr(code)}" />`}
+      parent.children[index] = {type: 'html', value: `<GrapheneQuery name="${svelteStringAttr(name)}" code="${svelteStringAttr(code)}" />`}
     })
   }
 }

--- a/ui/components/GrapheneQuery.svelte
+++ b/ui/components/GrapheneQuery.svelte
@@ -10,8 +10,8 @@
 
   let {name = '', code = '', encodedName, encodedCode}: Props = $props()
 
-  // Fenced markdown queries are encoded so SQL syntax never has to survive Svelte's HTML parser.
-  function decodeQueryAttr(value: string) {
+  // Fenced markdown queries are base64-encoded so SQL syntax never has to survive Svelte's HTML parser.
+  function decodeBase64QueryAttr(value: string) {
     let binary = atob(value)
     let bytes = Uint8Array.from(binary, char => char.charCodeAt(0))
     return new TextDecoder().decode(bytes)
@@ -19,7 +19,7 @@
 
   onMount(() => {
     if (typeof window !== 'undefined' && window.$GRAPHENE) {
-      window.$GRAPHENE.registerQuery(encodedName ? decodeQueryAttr(encodedName) : name, encodedCode ? decodeQueryAttr(encodedCode) : code)
+      window.$GRAPHENE.registerQuery(encodedName ? decodeBase64QueryAttr(encodedName) : name, encodedCode ? decodeBase64QueryAttr(encodedCode) : code)
     }
   })
 </script>

--- a/ui/components/GrapheneQuery.svelte
+++ b/ui/components/GrapheneQuery.svelte
@@ -2,13 +2,11 @@
   import {onMount} from 'svelte'
 
   interface Props {
-    name?: string
-    code?: string
-    encodedName?: string
-    encodedCode?: string
+    name: string
+    code: string
   }
 
-  let {name = '', code = '', encodedName, encodedCode}: Props = $props()
+  let {name, code}: Props = $props()
 
   // Fenced markdown queries are base64-encoded so SQL syntax never has to survive Svelte's HTML parser.
   function decodeBase64QueryAttr(value: string) {
@@ -19,7 +17,7 @@
 
   onMount(() => {
     if (typeof window !== 'undefined' && window.$GRAPHENE) {
-      window.$GRAPHENE.registerQuery(encodedName ? decodeBase64QueryAttr(encodedName) : name, encodedCode ? decodeBase64QueryAttr(encodedCode) : code)
+      window.$GRAPHENE.registerQuery(decodeBase64QueryAttr(name), decodeBase64QueryAttr(code))
     }
   })
 </script>

--- a/ui/components/GrapheneQuery.svelte
+++ b/ui/components/GrapheneQuery.svelte
@@ -8,16 +8,9 @@
 
   let {name, code}: Props = $props()
 
-  // Fenced markdown queries are base64-encoded so SQL syntax never has to survive Svelte's HTML parser.
-  function decodeBase64QueryAttr(value: string) {
-    let binary = atob(value)
-    let bytes = Uint8Array.from(binary, char => char.charCodeAt(0))
-    return new TextDecoder().decode(bytes)
-  }
-
   onMount(() => {
     if (typeof window !== 'undefined' && window.$GRAPHENE) {
-      window.$GRAPHENE.registerQuery(decodeBase64QueryAttr(name), decodeBase64QueryAttr(code))
+      window.$GRAPHENE.registerQuery(name, code)
     }
   })
 </script>

--- a/ui/components/GrapheneQuery.svelte
+++ b/ui/components/GrapheneQuery.svelte
@@ -2,15 +2,24 @@
   import {onMount} from 'svelte'
 
   interface Props {
-    name: string
-    code: string
+    name?: string
+    code?: string
+    encodedName?: string
+    encodedCode?: string
   }
 
-  let {name, code}: Props = $props()
+  let {name = '', code = '', encodedName, encodedCode}: Props = $props()
+
+  // Fenced markdown queries are encoded so SQL syntax never has to survive Svelte's HTML parser.
+  function decodeQueryAttr(value: string) {
+    let binary = atob(value)
+    let bytes = Uint8Array.from(binary, char => char.charCodeAt(0))
+    return new TextDecoder().decode(bytes)
+  }
 
   onMount(() => {
     if (typeof window !== 'undefined' && window.$GRAPHENE) {
-      window.$GRAPHENE.registerQuery(name, code)
+      window.$GRAPHENE.registerQuery(encodedName ? decodeQueryAttr(encodedName) : name, encodedCode ? decodeQueryAttr(encodedCode) : code)
     }
   })
 </script>


### PR DESCRIPTION
This turned out to be an issue with the rendering of the GrapheneQuery svelte component - if you ran `npx graphene run repro-gt-escape.md -q delayed_flights` it would show you the actual duckdb error with the format string. However the `escapeHtml` helper used to escape query when compiling markdown was not escaping everything that the Svelte parser would interpret. Per Codex:

>  cli/mdCompile.ts was turning the fenced SQL into:
>
>  ```
>  <GrapheneQuery code="select
>    format('{:.1%}', 0.5) as pct
>  from flights" />
> ```
>
>  Svelte still parses {...} inside quoted component attributes as JS interpolation, so {:.1%} was treated as invalid JS before the query ever reached DuckDB.

~I opted to fix this by simply base64 encoding the name/code props rather than trying to escape them. This feels a bit gross, but trying to fully escape these in a way that definitely survives the full mdsvex/rehype/sanitize-html pipeline looked hairy.~

Per your comment, reworked to use the approach from https://github.com/sveltejs/svelte/issues/2602#issuecomment-487375068 to avoid the Svelte interpolation

With the change the duckdb error bubbles up as expected:
<img width="730" height="148" alt="Screenshot 2026-05-05 at 2 07 32 PM" src="https://github.com/user-attachments/assets/b1915521-72e5-41d3-8b9a-5222dce18e32" />

