### PR TITLE
`create-graphene` tweaks

### DIFF
--- a/create/create.test.ts
+++ b/create/create.test.ts
@@ -347,6 +347,8 @@ describe('runCreate', () => {
 
     let linkTarget = await readlink(path.join(root, 'demo-app/.claude/skills/graphene'))
     expect(linkTarget).toBe('../../node_modules/@graphenedata/cli/dist/skills/graphene')
+    expect(await readFile(path.join(root, 'demo-app/CLAUDE.md'), 'utf8')).toContain('npx graphene check')
+    expect(await lstat(path.join(root, 'demo-app/AGENTS.md')).catch(() => null)).toBeNull()
   })
 
   it('skips dependency installation with --no-install', async () => {

--- a/create/create.test.ts
+++ b/create/create.test.ts
@@ -121,7 +121,7 @@ describe('runCreate', () => {
     let stdout = streamSink()
     let stderr = streamSink()
 
-    textMock.mockResolvedValueOnce('my-analytics').mockResolvedValueOnce('MY_DB.ANALYTICS').mockResolvedValueOnce('myorg-myaccount').mockResolvedValueOnce('graphene_user')
+    textMock.mockResolvedValueOnce('my-analytics').mockResolvedValueOnce('myorg-myaccount').mockResolvedValueOnce('graphene_user')
     selectMock.mockResolvedValueOnce('snowflake').mockResolvedValueOnce('none')
     pathMock.mockResolvedValue(keyPath)
     passwordMock.mockResolvedValue('secret')
@@ -132,9 +132,9 @@ describe('runCreate', () => {
     let pkg = JSON.parse(await readFile(path.join(root, 'my-analytics', 'package.json'), 'utf8'))
     expect(pkg.graphene).toEqual({
       dialect: 'snowflake',
-      defaultNamespace: 'MY_DB.ANALYTICS',
       snowflake: {account: 'myorg-myaccount', username: 'graphene_user'},
     })
+    expect(textMock).not.toHaveBeenCalledWith(expect.objectContaining({message: 'Default namespace (optional)'}))
     expect(pkg.dependencies['snowflake-sdk']).toBeTruthy()
     expect(await readFile(path.join(root, 'my-analytics', '.env'), 'utf8')).toContain(`SNOWFLAKE_PRI_KEY_PATH=${keyPath}`)
     expect(snowflakeCreateConnectionMock).toHaveBeenCalledWith(expect.objectContaining({account: 'myorg-myaccount', username: 'graphene_user', privateKeyPath: keyPath}))
@@ -149,13 +149,7 @@ describe('runCreate', () => {
     await writeFile(goodKeyPath, 'good private key')
     let {runCreate} = await import('./create.ts')
 
-    textMock
-      .mockResolvedValueOnce('my-analytics')
-      .mockResolvedValueOnce('MY_DB.ANALYTICS')
-      .mockResolvedValueOnce('bad-account')
-      .mockResolvedValueOnce('bad_user')
-      .mockResolvedValueOnce('good-account')
-      .mockResolvedValueOnce('good_user')
+    textMock.mockResolvedValueOnce('my-analytics').mockResolvedValueOnce('bad-account').mockResolvedValueOnce('bad_user').mockResolvedValueOnce('good-account').mockResolvedValueOnce('good_user')
     selectMock.mockResolvedValueOnce('snowflake').mockResolvedValueOnce('edit').mockResolvedValueOnce('none')
     pathMock.mockResolvedValueOnce(badKeyPath).mockResolvedValueOnce(goodKeyPath)
     passwordMock.mockResolvedValueOnce('bad-secret').mockResolvedValueOnce('good-secret')
@@ -176,7 +170,7 @@ describe('runCreate', () => {
     await writeFile(keyPath, 'private key')
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('my-analytics').mockResolvedValueOnce('MY_DB.ANALYTICS').mockResolvedValueOnce('myorg-myaccount').mockResolvedValueOnce('graphene_user')
+    textMock.mockResolvedValueOnce('my-analytics').mockResolvedValueOnce('myorg-myaccount').mockResolvedValueOnce('graphene_user')
     selectMock.mockResolvedValueOnce('snowflake').mockResolvedValueOnce('continue').mockResolvedValueOnce('none')
     pathMock.mockResolvedValue(keyPath)
     passwordMock.mockResolvedValue('secret')
@@ -196,7 +190,7 @@ describe('runCreate', () => {
     await writeFile(keyPath, 'private key')
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('my-analytics').mockResolvedValueOnce('MY_DB.ANALYTICS').mockResolvedValueOnce('myorg-myaccount').mockResolvedValueOnce('graphene_user')
+    textMock.mockResolvedValueOnce('my-analytics').mockResolvedValueOnce('myorg-myaccount').mockResolvedValueOnce('graphene_user')
     selectMock.mockResolvedValueOnce('snowflake').mockResolvedValueOnce('none')
     pathMock.mockResolvedValue(keyPath)
     passwordMock.mockResolvedValue('secret')
@@ -212,7 +206,7 @@ describe('runCreate', () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('clickhouse-app').mockResolvedValueOnce('').mockResolvedValueOnce('https://example.clickhouse.cloud:8443').mockResolvedValueOnce('default')
+    textMock.mockResolvedValueOnce('clickhouse-app').mockResolvedValueOnce('https://example.clickhouse.cloud:8443').mockResolvedValueOnce('default')
     selectMock.mockResolvedValueOnce('clickhouse').mockResolvedValueOnce('none')
     passwordMock.mockResolvedValue('secret')
     spawnMock.mockImplementation(() => createChild())
@@ -222,7 +216,6 @@ describe('runCreate', () => {
     let pkg = JSON.parse(await readFile(path.join(root, 'clickhouse-app', 'package.json'), 'utf8'))
     expect(pkg.graphene).toEqual({
       dialect: 'clickhouse',
-      defaultNamespace: 'default',
       clickhouse: {url: 'https://example.clickhouse.cloud:8443', username: 'default'},
     })
     expect(pkg.dependencies['@clickhouse/client']).toBe('^1.18.2')
@@ -244,7 +237,7 @@ describe('runCreate', () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
+    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('')
     selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('none')
     spawnMock.mockImplementation(() => createChild())
 
@@ -311,7 +304,7 @@ describe('runCreate', () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
+    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('')
     selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('none')
     spawnMock.mockImplementation(() => createChild())
 
@@ -332,7 +325,7 @@ describe('runCreate', () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
+    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('')
     selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('.agents')
     spawnMock.mockImplementation(() => createChild())
 
@@ -346,7 +339,7 @@ describe('runCreate', () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('').mockResolvedValueOnce('')
+    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('')
     selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('.claude')
     spawnMock.mockImplementation(() => createChild())
 

--- a/create/create.test.ts
+++ b/create/create.test.ts
@@ -233,11 +233,11 @@ describe('runCreate', () => {
     await expect(runCreate({argv: ['demo-app', '--yes'], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})).rejects.toThrow('Target directory is not empty')
   })
 
-  it('leaves duckdb config unset when the path prompt is blank', async () => {
+  it('leaves duckdb config unset and explains how to add the file', async () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('')
+    textMock.mockResolvedValueOnce('demo-app')
     selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('none')
     spawnMock.mockImplementation(() => createChild())
 
@@ -247,6 +247,12 @@ describe('runCreate', () => {
     expect(pkg.graphene).toEqual({dialect: 'duckdb'})
     expect(pkg.dependencies['@duckdb/node-api']).toBe('1.3.2-alpha.26')
     expect(await readFile(path.join(root, 'demo-app', 'AGENTS.md'), 'utf8')).toContain('npx graphene check')
+    expect(textMock).not.toHaveBeenCalledWith(expect.objectContaining({message: 'Path to .duckdb file'}))
+    let message = outroMock.mock.calls.at(-1)?.[0]
+    expect(message).toContain('\u001b[36m.duckdb\u001b[39m')
+    expect(message).toContain('"graphene": {')
+    expect(message).toContain('"duckdb": {')
+    expect(message).toContain('"path": "/path/to/example')
   })
 
   it('streams install output into the task log and keeps line breaks on success', async () => {
@@ -304,7 +310,7 @@ describe('runCreate', () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('')
+    textMock.mockResolvedValueOnce('demo-app')
     selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('none')
     spawnMock.mockImplementation(() => createChild())
 
@@ -325,7 +331,7 @@ describe('runCreate', () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('')
+    textMock.mockResolvedValueOnce('demo-app')
     selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('.agents')
     spawnMock.mockImplementation(() => createChild())
 
@@ -339,7 +345,7 @@ describe('runCreate', () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
-    textMock.mockResolvedValueOnce('demo-app').mockResolvedValueOnce('')
+    textMock.mockResolvedValueOnce('demo-app')
     selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('.claude')
     spawnMock.mockImplementation(() => createChild())
 

--- a/create/create.ts
+++ b/create/create.ts
@@ -367,13 +367,6 @@ async function promptExistingFilePath({
   }
 }
 
-function namespacePlaceholder(database: Database) {
-  if (database === 'snowflake') return 'MY_DB.ANALYTICS'
-  if (database === 'bigquery') return 'my-project.analytics'
-  if (database === 'clickhouse') return 'default'
-  return 'analytics'
-}
-
 function getWarehouseClient(database: Database): WarehouseClient {
   if (database === 'snowflake') return 'snowflake-sdk'
   if (database === 'bigquery') return '@google-cloud/bigquery'
@@ -608,21 +601,11 @@ async function collectAnswers({options, packageManager, input, output}: {options
     }),
   )
 
-  let defaultNamespace = unwrapPrompt(
-    await clack.text({
-      message: 'Default namespace (optional)',
-      placeholder: namespacePlaceholder(database),
-      ...promptOptions(input, output),
-    }),
-  ).trim()
-  if (!defaultNamespace && database === 'clickhouse') defaultNamespace = 'default'
-
   let answers: ScaffoldAnswers = {
     targetDir,
     projectName,
     packageManager,
     database,
-    defaultNamespace: defaultNamespace || undefined,
     skillLinkTarget: 'none',
   }
 

--- a/create/create.ts
+++ b/create/create.ts
@@ -4,6 +4,7 @@ import * as clack from '@clack/prompts'
 import {spawn} from 'node:child_process'
 import {access, mkdir, readFile, readlink, readdir, symlink, writeFile} from 'node:fs/promises'
 import path from 'node:path'
+import {styleText} from 'node:util'
 
 import cliPackageJson from '../cli/package.json' with {type: 'json'}
 
@@ -614,20 +615,7 @@ async function collectAnswers({options, packageManager, input, output}: {options
     skillLinkTarget: 'none',
   }
 
-  if (database === 'duckdb') {
-    answers.duckdbPath =
-      unwrapPrompt(
-        await clack.text({
-          message: 'Path to .duckdb file',
-          placeholder: './data.duckdb',
-          validate(value) {
-            if (typeof value !== 'string' || !value.trim()) return
-            if (!value.endsWith('.duckdb')) return 'DuckDB path must end with .duckdb'
-          },
-          ...promptOptions(input, output),
-        }),
-      ).trim() || undefined
-  } else {
+  if (database !== 'duckdb') {
     await collectWarehouseCredentials(answers, options, input, output)
   }
 
@@ -749,7 +737,7 @@ export async function runCreate({argv, cwd, env = {}, stdin, stdout}: CreateCont
       await symlinkGrapheneSkill(targetDir, answers.skillLinkTarget)
     }
 
-    clack.outro('Done!', {output: stdout})
+    clack.outro(completionMessage(answers), {output: stdout})
   } catch (err) {
     if (err instanceof CreateCancelled) {
       clack.cancel('Operation cancelled.', {output: stdout})
@@ -757,4 +745,25 @@ export async function runCreate({argv, cwd, env = {}, stdin, stdout}: CreateCont
     }
     throw err
   }
+}
+
+function completionMessage(answers: ScaffoldAnswers): string {
+  if (answers.database !== 'duckdb') return 'Done!'
+  return [
+    'Done!',
+    '',
+    `For DuckDB, copy your ${color('cyan', '.duckdb')} file into the ${color('magenta', answers.projectName)} folder so Graphene can discover it.`,
+    '',
+    `If the duckdb file lives elsewhere, set the path in ${color('magenta', 'package.json')}:`,
+    '',
+    color('gray', '"graphene": {'),
+    color('gray', '  "duckdb": {'),
+    color('gray', '    "path": "/path/to/example.duckdb"'),
+    color('gray', '  }'),
+    color('gray', '}'),
+  ].join('\n')
+}
+
+function color(style: Parameters<typeof styleText>[0], text: string): string {
+  return styleText(style, text, {validateStream: false})
 }

--- a/create/create.ts
+++ b/create/create.ts
@@ -226,7 +226,7 @@ export function renderTemplate({answers, cliVersion}: {answers: ScaffoldAnswers;
   let files: TemplateFiles = {
     'package.json': JSON.stringify(pkg, null, 2) + '\n',
     '.gitignore': ['node_modules', '.env', '*.duckdb'].join('\n') + '\n',
-    'AGENTS.md': renderAgents(answers),
+    [agentsFileName(answers.skillLinkTarget)]: renderAgents(answers),
     'index.md': renderIndex(answers),
   }
   if (answers.packageManager?.name === 'yarn') files['.yarnrc.yml'] = 'nodeLinker: node-modules\n'
@@ -242,6 +242,11 @@ function grapheneCommand(packageManager: PackageManager | undefined, args: strin
   if (packageManager?.name === 'yarn') return `yarn graphene ${args}`
   if (packageManager?.name === 'bun') return `bun run graphene ${args}`
   return `npx graphene ${args}`
+}
+
+function agentsFileName(skillLinkTarget: SkillLinkTarget): 'AGENTS.md' | 'CLAUDE.md' {
+  if (skillLinkTarget === '.claude') return 'CLAUDE.md'
+  return 'AGENTS.md'
 }
 
 function renderAgents(answers: ScaffoldAnswers): string {

--- a/create/helpers.test.ts
+++ b/create/helpers.test.ts
@@ -99,6 +99,17 @@ describe('create helpers', () => {
     expect(bunFiles['.yarnrc.yml']).toBeUndefined()
   })
 
+  it('renders CLAUDE.md when the Claude skill target is selected', () => {
+    let files = renderTemplate({
+      cliVersion: '0.0.15',
+      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'pnpm', version: '10.1.0'}, database: 'duckdb', skillLinkTarget: '.claude'},
+    })
+
+    expect(files['CLAUDE.md']).toContain('pnpm graphene check')
+    expect(files['CLAUDE.md']).toContain('Assume all DuckDB functions are available when writing GSQL.')
+    expect(files['AGENTS.md']).toBeUndefined()
+  })
+
   it('renders a snowflake project with .env auth vars', () => {
     let files = renderTemplate({
       cliVersion: '0.0.15',


### PR DESCRIPTION
This PR updates the `create-graphene` flow with a few changes from the run-through today:

- Removes the `defaultNamespace` prompt
- If the user selects the `.claude` dir for the agent skill, writes the initial prompt to `CLAUDE.md` rather than `AGENTS.md`
- When DuckDB is selected, no longer prompt for the path to the .duckdb file, and instead has the completion message instruct the user to either copy the .duckdb file into the project dir, or configure the path in `package.json`

Note: I did not add more color to the "project name" prompt. I'm open to doing so, but most of the other templates I tested (e.g. `npm create next-app`) just ask for a "project name". If we do change it I'd maybe just have it ask what directory we should put the new project in (and allow an arbitrary path, not just a name within the current directory), but still infer the package.json name from that 