### PR TITLE
make `graphene run page.md` run server in foreground

### DIFF
--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -155,6 +155,16 @@ describe('cli run', () => {
     expect(res.stdout).toContain('AA')
   })
 
+  it('stops an owned markdown server after a no-browser run', async () => {
+    await stopGrapheneIfRunning()
+
+    let res = await runCli(['run', 'index.md'], {cwd: flightDir})
+    expect(res.code).toBe(1)
+    expect(res.stdout).toContain('Starting Graphene server')
+    expect(res.stdout).toContain('Failed to open a new tab')
+    expect(await isServerRunning(TEST_PORT)).toBe(false)
+  })
+
   it('prints a clean error for a missing markdown query input', async () => {
     let res = await runCli(['run', 'carrier_detail.md', '--query', 'carrier_info'], {cwd: flightDir})
     expect(res.code).toBe(1)

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -13,7 +13,7 @@ import {analyzeWorkspace, getFile, loadWorkspace, toSql} from '../lang/core.ts'
 import {type AnalysisResult, type WorkspaceFileInput} from '../lang/types.ts'
 import {pollFor} from '../lang/util.ts'
 import {openInBrowser} from './auth.ts'
-import {getGrapheneCache, isServerRunning, runServeInBackground} from './background.ts'
+import {getGrapheneCache} from './background.ts'
 import {runQuery} from './connections/index.ts'
 import {mockFileMap} from './mockFiles.ts'
 import {normalizeFile} from './normalizeFile.ts'
@@ -56,7 +56,7 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
     return false
   }
 
-  let resp = await sendSocketRequest({mdFile, action: 'check', chart: options.chart, inputs: options.inputs, log})
+  let resp = await sendSocketRequest({mdFile, action: 'check', chart: options.chart, inputs: options.inputs, log, telemetry: options.telemetry})
   if (!resp) return false
 
   let errors = Array.from(resp.errors || []) as GrapheneError[]
@@ -109,7 +109,7 @@ export async function listMdFileQueries(mdArg: string, telemetry?: CliTelemetry,
     return false
   }
 
-  let resp = await sendSocketRequest({mdFile, action: 'list', log})
+  let resp = await sendSocketRequest({mdFile, action: 'list', log, telemetry})
   if (!resp) return false
 
   let componentIds = (resp.componentIds || []) as string[]
@@ -152,42 +152,70 @@ export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: str
   return true
 }
 
-async function sendSocketRequest({mdFile, action, chart, inputs, log}: {mdFile: string; action: 'check' | 'list'; chart?: string; inputs?: RunInputs; log: (...args: any[]) => void}) {
+async function sendSocketRequest({
+  mdFile,
+  action,
+  chart,
+  inputs,
+  log,
+  telemetry,
+}: {
+  mdFile: string
+  action: 'check' | 'list'
+  chart?: string
+  inputs?: RunInputs
+  log: (...args: any[]) => void
+  telemetry?: CliTelemetry
+}) {
   let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')
   if (pageUrl === '/index') pageUrl = '/'
   pageUrl = appendInputsToUrl(pageUrl, inputs)
 
-  if (process.env.NODE_ENV !== 'test' && !(await isServerRunning())) {
-    log('Starting Graphene server...')
-    await runServeInBackground()
-  }
+  let serverHost = `http://127.0.0.1:${config.port}`
+  let pageHost = `http://localhost:${config.port}`
+  let ownedServer: ViteDevServer | null = null
 
-  let host = `http://localhost:${config.port}`
-  let resp = await fetchSocketRequest({host, pageUrl, action, chart})
+  try {
+    let resp = await fetchSocketRequest({host: serverHost, pageHost, pageUrl, action, chart})
 
-  if (resp.error == 'no_server') {
+    if (resp.error == 'no_server') {
+      log('Starting Graphene server...')
+      let mod = await import('./serve2.ts')
+      ownedServer = await mod.serve2(telemetry, {host: '127.0.0.1', log})
+      resp = await fetchSocketRequest({host: serverHost, pageHost, pageUrl, action, chart})
+    }
+
+    if (resp.error == 'no_server') {
+      log('Failed to start Graphene server')
+      return null
+    }
+
+    if (resp.error == 'no_tab' && process.env.NODE_ENV !== 'test') {
+      log(`Opening page ${pageHost}${pageUrl}`)
+      openInBrowser(pageHost + pageUrl)
+      await new Promise(resolve => setTimeout(resolve, 500))
+      resp = await fetchSocketRequest({host: serverHost, pageHost, pageUrl, action, chart})
+    }
+
+    if (resp.error == 'no_tab') {
+      log('Failed to open a new tab')
+      return null
+    }
+
+    if (resp.error) {
+      log(`Failed to ${action == 'check' ? 'run check' : 'list queries'}: ${resp.error}`)
+      return null
+    }
+
+    return resp
+  } catch (err) {
     log('Failed to start Graphene server')
+    if (err instanceof Error) log(err.message)
+    else log(String(err))
     return null
+  } finally {
+    await ownedServer?.close()
   }
-
-  if (resp.error == 'no_tab' && process.env.NODE_ENV !== 'test') {
-    log(`Opening page ${host}${pageUrl}`)
-    openInBrowser(host + pageUrl)
-    await new Promise(resolve => setTimeout(resolve, 500))
-    resp = await fetchSocketRequest({host, pageUrl, action, chart})
-  }
-
-  if (resp.error == 'no_tab') {
-    log('Failed to open a new tab')
-    return null
-  }
-
-  if (resp.error) {
-    log(`Failed to ${action == 'check' ? 'run check' : 'list queries'}: ${resp.error}`)
-    return null
-  }
-
-  return resp
 }
 
 function appendInputsToUrl(pageUrl: string, inputs: RunInputs = {}) {
@@ -201,15 +229,14 @@ function appendInputsToUrl(pageUrl: string, inputs: RunInputs = {}) {
   return `${pageUrl}?${rendered}`
 }
 
-async function fetchSocketRequest({host, pageUrl, action, chart}: {host: string; pageUrl: string; action: 'check' | 'list'; chart?: string}) {
+async function fetchSocketRequest({host, pageHost, pageUrl, action, chart}: {host: string; pageHost: string; pageUrl: string; action: 'check' | 'list'; chart?: string}) {
   let abort = new AbortController()
   let timeout = setTimeout(() => abort.abort(), 30_000)
-  let browserHost = host.replace('127.0.0.1', 'localhost')
   try {
     let response = await fetch(`${host}/_api/check`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({pageUrl: browserHost + pageUrl, action, chart}),
+      body: JSON.stringify({pageUrl: pageHost + pageUrl, action, chart}),
       signal: abort.signal,
     })
     clearTimeout(timeout)

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -32,21 +32,28 @@ const QUERY_VERSION = 1
 let uiRoot: string
 let nodeRequire = createRequire(import.meta.url)
 
-export async function serve2(telemetry?: CliTelemetry): Promise<ViteDevServer> {
-  let server = await createServer(await createConfig(telemetry))
+interface ServeOptions {
+  host?: string
+  log?: (...args: any[]) => void
+}
+
+export async function serve2(telemetry?: CliTelemetry, options: ServeOptions = {}): Promise<ViteDevServer> {
+  let server = await createServer(await createConfig(telemetry, options))
   // I originally added this to avoid the page refreshing immediately on load.
   // We def don't want to run it in tests, because its not safe to do in parallel.
   // I'm not sure it's still needed, now that we explicitly list out `optimizeDeps.includes`, refreshes should be rare
   // await optimizeDeps(server.config, true)
   await server.listen()
-  console.log(`Server running at http://localhost:${server.config.server.port}`)
+  let displayHost = options.host || 'localhost'
+  let log = options.log || console.log
+  log(`Server running at http://${displayHost}:${server.config.server.port}`)
 
   return server
 }
 
-async function createConfig(telemetry?: CliTelemetry): Promise<InlineConfig> {
+async function createConfig(telemetry?: CliTelemetry, options: ServeOptions = {}): Promise<InlineConfig> {
   uiRoot = path.join(fileURLToPath(import.meta.url), '../../ui')
-  let port = Number(process.env.GRAPHENE_PORT) || 4000
+  let port = config.port || Number(process.env.GRAPHENE_PORT) || 4000
   let svelteRoot = path.dirname(nodeRequire.resolve('svelte/package.json'))
   let sveltePackage = nodeRequire('svelte/package.json')
   let svelteDependencyRoot = path.dirname(svelteRoot)
@@ -56,7 +63,7 @@ async function createConfig(telemetry?: CliTelemetry): Promise<InlineConfig> {
 
   // Bind to 0.0.0.0 when running in a container so port forwarding works from the host
   let inContainer = fs.existsSync('/.dockerenv')
-  let host = inContainer ? '0.0.0.0' : '127.0.0.1'
+  let host = options.host || (inContainer ? '0.0.0.0' : '127.0.0.1')
 
   return {
     root: config.root,

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -1,11 +1,19 @@
+import {spawn, type ChildProcessWithoutNullStreams} from 'node:child_process'
+import path from 'path'
 import stripAnsi from 'strip-ansi'
+import {fileURLToPath} from 'url'
 
+import {isServerRunning} from '../../cli/background.ts'
 import {check} from '../../cli/check.ts'
 import {mockFileMap} from '../../cli/mockFiles.ts'
 import {listMdFileQueries, runMdFile} from '../../cli/run.ts'
 import {trimIndentation} from '../../lang/util.ts'
-import {test, expect, waitForGrapheneLoad} from './fixtures.ts'
+import {test, expect, getAvailablePort, waitForGrapheneLoad} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const cliEntry = path.join(repoRoot, 'cli/cli.ts')
+const flightDir = path.join(repoRoot, 'examples/flights')
 
 let logs = ''
 function log(...args: any[]) {
@@ -20,6 +28,23 @@ function outputLines() {
     'Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png',
   )
   return stripAnsi(normalized.trim())
+}
+
+function waitForOutput(read: () => string, text: string, timeoutMs = 5000) {
+  let deadline = Date.now() + timeoutMs
+  return new Promise<void>((resolve, reject) => {
+    let poll = () => {
+      if (read().includes(text)) return resolve()
+      if (Date.now() >= deadline) return reject(new Error(`Timed out waiting for "${text}"`))
+      setTimeout(poll, 50)
+    }
+    poll()
+  })
+}
+
+function waitForCli(child: ChildProcessWithoutNullStreams): Promise<number> {
+  if (child.exitCode !== null) return Promise.resolve(child.exitCode)
+  return new Promise(resolve => child.on('close', code => resolve(code ?? 0)))
 }
 
 test.beforeEach(() => {
@@ -112,6 +137,34 @@ test('cli run with md file reports dynamic unsupported chart wrapper props', asy
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
   )
+})
+
+test('cli run with md file owns and stops a transient server', async ({page}) => {
+  let port = await getAvailablePort()
+  let child = spawn('node', [cliEntry, 'run', 'index.md'], {
+    cwd: flightDir,
+    env: {...process.env, GRAPHENE_PORT: String(port), GRAPHENE_TELEMETRY_DISABLED: '1', NODE_ENV: 'test'},
+  })
+  let stdout = ''
+  let stderr = ''
+  child.stdout.on('data', d => (stdout += d.toString()))
+  child.stderr.on('data', d => (stderr += d.toString()))
+  expectConsoleError(/WebSocket connection to 'ws:\/\/(localhost|127\.0\.0\.1):\d+\/_api\/ws'/)
+
+  try {
+    await waitForOutput(() => stdout, 'Server running at')
+    await page.goto(`http://localhost:${port}/`)
+    await waitForGrapheneLoad(page)
+
+    let code = await waitForCli(child)
+    if (code !== 0) console.error(`[check.test] graphene run failed (code ${code})\nstdout:\n${stdout}\nstderr:\n${stderr}`)
+    expect(code).toBe(0)
+    expect(stdout).toContain('No errors found')
+    expect(stdout).toContain('Screenshot saved to')
+    expect(await isServerRunning(port)).toBe(false)
+  } finally {
+    if (child.exitCode === null) child.kill()
+  }
 })
 
 test('cli run with md file reports dynamic unsupported ECharts top-level props', async ({server, page}) => {


### PR DESCRIPTION
This PR updates the `graphene run page.md` flow to spawn the graphene server in the foreground (in the same way as `graphene serve` without `--bg`). Unfortunately this doesn't actually affect the interaction with the default Codex sandbox behavior (it does not allow localhost binding by default, whereas Claude Code does - see #384). But it does change the error from the run command in that case from the very cryptic

```
Starting Graphene server...
file:///Users/dylan/Code/example-nba/node_modules/@graphenedata/cli/dist/cli/chunk-OVWODUTJ.js:12200
      reject(new Error("Exited before server started"));
             ^

Error: Exited before server started
    at ChildProcess.<anonymous> (file:///Users/dylan/Code/example-nba/node_modules/@graphenedata/cli/dist/cli/chunk-OVWODUTJ.js:12200:14)
    at Object.onceWrapper (node:events:623:26)
    at ChildProcess.emit (node:events:508:28)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12)
```

to:

```
Starting Graphene server...
Failed to start Graphene server
listen EPERM: operation not permitted 127.0.0.1:4000
```