### PR TITLE
fix LSP `watchFiles` registration

### DIFF
--- a/language-server/src/service.test.ts
+++ b/language-server/src/service.test.ts
@@ -2,10 +2,10 @@
 import {mkdtemp, mkdir, rm, writeFile} from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import {expect} from 'vitest'
+import {expect, vi} from 'vitest'
 import {URI} from 'vscode-uri'
 
-import {discoverGrapheneProjects, findOwningProjectRoot} from './service.ts'
+import {createGrapheneService, discoverGrapheneProjects, findOwningProjectRoot} from './service.ts'
 
 describe('Graphene project discovery', () => {
   it('finds package.json files with a top-level graphene config and ignores other packages', async () => {
@@ -81,5 +81,37 @@ describe('project ownership', () => {
     expect(findOwningProjectRoot(path.join(nestedRoot, 'report.md'), [appRoot, nestedRoot])).toBe(nestedRoot)
     expect(findOwningProjectRoot(path.join(appRoot, 'tables', 'users.gsql'), [appRoot, nestedRoot])).toBe(appRoot)
     expect(findOwningProjectRoot(path.join(root, 'notes.md'), [appRoot, nestedRoot])).toBeNull()
+  })
+})
+
+describe('workspace file watching', () => {
+  it('registers md and gsql file watchers when the service plugin is created', async () => {
+    let disposeFileWatcher = vi.fn()
+    let disposeWatchedFiles = vi.fn()
+    let disposeContent = vi.fn()
+    let server = {
+      fileWatcher: {
+        watchFiles: vi.fn(() => Promise.resolve({dispose: disposeFileWatcher})),
+        onDidChangeWatchedFiles: vi.fn(() => ({dispose: disposeWatchedFiles})),
+      },
+      documents: {
+        onDidChangeContent: vi.fn(() => ({dispose: disposeContent})),
+        get: vi.fn(),
+      },
+      languageFeatures: {
+        requestRefresh: vi.fn(),
+      },
+    }
+
+    let instance = createGrapheneService(server as any).create({env: {workspaceFolders: []}} as any)
+    await Promise.resolve()
+
+    expect(server.fileWatcher.watchFiles).toHaveBeenCalledWith(['**/*.{md,gsql}'])
+    expect(server.fileWatcher.onDidChangeWatchedFiles).toHaveBeenCalled()
+
+    instance.dispose?.()
+    expect(disposeFileWatcher).toHaveBeenCalled()
+    expect(disposeWatchedFiles).toHaveBeenCalled()
+    expect(disposeContent).toHaveBeenCalled()
   })
 })

--- a/language-server/src/service.ts
+++ b/language-server/src/service.ts
@@ -117,9 +117,11 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
         let fileWatcher: Disposable | undefined
         let changeWatchedFiles: Disposable | undefined
         let changeContent: Disposable | undefined
+        let disposed = false
 
-        server.onInitialized(async () => {
-          fileWatcher = await server.fileWatcher.watchFiles(['**/*.{md,gsql}'])
+        void server.fileWatcher.watchFiles(['**/*.{md,gsql}']).then(watcher => {
+          if (disposed) return watcher.dispose()
+          fileWatcher = watcher
         })
 
         changeWatchedFiles = server.fileWatcher.onDidChangeWatchedFiles(({changes}) => {
@@ -137,6 +139,7 @@ export function createGrapheneService(server: ReturnType<typeof createServer>): 
 
         return {
           dispose() {
+            disposed = true
             fileWatcher?.dispose()
             changeWatchedFiles?.dispose()
             changeContent?.dispose()


### PR DESCRIPTION
This turned out to just be an issue with where we were registering our file watcher. By the time `watchWorkspace` is called (in the service's `create`), the initialization callbacks have already fired, and so the file watcher logic in the `server.onInitialized` callback was never invoked. This PR updates the setup path to simply register the watcher directly on that path rather than using `server.onInitialized`, since the server is already initialized.

Tested with the `aircrafts.gsql` repro - both clearing the file and deleting it altogether - and both cases update the diagnostics for other files without `aircrafts.gsql` being open.