### PR TITLE
Reorganize flights models with new commenting strategy

### DIFF
--- a/examples/flights/tables/aircraft.gsql
+++ b/examples/flights/tables/aircraft.gsql
@@ -1,30 +1,47 @@
+-- Individual aircraft from the FAA registry, including registration and ownership info.
+-- Each row is one aircraft (tail_num).
 table aircraft (
-  id BIGINT -- Unique identifier for the aircraft record
-  tail_num VARCHAR -- Aircraft tail number (registration identifier, e.g., 'N806MD')
-  aircraft_serial VARCHAR -- Aircraft serial number
-  aircraft_model_code VARCHAR -- Code identifying the aircraft model
-  aircraft_engine_code VARCHAR -- Code identifying the engine type
-  year_built BIGINT -- Year the aircraft was manufactured
-  aircraft_type_id BIGINT -- Identifier for the aircraft type category
-  aircraft_engine_type_id BIGINT -- Identifier for the engine type category
-  registrant_type_id BIGINT -- Identifier for the registrant type (individual, corporation, etc.)
-  name VARCHAR -- Name of the aircraft owner/registrant
-  address1 VARCHAR -- First line of owner's address
-  address2 VARCHAR -- Second line of owner's address (if applicable)
-  city VARCHAR -- City of the owner's address
-  state VARCHAR -- State or province of the owner's address
-  zip VARCHAR -- ZIP or postal code of the owner's address
-  region VARCHAR -- Regional identifier
-  county VARCHAR -- County of the owner's address
-  country VARCHAR -- Country of registration (typically 'US' for United States)
-  certification VARCHAR -- Certification information
-  status_code VARCHAR -- Aircraft status code (e.g., 'A' = Active, 'V' = Valid, 'M' = Missing, 'E' = Expired, 'R' = Revoked, 'S' = Suspended, numeric codes for other statuses)
+
+  /* Identifiers */
+
+  id BIGINT
+  tail_num VARCHAR -- Registration identifier, e.g., 'N806MD'
+  aircraft_serial VARCHAR -- Manufacturer serial number
   mode_s_code VARCHAR -- Mode S transponder code
+
+  /* Model & type */
+
+  aircraft_model_code VARCHAR
+  aircraft_engine_code VARCHAR
+  aircraft_type_id BIGINT
+  aircraft_engine_type_id BIGINT
+  year_built BIGINT
+
+  /* Registration & status */
+
+  registrant_type_id BIGINT -- Registrant type (individual, corporation, etc.)
+  -- 'A' = Active, 'V' = Valid, 'M' = Missing, 'E' = Expired, 'R' = Revoked, 'S' = Suspended
+  status_code VARCHAR
+  certification VARCHAR
   fract_owner VARCHAR -- Fractional ownership indicator
-  last_action_date DATE -- Date of the last action taken on the registration
-  cert_issue_date DATE -- Date the aircraft certificate was issued
+  last_action_date DATE
+  cert_issue_date DATE
   air_worth_date DATE -- Airworthiness certificate date
+
+  /* Owner / address */
+
+  name VARCHAR -- Owner / registrant name
+  address1 VARCHAR
+  address2 VARCHAR
+  city VARCHAR
+  state VARCHAR
+  zip VARCHAR
+  region VARCHAR
+  county VARCHAR
+  country VARCHAR -- Typically 'US'
+
+  /* Join relationships */
 
   join one aircraft_models on aircraft_model_code = aircraft_models.aircraft_model_code
   join many flights on tail_num = flights.tail_num
-);
+)

--- a/examples/flights/tables/aircraft_models.gsql
+++ b/examples/flights/tables/aircraft_models.gsql
@@ -1,16 +1,19 @@
+-- Aircraft model specifications from the FAA registry.
+-- Each row is one model (aircraft_model_code).
 table aircraft_models (
-  aircraft_model_code VARCHAR -- Unique code identifying the aircraft model
-  manufacturer VARCHAR -- Name of the aircraft manufacturer (e.g., 'BOEING', 'AIRBUS', 'CESSNA')
-  model VARCHAR -- Model name or designation (e.g., '737', 'A320', '172')
-  aircraft_type_id BIGINT -- Identifier for the aircraft type category
-  aircraft_engine_type_id BIGINT -- Identifier for the engine type category
-  aircraft_category_id BIGINT -- Identifier for the aircraft category
-  amateur BIGINT -- Whether this is an amateur-built aircraft (0 = no, 1 = yes)
-  engines BIGINT -- Number of engines on the aircraft
-  seats BIGINT -- Number of passenger seats (0 for cargo-only or single-seat aircraft)
-  weight BIGINT -- Maximum takeoff weight in pounds
-  speed BIGINT -- Maximum speed in knots
+  aircraft_model_code VARCHAR
+  manufacturer VARCHAR -- e.g., 'BOEING', 'AIRBUS', 'CESSNA'
+  model VARCHAR -- Model designation, e.g., '737', 'A320', '172'
+  aircraft_type_id BIGINT
+  aircraft_engine_type_id BIGINT
+  aircraft_category_id BIGINT
+  amateur BIGINT -- Amateur-built indicator (0 = no, 1 = yes)
+  engines BIGINT -- Number of engines
+  seats BIGINT -- Number of passenger seats (0 for cargo-only or single-seat)
+  weight BIGINT -- Maximum takeoff weight, in pounds
+  speed BIGINT -- Maximum speed, in knots
+
+  /* Join relationships */
 
   join many aircraft on aircraft_model_code = aircraft.aircraft_model_code
-);
-
+)

--- a/examples/flights/tables/airports.gsql
+++ b/examples/flights/tables/airports.gsql
@@ -1,34 +1,48 @@
+-- Airports and other aviation facilities (heliports, seaplane bases, etc.) in the FAA registry.
+-- Each row is one facility (code).
 table airports (
-  
-  id BIGINT -- Unique identifier for the airport
+
+  /* Identifiers */
+
+  id BIGINT
   code VARCHAR -- IATA airport code (e.g., 'JFK', 'LAX', 'ORD')
   site_number VARCHAR -- FAA site number identifier
-  fac_type VARCHAR -- Facility type (e.g., 'AIRPORT', 'HELIPORT', 'SEAPLANE BASE', 'BALLOONPORT', 'GLIDERPORT', 'STOLPORT', 'ULTRALIGHT')
-  fac_use VARCHAR -- Facility use classification ('PU' = Public, 'PR' = Private)
+  full_name VARCHAR -- Full official name of the airport
+
+  /* Classification */
+
+  fac_type VARCHAR -- Facility type: 'AIRPORT', 'HELIPORT', 'SEAPLANE BASE', 'BALLOONPORT', 'GLIDERPORT', 'STOLPORT', 'ULTRALIGHT'
+  fac_use VARCHAR -- 'PU' = Public, 'PR' = Private
+  own_type VARCHAR -- Ownership type: 'PU' = Public, 'PR' = Private
+  major VARCHAR -- Major hub indicator ('Y' / 'N')
+  cntl_twr VARCHAR -- Control tower presence ('Y' / 'N')
+
+  /* Location */
+
+  city VARCHAR
+  county VARCHAR
+  state VARCHAR
+  longitude DOUBLE
+  latitude DOUBLE
+  elevation BIGINT -- Elevation above sea level, in feet
+  cbd_dist BIGINT -- Distance to central business district, in miles
+  cbd_dir VARCHAR -- Compass direction to CBD (e.g., 'N', 'SW', 'SE')
+
+  /* FAA / regulatory */
+
   faa_region VARCHAR -- FAA region code
   faa_dist VARCHAR -- FAA district code
-  city VARCHAR -- City where the airport is located
-  county VARCHAR -- County where the airport is located
-  state VARCHAR -- State or province code where the airport is located
-  full_name VARCHAR -- Full official name of the airport
-  own_type VARCHAR -- Ownership type ('PU' = Public, 'PR' = Private)
-  longitude DOUBLE -- Longitude coordinate of the airport
-  latitude DOUBLE -- Latitude coordinate of the airport
-  elevation BIGINT -- Airport elevation above sea level in feet
   aero_cht VARCHAR -- Aeronautical chart identifier
-  cbd_dist BIGINT -- Distance to central business district in miles
-  cbd_dir VARCHAR -- Compass direction to central business district (e.g., 'N', 'SW', 'SE')
-  act_date VARCHAR -- Activation date of the airport
-  cert VARCHAR -- Certification information (e.g., 'ES 05/1973')
+  act_date VARCHAR -- Activation date
+  cert VARCHAR -- Certification info (e.g., 'ES 05/1973')
   fed_agree VARCHAR -- Federal agreement status
   cust_intl VARCHAR -- Customs international status
   c_ldg_rts VARCHAR -- Commercial landing rights indicator
-  joint_use VARCHAR -- Joint use indicator ('Y' = yes, 'N' = no, empty = not applicable)
-  mil_rts VARCHAR -- Military routes indicator ('Y' = yes, 'N' = no, empty = not applicable)
-  cntl_twr VARCHAR -- Control tower presence ('Y' = yes, 'N' = no)
-  major VARCHAR -- Major airport indicator ('Y' = yes, 'N' = no) - indicates if this is a major hub airport
+  joint_use VARCHAR -- Joint use indicator ('Y' / 'N' / empty)
+  mil_rts VARCHAR -- Military routes indicator ('Y' / 'N' / empty)
+
+  /* Join relationships */
 
   join many flights as departures on code = departures.origin
   join many flights as arrivals on code = arrivals.destination
-);
-
+)

--- a/examples/flights/tables/carriers.gsql
+++ b/examples/flights/tables/carriers.gsql
@@ -1,9 +1,11 @@
+-- Airline carriers operating flights in the FAA dataset.
+-- Each row is one carrier (code).
 table carriers (
-  
-  code VARCHAR, -- Two-letter airline carrier code (e.g., 'AA' for American Airlines, 'UA' for United Airlines)
-  name VARCHAR -- Full official name of the airline carrier
-  nickname VARCHAR -- Common nickname or shortened name for the carrier
+  code VARCHAR -- Two-letter airline carrier code (e.g., 'AA' for American Airlines, 'UA' for United Airlines)
+  name VARCHAR -- Full official name of the airline
+  nickname VARCHAR -- Common nickname or shortened name
+
+  /* Join relationships */
 
   join many flights on code = flights.carrier
-);
-
+)

--- a/examples/flights/tables/flights.gsql
+++ b/examples/flights/tables/flights.gsql
@@ -1,30 +1,49 @@
+-- Individual commercial flights from the FAA dataset (2000-2005), one row per scheduled flight.
+-- Each row is one flight (id2).
 table flights (
-  id2 BIGINT -- Unique identifier for the flight record
-  carrier VARCHAR -- Airline carrier code (e.g., 'AA', 'UA', 'DL')
-  origin VARCHAR -- IATA airport code for the origin airport
-  destination VARCHAR -- IATA airport code for the destination airport
+
+  /* Identifiers */
+
+  id2 BIGINT
+  carrier VARCHAR -- Airline carrier code, e.g., 'AA', 'UA', 'DL'
   flight_num VARCHAR -- Flight number assigned by the carrier
-  flight_time BIGINT -- Scheduled flight time in minutes (time in the air, excluding taxi)
-  tail_num VARCHAR -- Aircraft tail number (registration identifier)
+  tail_num VARCHAR -- Aircraft registration
+
+  /* Route */
+
+  origin VARCHAR -- IATA code of origin airport
+  destination VARCHAR -- IATA code of destination airport
+  distance BIGINT -- Distance between origin and destination, in miles. Not to be confused with miles_flown
+
+  /* Times & delays (minutes) */
+
   dep_time TIMESTAMP -- Actual departure time
   arr_time TIMESTAMP -- Actual arrival time
-  dep_delay BIGINT -- Departure delay in minutes (negative = early, positive = late)
-  arr_delay BIGINT -- Arrival delay in minutes (negative = early, positive = late)
-  taxi_out BIGINT -- Time spent taxiing out to runway before takeoff, in minutes
-  taxi_in BIGINT -- Time spent taxiing in from runway after landing, in minutes
-  distance BIGINT -- The distance between the origin and destination airports, in miles. Not to be confused with miles_flown
-  cancelled VARCHAR -- Whether the flight was cancelled ('Y' = yes, 'N' = no)
-  diverted VARCHAR -- Whether the flight was diverted to a different airport ('Y' = yes, 'N' = no)
+  flight_time BIGINT -- Scheduled time in the air, excluding taxi
+  taxi_out BIGINT -- Taxi time before takeoff
+  taxi_in BIGINT -- Taxi time after landing
+  dep_delay BIGINT -- Departure delay; negative = early, positive = late
+  arr_delay BIGINT -- Arrival delay; negative = early, positive = late
+
+  /* Status */
+
+  cancelled VARCHAR -- 'Y' / 'N'
+  diverted VARCHAR -- 'Y' / 'N'
+
+  /* Join relationships */
 
   join one carriers on carrier = carriers.code
   join one airports as origin_airport on origin = origin_airport.code
   join one airports as destination_airport on destination = destination_airport.code
   join one aircraft on tail_num = aircraft.tail_num
 
-  is_long_haul: flight_time > 360 -- Whether the flight was a long haul flight (over 6 hours)
+  /* Dimensions */
+
+  is_long_haul: flight_time > 360 -- Over 6 hours in the air
   is_cancelled: cancelled = 'Y'
-  is_cancelled_or_diverted: cancelled = 'Y' or diverted = 'Y' -- Whether the flight was cancelled or diverted
-  miles_flown: case when is_cancelled_or_diverted then 0 else distance end -- Actual miles flown, approximated by the distance between the origin and destination airports not including cancelled or diverted flights
+  is_cancelled_or_diverted: cancelled = 'Y' or diverted = 'Y'
+  -- Distance actually flown; cancelled/diverted flights count as 0
+  miles_flown: case when is_cancelled_or_diverted then 0 else distance end
   aircraft_age: YEAR(dep_time)::float - aircraft.year_built
 
   status: case
@@ -33,8 +52,10 @@ table flights (
     else 'On Time'
   end
 
-  on_time_departure_rate: avg(case when dep_delay <= 0 then 1 else 0 end) -- departed on time or early #ratio
-  on_time_arrival_rate: avg(case when arr_delay <= 0 then 1 else 0 end) -- arrived on time or early #ratio
+  /* Measures */
+
+  on_time_departure_rate: avg(case when dep_delay <= 0 then 1 else 0 end) #ratio
+  on_time_arrival_rate: avg(case when arr_delay <= 0 then 1 else 0 end) #ratio
   cancellation_rate: avg(case when cancelled = 'Y' then 1 else 0 end) #ratio
   diversion_rate: avg(case when diverted = 'Y' then 1 else 0 end) #ratio
-);
+)


### PR DESCRIPTION
Apply new organization and commenting strategy across the flights example models (aircraft, aircraft_models, airports, carriers, flights) to follow best practices.