### PR TITLE
try bumping timeout for clickhouse example

### DIFF
--- a/cli/connections/clickhouse.ts
+++ b/cli/connections/clickhouse.ts
@@ -7,6 +7,7 @@ export interface ClickHouseOptions {
   username: string
   password: string
   database?: string
+  requestTimeout?: number
 }
 
 export class ClickHouseConnection implements QueryConnection {
@@ -21,6 +22,7 @@ export class ClickHouseConnection implements QueryConnection {
       password: options.password,
       database: this.defaultDatabase,
       application: 'Graphene',
+      request_timeout: options.requestTimeout,
     })
   }
 

--- a/cli/connections/index.ts
+++ b/cli/connections/index.ts
@@ -35,6 +35,7 @@ export async function getConnection(): Promise<QueryConnection> {
       username,
       password,
       database: config.clickhouse?.database || config.defaultNamespace || 'default',
+      requestTimeout: config.clickhouse?.requestTimeout,
     })
   } else if (config.dialect === 'snowflake') {
     let mod = await importConnection(() => import('./snowflake.ts'), 'snowflake-sdk', 'Snowflake')

--- a/examples/clickhouse/package.json
+++ b/examples/clickhouse/package.json
@@ -21,7 +21,8 @@
     "defaultNamespace": "default",
     "clickhouse": {
       "url": "https://kzo1vb16sa.us-east-1.aws.clickhouse.cloud:8443",
-      "username": "default"
+      "username": "default",
+      "requestTimeout": 120000
     },
     "envFile": [
       ".env",

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -29,6 +29,7 @@ export interface Config {
     url?: string
     username?: string
     database?: string
+    requestTimeout?: number
   }
 
   duckdb?: {

--- a/ui/tests/run-examples.test.ts
+++ b/ui/tests/run-examples.test.ts
@@ -122,7 +122,7 @@ test.skipIf(!process.env.SLOW_TEST)('graphene run succeeds for every markdown fi
       for (let mdPath of markdownFiles) {
         console.log(`[run-examples] running ${path.basename(exampleDir)}/${mdPath}`)
         await page.goto(`http://localhost:${port}${toPageUrl(mdPath)}`)
-        await waitForGrapheneLoad(page, 60_000)
+        await waitForGrapheneLoad(page, 120_000)
 
         let runResult = await runCli(['run', mdPath], exampleDir, childEnv)
         expectSuccess(`run ${path.basename(exampleDir)}/${mdPath}`, runResult)


### PR DESCRIPTION
The test-examples CI check is flaking a lot, always on the clickhouse example with query timeouts. My beliefs is that this is due to slow first queries when the test instance has been idled (idle timeout is set to 5 minutes). This PR updates the example to override the timeout to 120s (up from the default of 30s).

My not-very-scientific testing has been to wait until the instance shows as idle in the clickhouse UI, then:

1. Running `npx graphene run flows.md --query flow_summary` in the example, which took over 30s but succeeded
2. Pushing this PR (after the instance re-idled). Result of test-examples: ~pending~ ~failed :(~ EDIT: After bumping `waitForGrapheneLoad`, success! ~2x~ 3x