### PR TITLE
fix interaction between release PR and install.test.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 0.0.17
+
+### Breaking changes
+
+None.
+
+### Added
+
+- Added `graphene run --input` for setting input values from the CLI (`82ec2fa7`).
+- Added credential validation, ClickHouse setup, and improved prompting to `create-graphene` (`4afd2ac5`, `d7209250`).
+- Added the `create-graphene` package name and `npm create graphene` installer command (`0b1cc954`).
+- Added configurable ClickHouse request timeouts (`95d4bb81`).
+
+### Fixed
+
+- Fixed ordinal chart axes by hiding grid lines and improving tick rendering (`6ddb3602`).
+- Fixed `<GrapheneQuery />` prop escaping to avoid accidental Svelte interpolation (`f2b966f8`).
+- Fixed language-server file watching registration in editors (`69d09cec`).
+- Fixed chart-generated queries that reused the same column for multiple attributes, like `y` and `sort` (`465b3ae0`).
+- Fixed `graphene run` screenshots to be written inside the project directory (`8e11f8ad`).
+
 ## 0.0.16
 
 ### Breaking changes

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphenedata/cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "private": true,
   "license": "Elastic-2.0",
   "author": "Graphene Systems Inc",

--- a/create/package.json
+++ b/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-graphene",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "license": "Elastic-2.0",
   "author": "Graphene Systems Inc",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphene",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/tests/install.test.ts
+++ b/ui/tests/install.test.ts
@@ -212,7 +212,7 @@ test.skipIf(!process.env.SLOW_TEST)('install graphene and use it with yarn', {ti
     {
       name: 'yarn',
       create: tarball => ['corepack', ['yarn@4.12.0', 'dlx', '--package', tarball, 'create-graphene', 'demo-app', '--yes', '--no-install']],
-      install: () => ['corepack', ['yarn@4.12.0', 'install']],
+      install: () => ['corepack', ['yarn@4.12.0', 'install', '--no-immutable']],
       graphene: args => ['corepack', ['yarn@4.12.0', 'run', 'graphene', ...args]],
     },
     page,

--- a/ui/tests/install.test.ts
+++ b/ui/tests/install.test.ts
@@ -39,7 +39,7 @@ function getOutput(res: RunResult) {
 interface PackageManagerTest {
   name: 'npm' | 'pnpm' | 'yarn'
   create: (tarball: string) => [string, string[]]
-  install: (tarball: string) => [string, string[]]
+  install: () => [string, string[]]
   graphene: (args: string[]) => [string, string[]]
 }
 
@@ -66,6 +66,13 @@ async function copyTarballToTemp(tarball: string, tempRoot: string) {
 async function expectNoSvelteDependency(projectDir: string) {
   let pkg = JSON.parse(await fsp.readFile(path.join(projectDir, 'package.json'), 'utf8'))
   expect(pkg.dependencies?.svelte).toBeUndefined()
+}
+
+async function usePackedCliDependency(projectDir: string, cliTarball: string) {
+  let packageJsonPath = path.join(projectDir, 'package.json')
+  let pkg = JSON.parse(await fsp.readFile(packageJsonPath, 'utf8'))
+  pkg.dependencies['@graphenedata/cli'] = `file:${path.relative(projectDir, cliTarball)}`
+  await fsp.writeFile(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n')
 }
 
 async function installGrapheneAndUseIt(packageManager: PackageManagerTest, page: Page) {
@@ -98,11 +105,12 @@ async function installGrapheneAndUseIt(packageManager: PackageManagerTest, page:
     let [createCommand, createArgs] = packageManager.create(createTarball)
     let scaffold = await run(createCommand, createArgs, tempRoot, childEnv)
     expectSuccess(`${packageManager.name} create-graphene`, scaffold)
+    await usePackedCliDependency(projectDir, cliTarball)
     await expectNoSvelteDependency(projectDir)
 
-    let [installCommand, installArgs] = packageManager.install(cliTarball)
+    let [installCommand, installArgs] = packageManager.install()
     let installResult = await run(installCommand, installArgs, projectDir, childEnv)
-    expectSuccess(`${packageManager.name} install tarball`, installResult)
+    expectSuccess(`${packageManager.name} install`, installResult)
     await expectNoSvelteDependency(projectDir)
 
     // add actual data and a page with a real chart, so our smoke test will
@@ -180,7 +188,7 @@ test.skipIf(!process.env.SLOW_TEST)('install graphene and use it with npm', {tim
     {
       name: 'npm',
       create: tarball => ['npm', ['exec', '--yes', '--package', tarball, '--', 'create-graphene', 'demo-app', '--yes', '--no-install']],
-      install: tarball => ['npm', ['install', tarball]],
+      install: () => ['npm', ['install']],
       graphene: args => ['npm', ['run', 'graphene', '--', ...args]],
     },
     page,
@@ -192,7 +200,7 @@ test.skipIf(!process.env.SLOW_TEST)('install graphene and use it with pnpm', {ti
     {
       name: 'pnpm',
       create: tarball => ['pnpm', ['dlx', '--package', tarball, 'create-graphene', 'demo-app', '--yes', '--no-install']],
-      install: tarball => ['pnpm', ['add', '--config.minimumReleaseAge=0', tarball]],
+      install: () => ['pnpm', ['install', '--config.minimumReleaseAge=0']],
       graphene: args => ['pnpm', ['run', 'graphene', '--', ...args]],
     },
     page,
@@ -204,7 +212,7 @@ test.skipIf(!process.env.SLOW_TEST)('install graphene and use it with yarn', {ti
     {
       name: 'yarn',
       create: tarball => ['corepack', ['yarn@4.12.0', 'dlx', '--package', tarball, 'create-graphene', 'demo-app', '--yes', '--no-install']],
-      install: tarball => ['corepack', ['yarn@4.12.0', 'add', tarball]],
+      install: () => ['corepack', ['yarn@4.12.0', 'install']],
       graphene: args => ['corepack', ['yarn@4.12.0', 'run', 'graphene', ...args]],
     },
     page,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphene-data-vscode",
   "displayName": "Graphene VSCode Language Support",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "private": true,
   "description": "",
   "categories": [


### PR DESCRIPTION
test-install is failing on #377 due to a funny interaction where it tries to resolve the not-yet-released version. Interestingly only pnpm fails in this way - the npm and yarn tests pass and seem to realize they are substituting the tarball installed before trying to resolve the version. This PR updates the install test to explicitly swap in the `@graphenedata/cli` dep in package.json with a `file:` dependency pointing to the tarball to avoid this.