### PR TITLE
Fix duplicate query fields

### DIFF
--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -15,7 +15,7 @@ interface QueryNode {
   contents: string
   callback?: ResultHandler
   loading: boolean
-  fields: Map<string, string | string[]>
+  fields: string[]
   componentId?: string
   error?: GrapheneError
 }
@@ -39,24 +39,22 @@ export const setQueryFetcher = f => (queryFetcher = f)
 // Called by GrapheneQuery tags to register a named query on the page
 function registerQuery(name: string, contents: string) {
   queries = queries.filter(q => q.name !== name)
-  queries.push({name, contents, loading: false, fields: new Map()})
+  queries.push({name, contents, loading: false, fields: []})
 }
 
 // Called by viz components to request a particular query of data
 function query(source: string, fields: Record<string, string | string[]>, callback: ResultHandler, componentId?: string) {
-  // using Map here because it preserves the order in which we add fields to the select, which we use when we get the result.
-  let map = new Map(Object.entries(fields))
-  let exprs: string[] = []
-  if (map.size > 0) {
-    map.forEach(value => {
-      if (Array.isArray(value)) exprs.push(...value)
-      else exprs.push(value)
+  // Preserve field order because translateData maps result fields back to requested expressions by index.
+  let seen = new Set<string>()
+  let exprs = Object.values(fields)
+    .flatMap(value => (Array.isArray(value) ? value : [value]))
+    .filter(field => {
+      if (seen.has(field)) return false
+      seen.add(field)
+      return true
     })
-  } else {
-    exprs = ['*']
-  }
-  let contents = `from ${source} select ${exprs.join(', ')}`
-  queries.push({contents, callback, loading: false, fields: map, source, componentId})
+  let contents = `from ${source} select ${(exprs.length ? exprs : ['*']).join(', ')}`
+  queries.push({contents, callback, loading: false, fields: exprs, source, componentId})
   runAll()
   return componentId
 }
@@ -147,7 +145,7 @@ export function translateData(data: any, node: QueryNode): QueryResult {
   let rows = data.rows || []
   let fields: Field[] = []
 
-  let requestFields = Array.from(node.fields.values()).flatMap(f => f)
+  let requestFields = node.fields
 
   data.fields.forEach((field, index) => {
     let requested = requestFields[index]

--- a/ui/tests/queryEngine.test.ts
+++ b/ui/tests/queryEngine.test.ts
@@ -3,14 +3,18 @@ import {beforeAll, test, expect} from 'vitest'
 import {scalarType} from '../../lang/types.ts'
 
 let translateData: (data: any, node: any) => {rows: any[]; fields?: any[]}
+let setQueryFetcher: (fetcher: any) => void
 
 beforeAll(async () => {
+  ;(globalThis as any).$state = {raw: value => value}
+  ;(globalThis as any).caches = {open: () => Promise.resolve({keys: () => Promise.resolve([])})}
   ;(globalThis as any).window = {
     $GRAPHENE: {},
     addEventListener: () => {},
     removeEventListener: () => {},
+    location: {search: ''},
   }
-  ;({translateData} = await import('../internal/queryEngine.ts'))
+  ;({translateData, setQueryFetcher} = await import('../internal/queryEngine.ts'))
 })
 
 test('translateData remaps Snowflake-style uppercase row keys to requested field casing', () => {
@@ -21,12 +25,7 @@ test('translateData remaps Snowflake-style uppercase row keys to requested field
       {name: 'num', type: scalarType('number')},
     ],
   }
-  let node = {
-    fields: new Map([
-      ['x', 'location_state_code'],
-      ['y', 'num'],
-    ]),
-  }
+  let node = {fields: ['location_state_code', 'num']}
 
   let result = translateData(data, node)
 
@@ -42,12 +41,7 @@ test('translateData remaps default-named expressions to requested expression key
       {name: 'count', type: scalarType('number'), metadata: {defaultName: 'count'}},
     ],
   }
-  let node = {
-    fields: new Map([
-      ['x', "date_trunc('month', created_at)"],
-      ['y', 'count()'],
-    ]),
-  }
+  let node = {fields: ["date_trunc('month', created_at)", 'count()']}
 
   let result = translateData(data, node)
 
@@ -63,14 +57,33 @@ test('translateData preserves field metadata for downstream table rendering', ()
       {name: 'sales', type: scalarType('number')},
     ],
   }
-  let node = {
-    fields: new Map([
-      ['x', 'month_start'],
-      ['y', 'sales'],
-    ]),
-  }
+  let node = {fields: ['month_start', 'sales']}
 
   let result = translateData(data, node)
 
   expect(result.fields?.[0].metadata).toEqual({timeGrain: 'month'})
+})
+
+test('query deduplicates fields before building gsql', async () => {
+  ;(window as any).$GRAPHENE.resetQueryEngine()
+  let gsql = ''
+  setQueryFetcher((req: any) => {
+    gsql = req.gsql
+    return Promise.resolve({
+      rows: [{name: 'Alaska Airlines', avg_delay: 12}],
+      fields: [
+        {name: 'name', type: scalarType('string')},
+        {name: 'avg_delay', type: scalarType('number')},
+      ],
+    })
+  })
+
+  let result = await new Promise<any>(resolve => {
+    ;(window as any).$GRAPHENE.query('delays_by_carrier', {x: 'name', y: 'avg_delay', sort: 'avg_delay'}, (res: any) => {
+      if (res) resolve(res)
+    })
+  })
+
+  expect(gsql).toBe('from delays_by_carrier select name, avg_delay')
+  expect(result.fields.map((field: any) => field.name)).toEqual(['name', 'avg_delay'])
 })


### PR DESCRIPTION
If a chart has the same column for multiple attrs (like y and sort) we'd generate an invalid query.