### PR TITLE
tweak deps to unblock `npm link`ing CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -47,6 +47,7 @@
     "json5": "^2.2.3",
     "mdsvex": "^0.12.6",
     "sanitize-html": "^2.17.0",
+    "svelte": "5.55.3",
     "unified": "^11.0.5",
     "unist-util-visit": "4.1.2",
     "vite": "7.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,9 +291,6 @@ importers:
         specifier: 5.55.3
         version: 5.55.3(@typescript-eslint/types@8.56.1)
     devDependencies:
-      '@graphenedata/cli':
-        specifier: workspace:*
-        version: link:../cli
       '@graphenedata/lang':
         specifier: workspace:*
         version: link:../lang

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       sanitize-html:
         specifier: ^2.17.0
         version: 2.17.1
+      svelte:
+        specifier: 5.55.3
+        version: 5.55.3(@typescript-eslint/types@8.56.1)
       unified:
         specifier: ^11.0.5
         version: 11.0.5

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,6 @@
     "svelte": "5.55.3"
   },
   "devDependencies": {
-    "@graphenedata/cli": "workspace:*",
     "@graphenedata/lang": "workspace:*",
     "@playwright/test": "1.58.2",
     "@sveltejs/vite-plugin-svelte": "6.2.4",


### PR DESCRIPTION
This is maybe an argument for reverting #325, but with the tweaked dependency setup I've had trouble using `npm link` on the CLI package to test local changes - specifically `MODULE_NOT_FOUND` errors with svelte. But this seems to be the only package it hits this with, so this PR re-declares just the svelte dependency to make it play nicely with `npm link`. I also removed a circular workspace dependency which I hadn't realized was introduced (`cli/` and `ui/` depending on one another - some `ui/` tests import from CLI which is probably why the agent added both directions)