### PR TITLE
add graphene CLI commands to SKILL.md `allowed-tools`

### DIFF
--- a/cli/esbuild.mjs
+++ b/cli/esbuild.mjs
@@ -44,6 +44,7 @@ await writeFile(
 ---
 name: graphene
 description: How to use Graphene, our framework for data modeling, analysis, and visualization.
+allowed-tools: Bash(npx graphene:*) Bash(pnpm graphene:*) Bash(yarn graphene:*) Bash(bun run graphene:*)
 ---
 
 ${await readFile(path.resolve(__dirname, '../docs/base.md'), 'utf8')}


### PR DESCRIPTION
This PR adds [`allowed-tools` entries](https://agentskills.io/specification#allowed-tools-field) to the Graphene skill's frontmatter to pre-allow Graphene CLI commands. I believe only Claude respects these currently, but it seems worth it. Also, due to the way we symlink the skill from `node_modules`, we can't tailor it to the user's package manager the way create-graphene does in its generated AGENTS.md, and just include an entry for each package manager.