### PR TITLE
have create-graphene write Codex project config

### DIFF
--- a/create/create.test.ts
+++ b/create/create.test.ts
@@ -304,6 +304,7 @@ describe('runCreate', () => {
     expect(spawnMock).toHaveBeenCalled()
     expect(await lstat(path.join(root, 'demo-app/.agents/skills/graphene')).catch(() => null)).toBeNull()
     expect(await lstat(path.join(root, 'demo-app/.claude/skills/graphene')).catch(() => null)).toBeNull()
+    expect(await lstat(path.join(root, 'demo-app/.codex/config.toml')).catch(() => null)).toBeNull()
   })
 
   it('does not prompt before installing dependencies', async () => {
@@ -324,21 +325,51 @@ describe('runCreate', () => {
     })
 
     expect(confirmMock).not.toHaveBeenCalled()
+    expect(selectMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: 'Configure which agent?',
+        options: [
+          {value: 'codex', label: 'Codex'},
+          {value: 'claude', label: 'Claude'},
+          {value: 'other', label: 'Other agent'},
+          {value: 'none', label: 'Skip extra setup'},
+        ],
+      }),
+    )
     expect(spawnMock).toHaveBeenCalledWith('yarn', ['install'], expect.any(Object))
   })
 
-  it('symlinks the Graphene skill into the selected agent folder', async () => {
+  it('symlinks the Graphene skill and writes Codex config when Codex is selected', async () => {
     let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
     let {runCreate} = await import('./create.ts')
 
     textMock.mockResolvedValueOnce('demo-app')
-    selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('.agents')
+    selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('codex')
     spawnMock.mockImplementation(() => createChild())
 
     await runCreate({argv: [], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
 
     let linkTarget = await readlink(path.join(root, 'demo-app/.agents/skills/graphene'))
     expect(linkTarget).toBe('../../node_modules/@graphenedata/cli/dist/skills/graphene')
+    expect(await readFile(path.join(root, 'demo-app/.codex/config.toml'), 'utf8')).toBe(`# Enable Graphene page screenshots in Codex by allowing the local dev server.
+default_permissions = "graphene"
+
+[permissions.graphene.filesystem]
+":root" = "read"
+":project_roots" = { "." = "write" }
+":tmpdir" = "write"
+
+[permissions.graphene.network]
+enabled = true
+mode = "full"
+allow_local_binding = true
+
+[permissions.graphene.network.domains]
+"localhost" = "allow"
+"127.0.0.1" = "allow"
+"::1" = "allow"
+`)
   })
 
   it('symlinks the Graphene skill into the selected Claude folder', async () => {
@@ -346,7 +377,7 @@ describe('runCreate', () => {
     let {runCreate} = await import('./create.ts')
 
     textMock.mockResolvedValueOnce('demo-app')
-    selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('.claude')
+    selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('claude')
     spawnMock.mockImplementation(() => createChild())
 
     await runCreate({argv: [], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
@@ -355,6 +386,23 @@ describe('runCreate', () => {
     expect(linkTarget).toBe('../../node_modules/@graphenedata/cli/dist/skills/graphene')
     expect(await readFile(path.join(root, 'demo-app/CLAUDE.md'), 'utf8')).toContain('npx graphene check')
     expect(await lstat(path.join(root, 'demo-app/AGENTS.md')).catch(() => null)).toBeNull()
+    expect(await lstat(path.join(root, 'demo-app/.codex/config.toml')).catch(() => null)).toBeNull()
+  })
+
+  it('symlinks the Graphene skill into .agents for other agents without Codex config', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
+    let {runCreate} = await import('./create.ts')
+
+    textMock.mockResolvedValueOnce('demo-app')
+    selectMock.mockResolvedValueOnce('duckdb').mockResolvedValueOnce('other')
+    spawnMock.mockImplementation(() => createChild())
+
+    await runCreate({argv: [], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
+
+    let linkTarget = await readlink(path.join(root, 'demo-app/.agents/skills/graphene'))
+    expect(linkTarget).toBe('../../node_modules/@graphenedata/cli/dist/skills/graphene')
+    expect(await readFile(path.join(root, 'demo-app/AGENTS.md'), 'utf8')).toContain('npx graphene check')
+    expect(await lstat(path.join(root, 'demo-app/.codex/config.toml')).catch(() => null)).toBeNull()
   })
 
   it('skips dependency installation with --no-install', async () => {
@@ -364,6 +412,23 @@ describe('runCreate', () => {
     await runCreate({argv: ['demo-app', '--yes', '--no-install'], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
 
     expect(spawnMock).not.toHaveBeenCalled()
+    expect(await lstat(path.join(root, 'demo-app/.agents/skills/graphene')).catch(() => null)).toBeNull()
+    expect(await lstat(path.join(root, 'demo-app/.codex/config.toml')).catch(() => null)).toBeNull()
+  })
+
+  it('does not prompt for agent setup with --no-install', async () => {
+    let root = await mkdtemp(path.join(os.tmpdir(), 'graphene-create-'))
+    let {runCreate} = await import('./create.ts')
+
+    selectMock.mockResolvedValueOnce('duckdb')
+
+    await runCreate({argv: ['demo-app', '--no-install'], cwd: root, stdin: process.stdin, stdout: streamSink().stream, stderr: streamSink().stream})
+
+    expect(selectMock).toHaveBeenCalledTimes(1)
+    expect(selectMock).toHaveBeenCalledWith(expect.objectContaining({message: 'Database'}))
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(await lstat(path.join(root, 'demo-app/.agents/skills/graphene')).catch(() => null)).toBeNull()
+    expect(await lstat(path.join(root, 'demo-app/.codex/config.toml')).catch(() => null)).toBeNull()
   })
 
   it('marks install failures without clearing the log', async () => {

--- a/create/create.ts
+++ b/create/create.ts
@@ -18,7 +18,7 @@ interface CliPackageJson {
 
 type Database = 'duckdb' | 'snowflake' | 'bigquery' | 'clickhouse'
 type WarehouseClient = '@clickhouse/client' | '@duckdb/node-api' | '@google-cloud/bigquery' | 'snowflake-sdk'
-type SkillLinkTarget = '.agents' | '.claude' | 'none'
+type AgentSetup = 'codex' | 'claude' | 'other' | 'none'
 type CredentialFailureAction = 'edit' | 'continue'
 
 interface CreateOptions {
@@ -101,7 +101,7 @@ interface ScaffoldAnswers {
   clickhouseUrl?: string
   clickhouseUsername?: string
   clickhousePassword?: string
-  skillLinkTarget: SkillLinkTarget
+  agentSetup: AgentSetup
 }
 
 interface InstallResult {
@@ -227,9 +227,10 @@ export function renderTemplate({answers, cliVersion}: {answers: ScaffoldAnswers;
   let files: TemplateFiles = {
     'package.json': JSON.stringify(pkg, null, 2) + '\n',
     '.gitignore': ['node_modules', '.env', '*.duckdb'].join('\n') + '\n',
-    [agentsFileName(answers.skillLinkTarget)]: renderAgents(answers),
+    [agentsFileName(answers.agentSetup)]: renderAgents(answers),
     'index.md': renderIndex(answers),
   }
+  if (answers.agentSetup === 'codex') files['.codex/config.toml'] = renderCodexConfig()
   if (answers.packageManager?.name === 'yarn') files['.yarnrc.yml'] = 'nodeLinker: node-modules\n'
 
   let envFile = renderEnvFile(answers)
@@ -245,8 +246,8 @@ function grapheneCommand(packageManager: PackageManager | undefined, args: strin
   return `npx graphene ${args}`
 }
 
-function agentsFileName(skillLinkTarget: SkillLinkTarget): 'AGENTS.md' | 'CLAUDE.md' {
-  if (skillLinkTarget === '.claude') return 'CLAUDE.md'
+function agentsFileName(agentSetup: AgentSetup): 'AGENTS.md' | 'CLAUDE.md' {
+  if (agentSetup === 'claude') return 'CLAUDE.md'
   return 'AGENTS.md'
 }
 
@@ -262,6 +263,30 @@ function renderAgents(answers: ScaffoldAnswers): string {
       `- ${grapheneCommand(answers.packageManager, 'check')} - check the project for syntax and analysis errors`,
       `- ${grapheneCommand(answers.packageManager, 'run index.md')} - execute the index page`,
       `- ${grapheneCommand(answers.packageManager, 'serve --bg')} - start or restart the local dev server`,
+    ].join('\n') + '\n'
+  )
+}
+
+function renderCodexConfig(): string {
+  return (
+    [
+      '# Enable Graphene page screenshots in Codex by allowing the local dev server.',
+      'default_permissions = "graphene"',
+      '',
+      '[permissions.graphene.filesystem]',
+      '":root" = "read"',
+      '":project_roots" = { "." = "write" }',
+      '":tmpdir" = "write"',
+      '',
+      '[permissions.graphene.network]',
+      'enabled = true',
+      'mode = "full"',
+      'allow_local_binding = true',
+      '',
+      '[permissions.graphene.network.domains]',
+      '"localhost" = "allow"',
+      '"127.0.0.1" = "allow"',
+      '"::1" = "allow"',
     ].join('\n') + '\n'
   )
 }
@@ -576,7 +601,7 @@ async function collectAnswers({options, packageManager, input, output}: {options
       projectName: options.name || defaultProjectName(targetDir),
       packageManager,
       database: 'duckdb',
-      skillLinkTarget: 'none',
+      agentSetup: 'none',
     }
   }
 
@@ -612,7 +637,7 @@ async function collectAnswers({options, packageManager, input, output}: {options
     projectName,
     packageManager,
     database,
-    skillLinkTarget: 'none',
+    agentSetup: 'none',
   }
 
   if (database !== 'duckdb') {
@@ -620,13 +645,14 @@ async function collectAnswers({options, packageManager, input, output}: {options
   }
 
   if (options.install) {
-    answers.skillLinkTarget = unwrapPrompt(
-      await clack.select<SkillLinkTarget>({
-        message: 'Add the Graphene skill for agents?',
+    answers.agentSetup = unwrapPrompt(
+      await clack.select<AgentSetup>({
+        message: 'Configure which agent?',
         options: [
-          {value: '.agents', label: '.agents/skills/graphene'},
-          {value: '.claude', label: '.claude/skills/graphene'},
-          {value: 'none', label: 'Skip'},
+          {value: 'codex', label: 'Codex'},
+          {value: 'claude', label: 'Claude'},
+          {value: 'other', label: 'Other agent'},
+          {value: 'none', label: 'Skip extra setup'},
         ],
         ...promptOptions(input, output),
       }),
@@ -694,11 +720,18 @@ async function installDeps(targetDir: string, packageManager: PackageManager, en
   return {code, stderr}
 }
 
-async function symlinkGrapheneSkill(targetDir: string, skillLinkTarget: SkillLinkTarget): Promise<void> {
-  if (skillLinkTarget === 'none') return
+function skillLinkDirectory(agentSetup: AgentSetup): '.agents' | '.claude' | null {
+  if (agentSetup === 'codex' || agentSetup === 'other') return '.agents'
+  if (agentSetup === 'claude') return '.claude'
+  return null
+}
+
+async function symlinkGrapheneSkill(targetDir: string, agentSetup: AgentSetup): Promise<void> {
+  let linkDirectory = skillLinkDirectory(agentSetup)
+  if (!linkDirectory) return
 
   let sourcePath = path.join(targetDir, 'node_modules/@graphenedata/cli/dist/skills/graphene')
-  let linkPath = path.join(targetDir, skillLinkTarget, 'skills/graphene')
+  let linkPath = path.join(targetDir, linkDirectory, 'skills/graphene')
   let relativeSourcePath = path.relative(path.dirname(linkPath), sourcePath)
 
   await mkdir(path.dirname(linkPath), {recursive: true})
@@ -734,7 +767,7 @@ export async function runCreate({argv, cwd, env = {}, stdin, stdout}: CreateCont
     if (options.install) {
       let install = await installDeps(targetDir, packageManager, env)
       if (install.code !== 0) throw new Error(install.stderr.trim() || `${packageManager.name} install failed with code ${install.code}`)
-      await symlinkGrapheneSkill(targetDir, answers.skillLinkTarget)
+      await symlinkGrapheneSkill(targetDir, answers.agentSetup)
     }
 
     clack.outro(completionMessage(answers), {output: stdout})

--- a/create/helpers.test.ts
+++ b/create/helpers.test.ts
@@ -47,7 +47,7 @@ describe('create helpers', () => {
         packageManager: {name: 'pnpm', version: '10.1.0'},
         database: 'duckdb',
         duckdbPath: './data.duckdb',
-        skillLinkTarget: 'none',
+        agentSetup: 'none',
       },
     })
     let pkg = JSON.parse(files['package.json'])
@@ -73,7 +73,7 @@ describe('create helpers', () => {
         targetDir: 'demo-app',
         projectName: 'demo-app',
         database: 'duckdb',
-        skillLinkTarget: 'none',
+        agentSetup: 'none',
       },
     })
     let pkg = JSON.parse(files['package.json'])
@@ -86,11 +86,11 @@ describe('create helpers', () => {
   it('renders AGENTS.md commands for yarn and bun projects', () => {
     let yarnFiles = renderTemplate({
       cliVersion: '0.0.15',
-      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'yarn', version: '4.12.0'}, database: 'duckdb', skillLinkTarget: 'none'},
+      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'yarn', version: '4.12.0'}, database: 'duckdb', agentSetup: 'none'},
     })
     let bunFiles = renderTemplate({
       cliVersion: '0.0.15',
-      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'bun', version: '1.3.0'}, database: 'duckdb', skillLinkTarget: 'none'},
+      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'bun', version: '1.3.0'}, database: 'duckdb', agentSetup: 'none'},
     })
 
     expect(yarnFiles['AGENTS.md']).toContain('yarn graphene check')
@@ -99,15 +99,60 @@ describe('create helpers', () => {
     expect(bunFiles['.yarnrc.yml']).toBeUndefined()
   })
 
-  it('renders CLAUDE.md when the Claude skill target is selected', () => {
+  it('renders Codex setup files when Codex is selected', () => {
     let files = renderTemplate({
       cliVersion: '0.0.15',
-      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'pnpm', version: '10.1.0'}, database: 'duckdb', skillLinkTarget: '.claude'},
+      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'pnpm', version: '10.1.0'}, database: 'duckdb', agentSetup: 'codex'},
+    })
+
+    expect(files['AGENTS.md']).toContain('pnpm graphene check')
+    expect(files['.codex/config.toml']).toBe(`# Enable Graphene page screenshots in Codex by allowing the local dev server.
+default_permissions = "graphene"
+
+[permissions.graphene.filesystem]
+":root" = "read"
+":project_roots" = { "." = "write" }
+":tmpdir" = "write"
+
+[permissions.graphene.network]
+enabled = true
+mode = "full"
+allow_local_binding = true
+
+[permissions.graphene.network.domains]
+"localhost" = "allow"
+"127.0.0.1" = "allow"
+"::1" = "allow"
+`)
+    expect(files['CLAUDE.md']).toBeUndefined()
+  })
+
+  it('renders CLAUDE.md when Claude is selected', () => {
+    let files = renderTemplate({
+      cliVersion: '0.0.15',
+      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'pnpm', version: '10.1.0'}, database: 'duckdb', agentSetup: 'claude'},
     })
 
     expect(files['CLAUDE.md']).toContain('pnpm graphene check')
     expect(files['CLAUDE.md']).toContain('Assume all DuckDB functions are available when writing GSQL.')
     expect(files['AGENTS.md']).toBeUndefined()
+    expect(files['.codex/config.toml']).toBeUndefined()
+  })
+
+  it('renders AGENTS.md without Codex config for other agents and skipped setup', () => {
+    let otherFiles = renderTemplate({
+      cliVersion: '0.0.15',
+      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'pnpm', version: '10.1.0'}, database: 'duckdb', agentSetup: 'other'},
+    })
+    let skippedFiles = renderTemplate({
+      cliVersion: '0.0.15',
+      answers: {targetDir: 'demo-app', projectName: 'demo-app', packageManager: {name: 'pnpm', version: '10.1.0'}, database: 'duckdb', agentSetup: 'none'},
+    })
+
+    expect(otherFiles['AGENTS.md']).toContain('pnpm graphene check')
+    expect(otherFiles['.codex/config.toml']).toBeUndefined()
+    expect(skippedFiles['AGENTS.md']).toContain('pnpm graphene check')
+    expect(skippedFiles['.codex/config.toml']).toBeUndefined()
   })
 
   it('renders a snowflake project with .env auth vars', () => {
@@ -122,7 +167,7 @@ describe('create helpers', () => {
         snowflakeUsername: 'graphene_user',
         snowflakeKeyPath: '/Users/me/.ssh/graphene_snowflake_key.p8',
         snowflakePassphrase: 'secret',
-        skillLinkTarget: 'none',
+        agentSetup: 'none',
       },
     })
     let pkg = JSON.parse(files['package.json'])
@@ -148,7 +193,7 @@ describe('create helpers', () => {
         defaultNamespace: 'my-project.analytics',
         bigqueryProjectId: 'my-project-123',
         bigqueryKeyPath: '/Users/me/.ssh/graphene-bq-key.json',
-        skillLinkTarget: 'none',
+        agentSetup: 'none',
       },
     })
     let pkg = JSON.parse(files['package.json'])
@@ -174,7 +219,7 @@ describe('create helpers', () => {
         clickhouseUrl: 'https://example.clickhouse.cloud:8443',
         clickhouseUsername: 'default',
         clickhousePassword: 'secret',
-        skillLinkTarget: 'none',
+        agentSetup: 'none',
       },
     })
     let pkg = JSON.parse(files['package.json'])


### PR DESCRIPTION
It turns out the issue with `graphene run page.md` in Codex is very simple: Codex's default sandbox policy disallows even localhost binding, whereas Claude's allows it. This makes the difference between a page run working and not.

This PR updates the create-graphene flow to adjust how we prompt for agent setup (asking which agent to set up, with the options being "Claude", "Codex", or "Other agent"). In the Codex case we write a `.codex/config.toml` in the project folder with a default policy that enables `allow_local_binding`. In my opinion this feels totally above board - we are writing a Codex config scoped to the generated project, and only adjusting the localhost network access behavior (to be like Claude's default).