### PR TITLE
validate metadata in `check`

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -8,12 +8,12 @@ table orders (
   id bigint
   created_at datetime
   user_id bigint
-  amount float                          #units=usd
+  amount float                          #currency=USD
   status string
   join one users on user_id = users.id  -- many orders per user
   is_complete: status = 'Complete'      -- dimension (scalar expression)
-  revenue: sum(amount)                  -- measure (agg expression) #units=usd
-  avg_order: revenue / count(*)         -- measures can compose #units=usd
+  revenue: sum(amount)                  -- measure (agg expression) #currency=USD
+  avg_order: revenue / count(*)         -- measures can compose #currency=USD
 )
 table users (
   id bigint

--- a/docs/references/gsql.md
+++ b/docs/references/gsql.md
@@ -147,7 +147,7 @@ For this reason, some metadata should be set explicitly in the GSQL model, using
 | `#ratio` | no | Value is 0–1; rendered as `value × 100%` (e.g. `0.42` → `42%`) |
 | `#pct` | no | Value is already 0–100; rendered as `value%` (e.g. `42` → `42%`) |
 | `#currency=<code>` | no | Adds currency symbol and compacts to K/M/B. Accepts ISO 4217 currency codes like `USD`, `EUR`, and `JPY` |
-| `#unit=<unit>` | no | Physical unit label. Any non-empty value is accepted |
+| `#unit=<unit>` | no | Appends the provided value to the end of labels in visualizations (e.g. `unit=minutes` appends "minutes", or "(minutes)" on axes). Any non-empty value is accepted |
 | `#timeGrain=<grain>` | yes (from `date_trunc`, `date_bin`, casts) | Controls time axis label format. Values: `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, `second` |
 | `#timeOrdinal=<ordinal>` | yes (from `extract`) | Treats values as ordinal positions on a categorical axis. Values: `hour_of_day`, `day_of_month`, `day_of_year`, `week_of_year`, `month_of_year`, `quarter_of_year`, `dow_0s` (0=Sun), `dow_1s` (1=Sun), `dow_1m` (1=Mon) |
 | `#description=<text>` | no | Description text for a table or field. `--` comments are also collected as descriptions |

--- a/docs/references/gsql.md
+++ b/docs/references/gsql.md
@@ -151,10 +151,7 @@ For this reason, some metadata should be set explicitly in the GSQL model, using
 | `#timeGrain=<grain>` | yes (from `date_trunc`, `date_bin`, casts) | Controls time axis label format. Values: `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, `second` |
 | `#timeOrdinal=<ordinal>` | yes (from `extract`) | Treats values as ordinal positions on a categorical axis. Values: `hour_of_day`, `day_of_month`, `day_of_year`, `week_of_year`, `month_of_year`, `quarter_of_year`, `dow_0s` (0=Sun), `dow_1s` (1=Sun), `dow_1m` (1=Mon) |
 | `#description=<text>` | no | Description text for a table or field. `--` comments are also collected as descriptions |
-| `#hide` | no | Marks a table or field as hidden. |
 | `#pii` | no | Marks a field as containing personally identifiable information. |
-
-Flag annotations (`#ratio`, `#pct`, `#hide`, `#pii`) accept either bare usage or `=true`.
 
 ## `select` statements
 

--- a/docs/references/gsql.md
+++ b/docs/references/gsql.md
@@ -138,7 +138,7 @@ There isn't always a SQL expression that can tip Graphene to the semantic meanin
 - The field could be a base column that has no source expression
 - There might not be enough information in the expression (eg. what currency a float is tied to)
 
-For this reason, some metadata should be set explicitly in the GSQL model, using annotations. Metadata annotations resemble hashtags (eg. `#ratio`, `#units=usd`) that can be inlined or written above the object they decorate.
+For this reason, some metadata should be set explicitly in the GSQL model, using annotations. Metadata annotations resemble hashtags (eg. `#ratio`, `#units=usd`) that can be inlined or written above the object they decorate. `graphene check` validates metadata keys and values.
 
 #### Recognized metadata
 
@@ -146,9 +146,11 @@ For this reason, some metadata should be set explicitly in the GSQL model, using
 |---|---|---|
 | `#ratio` | no | Value is 0–1; rendered as `value × 100%` (e.g. `0.42` → `42%`) |
 | `#pct` | no | Value is already 0–100; rendered as `value%` (e.g. `42` → `42%`) |
-| `#units=<currency>` | no | Adds currency symbol and compacts to K/M/B. Accepted values: `usd`, `eur`, `gbp`, `cad`, `aud`, `jpy` |
+| `#units=<unit>` | no | Adds currency symbol and compacts to K/M/B for currencies. Accepted values: `usd`, `eur`, `gbp`, `cad`, `aud`, `jpy`, `count`, `seconds` |
 | `#timeGrain=<grain>` | yes (from `date_trunc`, `date_bin`, casts) | Controls time axis label format. Values: `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, `second` |
 | `#timeOrdinal=<ordinal>` | yes (from `extract`) | Treats values as ordinal positions on a categorical axis. Values: `hour_of_day`, `day_of_month`, `day_of_year`, `week_of_year`, `month_of_year`, `quarter_of_year`, `dow_0s` (0=Sun), `dow_1s` (1=Sun), `dow_1m` (1=Mon) |
+
+The conventional table and field annotations `#description=<text>`, `#format=<text>`, `#color=<text>`, `#hide`, and `#pii` are also valid. Flag annotations accept either bare usage (for example `#ratio`) or `=true`.
 
 ## `select` statements
 

--- a/docs/references/gsql.md
+++ b/docs/references/gsql.md
@@ -17,8 +17,8 @@ table orders (
   user_id BIGINT
   created_at DATETIME
   status STRING -- One of 'Processing', 'Shipped', 'Complete', 'Cancelled', 'Returned'
-  amount FLOAT -- Amount paid by customer #units=usd
-  cost FLOAT -- Cost of materials #units=usd
+  amount FLOAT -- Amount paid by customer #currency=USD
+  cost FLOAT -- Cost of materials #currency=USD
 
   -- Join relationships
 
@@ -30,9 +30,9 @@ table orders (
   
   -- Measures
   
-  revenue: sum(case when revenue_recognized then amount else 0 end) #units=usd
-  cogs: sum(case when revenue_recognized then cost else 0 end) #units=usd
-  profit: revenue - cogs #units=usd
+  revenue: sum(case when revenue_recognized then amount else 0 end) #currency=USD
+  cogs: sum(case when revenue_recognized then cost else 0 end) #currency=USD
+  profit: revenue - cogs #currency=USD
   profit_margin: profit / revenue #ratio
 )
 
@@ -123,9 +123,9 @@ table orders (
   revenue_recognized: status in ('Processing', 'Shipped', 'Complete')
 
   /* Agg expressions */
-  revenue: sum(case when revenue_recognized then amount else 0 end) #units=usd
-  cogs: sum(case when revenue_recognized then cost else 0 end) #units=usd
-  profit: revenue - cogs #units=usd -- even though there are no agg functions here, this is still aggregative as it references other aggregative expressions
+  revenue: sum(case when revenue_recognized then amount else 0 end) #currency=USD
+  cogs: sum(case when revenue_recognized then cost else 0 end) #currency=USD
+  profit: revenue - cogs #currency=USD -- even though there are no agg functions here, this is still aggregative as it references other aggregative expressions
   profit_margin: profit / revenue #ratio
 )
 ```
@@ -138,7 +138,7 @@ There isn't always a SQL expression that can tip Graphene to the semantic meanin
 - The field could be a base column that has no source expression
 - There might not be enough information in the expression (eg. what currency a float is tied to)
 
-For this reason, some metadata should be set explicitly in the GSQL model, using annotations. Metadata annotations resemble hashtags (eg. `#ratio`, `#units=usd`) that can be inlined or written above the object they decorate.
+For this reason, some metadata should be set explicitly in the GSQL model, using annotations. Metadata annotations resemble hashtags (eg. `#ratio`, `#currency=USD`) that can be inlined or written above the object they decorate.
 
 #### Recognized metadata
 
@@ -146,7 +146,8 @@ For this reason, some metadata should be set explicitly in the GSQL model, using
 |---|---|---|
 | `#ratio` | no | Value is 0–1; rendered as `value × 100%` (e.g. `0.42` → `42%`) |
 | `#pct` | no | Value is already 0–100; rendered as `value%` (e.g. `42` → `42%`) |
-| `#units=<unit>` | no | Adds currency symbol and compacts to K/M/B for currencies. Accepted values: `usd`, `eur`, `gbp`, `cad`, `aud`, `jpy`, `count`, `seconds` |
+| `#currency=<code>` | no | Adds currency symbol and compacts to K/M/B. Accepts ISO 4217 currency codes like `USD`, `EUR`, and `JPY` |
+| `#unit=<unit>` | no | Physical unit label. Any non-empty value is accepted |
 | `#timeGrain=<grain>` | yes (from `date_trunc`, `date_bin`, casts) | Controls time axis label format. Values: `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, `second` |
 | `#timeOrdinal=<ordinal>` | yes (from `extract`) | Treats values as ordinal positions on a categorical axis. Values: `hour_of_day`, `day_of_month`, `day_of_year`, `week_of_year`, `month_of_year`, `quarter_of_year`, `dow_0s` (0=Sun), `dow_1s` (1=Sun), `dow_1m` (1=Mon) |
 
@@ -243,15 +244,15 @@ table orders (
   user_id BIGINT
   created_at DATETIME
   status STRING -- One of 'Processing', 'Shipped', 'Complete', 'Cancelled', 'Returned'
-  amount FLOAT -- Amount paid by customer #units=usd
-  cost FLOAT -- Cost of materials #units=usd
+  amount FLOAT -- Amount paid by customer #currency=USD
+  cost FLOAT -- Cost of materials #currency=USD
 
   join one users on user_id = users.id
 
   revenue_recognized: status in ('Processing', 'Shipped', 'Complete')
-  revenue: sum(case when revenue_recognized then amount else 0 end) #units=usd
-  cogs: sum(case when revenue_recognized then cost else 0 end) #units=usd
-  profit: revenue - cogs #units=usd
+  revenue: sum(case when revenue_recognized then amount else 0 end) #currency=USD
+  cogs: sum(case when revenue_recognized then cost else 0 end) #currency=USD
+  profit: revenue - cogs #currency=USD
   profit_margin: profit / revenue #ratio
 )
 ```
@@ -332,15 +333,15 @@ table orders (
   user_id BIGINT
   created_at DATETIME
   status STRING -- One of 'Processing', 'Shipped', 'Complete', 'Cancelled', 'Returned'
-  amount FLOAT -- Amount paid by customer #units=usd
-  cost FLOAT -- Cost of materials #units=usd
+  amount FLOAT -- Amount paid by customer #currency=USD
+  cost FLOAT -- Cost of materials #currency=USD
 
   join one users on user_id = users.id
 
   revenue_recognized: status in ('Processing', 'Shipped', 'Complete')
-  revenue: sum(case when revenue_recognized then amount else 0 end) #units=usd
-  cogs: sum(case when revenue_recognized then cost else 0 end) #units=usd
-  profit: revenue - cogs #units=usd
+  revenue: sum(case when revenue_recognized then amount else 0 end) #currency=USD
+  cogs: sum(case when revenue_recognized then cost else 0 end) #currency=USD
+  profit: revenue - cogs #currency=USD
   profit_margin: profit / revenue #ratio
 )
 
@@ -353,7 +354,7 @@ table users (
   join many orders on id = orders.user_id
   join one user_facts on id = user_facts.id
 
-  ltv: user_facts.ltv #units=usd
+  ltv: user_facts.ltv #currency=USD
   lifetime_orders: user_facts.lifetime_orders
 )
 
@@ -390,6 +391,6 @@ We can extend this table to add measures or joins:
 extend regional_orders (
   join one regions on region = regions.name
 
-  avg_order_value: total_revenue / num_orders #units=usd
+  avg_order_value: total_revenue / num_orders #currency=USD
 )
 ```

--- a/docs/references/gsql.md
+++ b/docs/references/gsql.md
@@ -150,8 +150,11 @@ For this reason, some metadata should be set explicitly in the GSQL model, using
 | `#unit=<unit>` | no | Physical unit label. Any non-empty value is accepted |
 | `#timeGrain=<grain>` | yes (from `date_trunc`, `date_bin`, casts) | Controls time axis label format. Values: `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, `second` |
 | `#timeOrdinal=<ordinal>` | yes (from `extract`) | Treats values as ordinal positions on a categorical axis. Values: `hour_of_day`, `day_of_month`, `day_of_year`, `week_of_year`, `month_of_year`, `quarter_of_year`, `dow_0s` (0=Sun), `dow_1s` (1=Sun), `dow_1m` (1=Mon) |
+| `#description=<text>` | no | Description text for a table or field. `--` comments are also collected as descriptions |
+| `#hide` | no | Marks a table or field as hidden. |
+| `#pii` | no | Marks a field as containing personally identifiable information. |
 
-The conventional table and field annotations `#description=<text>`, `#format=<text>`, `#color=<text>`, `#hide`, and `#pii` are also valid. Flag annotations accept either bare usage (for example `#ratio`) or `=true`.
+Flag annotations (`#ratio`, `#pct`, `#hide`, `#pii`) accept either bare usage or `=true`.
 
 ## `select` statements
 

--- a/docs/references/gsql.md
+++ b/docs/references/gsql.md
@@ -138,7 +138,7 @@ There isn't always a SQL expression that can tip Graphene to the semantic meanin
 - The field could be a base column that has no source expression
 - There might not be enough information in the expression (eg. what currency a float is tied to)
 
-For this reason, some metadata should be set explicitly in the GSQL model, using annotations. Metadata annotations resemble hashtags (eg. `#ratio`, `#units=usd`) that can be inlined or written above the object they decorate. `graphene check` validates metadata keys and values.
+For this reason, some metadata should be set explicitly in the GSQL model, using annotations. Metadata annotations resemble hashtags (eg. `#ratio`, `#units=usd`) that can be inlined or written above the object they decorate.
 
 #### Recognized metadata
 

--- a/examples/ecomm/models/order_items.gsql
+++ b/examples/ecomm/models/order_items.gsql
@@ -35,7 +35,6 @@ table order_items (
 
 -- Workaround due to aggregate locality ambiguity problem. See https://graphenedata.slack.com/archives/C095V84GQPR/p1760648883764849
 -- Do not query this directly
-#hide
 table order_items_facts as (
   from order_items select
     id,

--- a/examples/ecomm/models/users.gsql
+++ b/examples/ecomm/models/users.gsql
@@ -33,7 +33,6 @@ table users (
 )
 
 -- Do not query this directly
-#hide
 table user_facts as (
   from users select
     id,

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -18,7 +18,7 @@ import {
 } from './fanout.ts'
 import {analyzeBareFunction, analyzeFunction} from './functions.ts'
 import {parseMarkdown} from './markdown.ts'
-import {extractLeadingMetadata} from './metadata.ts'
+import {extractLeadingMetadataDetails, validateMetadataEntries} from './metadata.ts'
 import {parser} from './parser.js'
 import {parseTemporalLiteral, parseIntervalLiteral, parseIntervalUnit, renderTemporalArithmetic, renderStandaloneInterval} from './temporal.ts'
 import {inferTemporalExtractionMetadata} from './temporalMetadata.ts'
@@ -151,6 +151,15 @@ class AnalysisSession implements Analyzer {
     return `${kind}:${location.file}:${location.from.offset}:${location.to.offset}${suffix}`
   }
 
+  private extractMetadata(node: SyntaxNode) {
+    let details = extractLeadingMetadataDetails(node)
+    let file = getFile(node)
+    for (let diagnostic of validateMetadataEntries(details.entries)) {
+      this.diagRange(file, diagnostic.from, diagnostic.to, diagnostic.message)
+    }
+    return details.metadata
+  }
+
   private renderTableHover(table: Table) {
     let desc = table.metadata?.description ? `\n\n${table.metadata.description}` : ''
     return `#### ${table.name}${desc}`
@@ -193,7 +202,7 @@ class AnalysisSession implements Analyzer {
       let hasNamespace = name.includes('.')
       let tablePath = !hasNamespace && this.config.defaultNamespace ? `${this.config.defaultNamespace}.${name}` : name
       let type = syntaxNode.getChild('QueryExpression') ? 'view' : ('table' as const)
-      let table = {name, type, tablePath, filePath: fi.path, columns: [], joins: [], metadata: extractLeadingMetadata(syntaxNode), syntaxNode} as Table
+      let table = {name, type, tablePath, filePath: fi.path, columns: [], joins: [], metadata: this.extractMetadata(syntaxNode), syntaxNode} as Table
       Object.assign(table, this.addSymbol('table', refNode, name, {hover: this.renderTableHover(table)}))
 
       syntaxNode.getChildren('ColumnDef').forEach(node => this.addColumn(table, node))
@@ -221,7 +230,7 @@ class AnalysisSession implements Analyzer {
     if (parsed.error) return this.diag(node, parsed.error)
     if (!parsed.type) return this.diag(node, `Unsupported data type: ${txt(node.getChild('DataType'))}`)
     let type = parsed.type
-    let col: Column = {name, type, metadata: extractLeadingMetadata(node)}
+    let col: Column = {name, type, metadata: this.extractMetadata(node)}
     Object.assign(col, this.addSymbol('column', nameNode, name, {tableId: table.symbolId, hover: this.renderFieldHover(table, col)}))
     if (this.getField(name, table)) return this.diag(node, `Table already has a field called "${name}"`)
     table.columns.push(col)
@@ -247,7 +256,7 @@ class AnalysisSession implements Analyzer {
   private addComputedColumn(table: Table, node: SyntaxNode) {
     let nameNode = node.getChild('Alias')!
     let name = txt(nameNode)
-    let col: Column = {name, type: scalarType('string'), exprNode: node.getChild('Expression')!, metadata: extractLeadingMetadata(node)}
+    let col: Column = {name, type: scalarType('string'), exprNode: node.getChild('Expression')!, metadata: this.extractMetadata(node)}
     Object.assign(col, this.addSymbol('column', nameNode, name, {tableId: table.symbolId, hover: this.renderFieldHover(table, col)}))
     if (this.getField(name, table)) return this.diag(node, `Table already has a field called "${name}"`)
     table.columns.push(col)
@@ -1522,10 +1531,14 @@ class AnalysisSession implements Analyzer {
 
   diag<T>(node: SyntaxNode | SyntaxNodeRef, message: string, defaultReturn?: T): T {
     let file = getFile(node)
-    let from = getPosition(node.from, file)
-    let to = getPosition(node.to, file)
-    this.diagnostics.push({severity: 'error', message, file: toRelativePath(file.path), from, to, frame: buildFrame(from, to)})
+    this.diagRange(file, node.from, node.to, message)
     return defaultReturn as T
+  }
+
+  private diagRange(file: FileInfo, fromOffset: number, toOffset: number, message: string) {
+    let from = getPosition(fromOffset, file)
+    let to = getPosition(toOffset, file)
+    this.diagnostics.push({severity: 'error', message, file: toRelativePath(file.path), from, to, frame: buildFrame(from, to)})
   }
 
   checkTypes(expr: Expr, expected: TypeKind[], node: SyntaxNode) {

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -21,7 +21,8 @@ export type Field = {
 export type FieldMeta = {
   ratio?: true // 0 to 1 value
   pct?: true // 0 to 100 value
-  units?: string
+  currency?: string // ISO 4217 currency code
+  unit?: string // physical unit label
   timeGrain?: TimeGrain // resolution when the field is a date or timestamp
   timePart?: string // extracted temporal part, normalized across backend spellings
   timeOrdinal?: TimeOrdinal // if the value represents something special like day_of_week, week_of_year, etc

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -16,7 +16,7 @@ export type Field = {
 }
 
 // Metadata attached to fields.
-// There are a few built-in ones that Graphene already uses, but you can always attach your own metadata:
+// Graphene validates user-authored metadata annotations, while inferred metadata may add internal keys.
 // `price: cogs * 1.15 #ratio #format="US Dollar"` -> {ratio: true, format: 'US Dollar'}
 export type FieldMeta = {
   ratio?: true // 0 to 1 value

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -17,7 +17,7 @@ export type Field = {
 
 // Metadata attached to fields.
 // Graphene validates user-authored metadata annotations, while inferred metadata may add internal keys.
-// `price: cogs * 1.15 #ratio #format="US Dollar"` -> {ratio: true, format: 'US Dollar'}
+// `price: cogs * 1.15 #ratio #currency=USD` -> {ratio: true, currency: 'USD'}
 export type FieldMeta = {
   ratio?: true // 0 to 1 value
   pct?: true // 0 to 100 value

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -810,7 +810,7 @@ describe('lang', () => {
         -- a description
         #format=first_last
         name text,
-        another_field text, -- this is another field #units=seconds
+        another_field text, -- this is another field #unit=seconds
       )
       from t select name
     `)
@@ -821,7 +821,7 @@ describe('lang', () => {
     expect(name.metadata!.format).toBe('first_last')
     let another = table.columns.find(c => c.name === 'another_field')!
     expect(String(another.metadata!.description || '').toLowerCase()).toContain('this is another field')
-    expect(another.metadata!.units).toBe('seconds')
+    expect(another.metadata!.unit).toBe('seconds')
   })
 
   it('parses quoted values and multiple hash metadata comments', () => {
@@ -830,9 +830,9 @@ describe('lang', () => {
       #color=green #hide #format="US Dollar"
       table revenue (
         amount int,
-        -- gross revenue #units=usd #hide #format="US Dollar"
+        -- gross revenue #currency=USD #hide #format="US Dollar"
         gross int,
-        net int #units=usd #hide #format="US Dollar"
+        net int #currency=USD #hide #format="US Dollar"
       )
       from revenue select gross, net
     `)
@@ -840,9 +840,9 @@ describe('lang', () => {
     let table = getTable('revenue')!
     expect(table.metadata).toMatchObject({description: 'currency metrics', color: 'green', hide: 'true', format: 'US Dollar'})
     let gross = table.columns.find(c => c.name === 'gross')!
-    expect(gross.metadata).toMatchObject({description: 'gross revenue', units: 'usd', hide: 'true', format: 'US Dollar'})
+    expect(gross.metadata).toMatchObject({description: 'gross revenue', currency: 'USD', hide: 'true', format: 'US Dollar'})
     let net = table.columns.find(c => c.name === 'net')!
-    expect(net.metadata).toMatchObject({units: 'usd', hide: 'true', format: 'US Dollar'})
+    expect(net.metadata).toMatchObject({currency: 'USD', hide: 'true', format: 'US Dollar'})
   })
 
   it('keeps literal hash signs in descriptions while parsing trailing metadata pairs', () => {
@@ -884,12 +884,35 @@ describe('lang', () => {
     expect(`
       table foo (
         day date #timeGrain=mont
-        amount int -- revenue #units=dollars
+        amount int -- revenue #currency=ZZZ
         dow int #timeOrdinal=dow
+        weight int #unit=parsecs
       )
     `).toHaveDiagnostic(/Invalid value "mont" for "#timeGrain"/)
-    expect(getDiagnostics().some(d => /Invalid value "dollars" for "#units"/.test(d.message))).toBe(true)
+    expect(getDiagnostics().some(d => /Invalid value "ZZZ" for "#currency"/.test(d.message))).toBe(true)
     expect(getDiagnostics().some(d => /Invalid value "dow" for "#timeOrdinal"/.test(d.message))).toBe(true)
+  })
+
+  it('accepts ISO currency codes and arbitrary unit metadata values', () => {
+    analyze(`
+      table foo (
+        revenue int #currency=eur
+        distance int #unit=lightyears
+      )
+    `)
+    expect(getDiagnostics().filter(d => d.severity === 'error')).toEqual([])
+
+    let table = getTable('foo')!
+    expect(table.columns.find(c => c.name === 'revenue')!.metadata).toMatchObject({currency: 'eur'})
+    expect(table.columns.find(c => c.name === 'distance')!.metadata).toMatchObject({unit: 'lightyears'})
+  })
+
+  it('reports diagnostics for legacy plural units metadata', () => {
+    expect(`
+      table foo (
+        amount int -- revenue #units=usd
+      )
+    `).toHaveDiagnostic(/Unknown metadata key "#units"/)
   })
 
   it('reports diagnostics for invalid flag metadata values', () => {
@@ -942,13 +965,13 @@ describe('lang', () => {
   it('propagates field metadata from table columns to query output fields', () => {
     updateFile(
       `table revenue (
-      amount int -- gross revenue #units=usd
+      amount int -- gross revenue #currency=USD
     )`,
       'revenue.gsql',
     )
 
     let [query] = analyze('from revenue select amount')
-    expect(query.fields[0].metadata).toMatchObject({units: 'usd'})
+    expect(query.fields[0].metadata).toMatchObject({currency: 'USD'})
   })
 
   it('reports diagnostics for duplicate table definitions', () => {
@@ -1942,7 +1965,7 @@ describe('lang', () => {
       id INT64
       computed: id / 2
       -- this is a comment
-      #units=usd
+      #currency=USD
       name STRING
     ); from test select id`).toRenderSql('select test.id as id from test as test')
   })

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -808,7 +808,7 @@ describe('lang', () => {
       table t (
         id int,
         -- a description
-        #format=first_last
+        #pii
         name text,
         another_field text, -- this is another field #unit=seconds
       )
@@ -818,7 +818,7 @@ describe('lang', () => {
     expect(String(table.metadata?.description || '').toLowerCase()).toContain('this is my test table')
     let name = table.columns.find(c => c.name === 'name')!
     expect(String(name.metadata!.description || '').toLowerCase()).toContain('a description')
-    expect(name.metadata!.format).toBe('first_last')
+    expect(name.metadata!.pii).toBe('true')
     let another = table.columns.find(c => c.name === 'another_field')!
     expect(String(another.metadata!.description || '').toLowerCase()).toContain('this is another field')
     expect(another.metadata!.unit).toBe('seconds')
@@ -827,22 +827,22 @@ describe('lang', () => {
   it('parses quoted values and multiple hash metadata comments', () => {
     analyze(`
       -- currency metrics
-      #color=green #hide #format="US Dollar"
+      #hide #unit=dollars
       table revenue (
         amount int,
-        -- gross revenue #currency=USD #hide #format="US Dollar"
+        -- gross revenue #currency=USD #hide
         gross int,
-        net int #currency=USD #hide #format="US Dollar"
+        net int #currency=USD #hide
       )
       from revenue select gross, net
     `)
 
     let table = getTable('revenue')!
-    expect(table.metadata).toMatchObject({description: 'currency metrics', color: 'green', hide: 'true', format: 'US Dollar'})
+    expect(table.metadata).toMatchObject({description: 'currency metrics', hide: 'true', unit: 'dollars'})
     let gross = table.columns.find(c => c.name === 'gross')!
-    expect(gross.metadata).toMatchObject({description: 'gross revenue', currency: 'USD', hide: 'true', format: 'US Dollar'})
+    expect(gross.metadata).toMatchObject({description: 'gross revenue', currency: 'USD', hide: 'true'})
     let net = table.columns.find(c => c.name === 'net')!
-    expect(net.metadata).toMatchObject({currency: 'USD', hide: 'true', format: 'US Dollar'})
+    expect(net.metadata).toMatchObject({currency: 'USD', hide: 'true'})
   })
 
   it('keeps literal hash signs in descriptions while parsing trailing metadata pairs', () => {
@@ -861,14 +861,14 @@ describe('lang', () => {
   it('treats trailing dash comments in hash metadata lines as description', () => {
     analyze(`
       table foo (
-        #hide #color=green -- More comment
+        #hide #unit=parsecs -- More comment
         name text
       )
     `)
 
     let table = getTable('foo')!
     let name = table.columns.find(c => c.name === 'name')!
-    expect(name.metadata).toMatchObject({hide: 'true', color: 'green', description: 'More comment'})
+    expect(name.metadata).toMatchObject({hide: 'true', unit: 'parsecs', description: 'More comment'})
   })
 
   it('reports diagnostics for unknown metadata keys', () => {
@@ -938,14 +938,14 @@ describe('lang', () => {
   it('does not parse legacy dash-hash metadata comments', () => {
     analyze(`
       table foo (
-        --# format=first_last
+        --# unit=seconds
         name text
       )
     `)
 
     let table = getTable('foo')!
     let name = table.columns.find(c => c.name === 'name')!
-    expect(name.metadata?.format).toBeUndefined()
+    expect(name.metadata?.unit).toBeUndefined()
     expect(name.metadata?.description).toBeUndefined()
   })
 

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -861,14 +861,55 @@ describe('lang', () => {
   it('treats trailing dash comments in hash metadata lines as description', () => {
     analyze(`
       table foo (
-        #hide #key=value -- More comment
+        #hide #color=green -- More comment
         name text
       )
     `)
 
     let table = getTable('foo')!
     let name = table.columns.find(c => c.name === 'name')!
-    expect(name.metadata).toMatchObject({hide: 'true', key: 'value', description: 'More comment'})
+    expect(name.metadata).toMatchObject({hide: 'true', color: 'green', description: 'More comment'})
+  })
+
+  it('reports diagnostics for unknown metadata keys', () => {
+    expect(`
+      table foo (
+        #unknown=value
+        name text
+      )
+    `).toHaveDiagnostic(/Unknown metadata key "#unknown"/)
+  })
+
+  it('reports diagnostics for invalid metadata enum values', () => {
+    expect(`
+      table foo (
+        day date #timeGrain=mont
+        amount int -- revenue #units=dollars
+        dow int #timeOrdinal=dow
+      )
+    `).toHaveDiagnostic(/Invalid value "mont" for "#timeGrain"/)
+    expect(getDiagnostics().some(d => /Invalid value "dollars" for "#units"/.test(d.message))).toBe(true)
+    expect(getDiagnostics().some(d => /Invalid value "dow" for "#timeOrdinal"/.test(d.message))).toBe(true)
+  })
+
+  it('reports diagnostics for invalid flag metadata values', () => {
+    expect(`
+      table foo (
+        ratio number #ratio=false
+        hidden number #hide="true"
+      )
+    `).toHaveDiagnostic(/Metadata "#ratio" is a flag/)
+    expect(getDiagnostics().some(d => /Metadata "#hide" is a flag/.test(d.message))).toBe(true)
+  })
+
+  it('reports diagnostics for user-authored internal metadata keys', () => {
+    expect(`
+      table foo (
+        year_num int #timePart=year
+        month date #defaultName=month
+      )
+    `).toHaveDiagnostic(/Unknown metadata key "#timePart"/)
+    expect(getDiagnostics().some(d => /Unknown metadata key "#defaultName"/.test(d.message))).toBe(true)
   })
 
   it('does not parse legacy dash-hash metadata comments', () => {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -827,48 +827,48 @@ describe('lang', () => {
   it('parses quoted values and multiple hash metadata comments', () => {
     analyze(`
       -- currency metrics
-      #hide #unit=dollars
+      #pii #unit=dollars
       table revenue (
         amount int,
-        -- gross revenue #currency=USD #hide
+        -- gross revenue #currency=USD #pii
         gross int,
-        net int #currency=USD #hide
+        net int #currency=USD #pii
       )
       from revenue select gross, net
     `)
 
     let table = getTable('revenue')!
-    expect(table.metadata).toMatchObject({description: 'currency metrics', hide: 'true', unit: 'dollars'})
+    expect(table.metadata).toMatchObject({description: 'currency metrics', pii: 'true', unit: 'dollars'})
     let gross = table.columns.find(c => c.name === 'gross')!
-    expect(gross.metadata).toMatchObject({description: 'gross revenue', currency: 'USD', hide: 'true'})
+    expect(gross.metadata).toMatchObject({description: 'gross revenue', currency: 'USD', pii: 'true'})
     let net = table.columns.find(c => c.name === 'net')!
-    expect(net.metadata).toMatchObject({currency: 'USD', hide: 'true'})
+    expect(net.metadata).toMatchObject({currency: 'USD', pii: 'true'})
   })
 
   it('keeps literal hash signs in descriptions while parsing trailing metadata pairs', () => {
     analyze(`
       table foo (
-        -- Description with # sign #hide #pii
+        -- Description with # sign #ratio #pii
         name text
       )
     `)
 
     let table = getTable('foo')!
     let name = table.columns.find(c => c.name === 'name')!
-    expect(name.metadata).toMatchObject({description: 'Description with # sign', hide: 'true', pii: 'true'})
+    expect(name.metadata).toMatchObject({description: 'Description with # sign', ratio: 'true', pii: 'true'})
   })
 
   it('treats trailing dash comments in hash metadata lines as description', () => {
     analyze(`
       table foo (
-        #hide #unit=parsecs -- More comment
+        #pii #unit=parsecs -- More comment
         name text
       )
     `)
 
     let table = getTable('foo')!
     let name = table.columns.find(c => c.name === 'name')!
-    expect(name.metadata).toMatchObject({hide: 'true', unit: 'parsecs', description: 'More comment'})
+    expect(name.metadata).toMatchObject({pii: 'true', unit: 'parsecs', description: 'More comment'})
   })
 
   it('reports diagnostics for unknown metadata keys', () => {
@@ -919,10 +919,18 @@ describe('lang', () => {
     expect(`
       table foo (
         ratio number #ratio=false
-        hidden number #hide="true"
+        pii text #pii="true"
       )
     `).toHaveDiagnostic(/Metadata "#ratio" is a flag/)
-    expect(getDiagnostics().some(d => /Metadata "#hide" is a flag/.test(d.message))).toBe(true)
+    expect(getDiagnostics().some(d => /Metadata "#pii" is a flag/.test(d.message))).toBe(true)
+  })
+
+  it('reports diagnostics for unimplemented hide metadata', () => {
+    expect(`
+      table foo (
+        hidden number #hide
+      )
+    `).toHaveDiagnostic(/Unknown metadata key "#hide"/)
   })
 
   it('reports diagnostics for user-authored internal metadata keys', () => {

--- a/lang/metadata.ts
+++ b/lang/metadata.ts
@@ -34,8 +34,6 @@ let metadataKeyRules = {
   timeGrain: {kind: 'enum', values: ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second']},
   timeOrdinal: {kind: 'enum', values: ['hour_of_day', 'day_of_month', 'day_of_year', 'week_of_year', 'month_of_year', 'quarter_of_year', 'dow_0s', 'dow_1s', 'dow_1m']},
   description: {kind: 'string'},
-  format: {kind: 'string'},
-  color: {kind: 'string'},
 } as const
 
 let validMetadataKeys = Object.keys(metadataKeyRules)

--- a/lang/metadata.ts
+++ b/lang/metadata.ts
@@ -22,12 +22,15 @@ export type MetadataDiagnostic = {
   to: number
 }
 
+let isoCurrencyCodes = new Set(Intl.supportedValuesOf('currency').map(code => code.toLowerCase()))
+
 let metadataKeyRules = {
   ratio: {kind: 'flag'},
   pct: {kind: 'flag'},
   hide: {kind: 'flag'},
   pii: {kind: 'flag'},
-  units: {kind: 'enum', values: ['usd', 'eur', 'gbp', 'cad', 'aud', 'jpy', 'count', 'seconds']},
+  currency: {kind: 'currency'},
+  unit: {kind: 'string'},
   timeGrain: {kind: 'enum', values: ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second']},
   timeOrdinal: {kind: 'enum', values: ['hour_of_day', 'day_of_month', 'day_of_year', 'week_of_year', 'month_of_year', 'quarter_of_year', 'dow_0s', 'dow_1s', 'dow_1m']},
   description: {kind: 'string'},
@@ -119,6 +122,24 @@ export function validateMetadataEntries(entries: MetadataEntry[]): MetadataDiagn
         message: `Metadata "#${entry.key}" requires a value.`,
         from: entry.from,
         to: entry.to,
+      })
+      continue
+    }
+
+    if (rule.kind == 'currency') {
+      if (!entry.hasValue || !entry.value.trim()) {
+        diagnostics.push({
+          message: 'Metadata "#currency" requires a value.',
+          from: entry.from,
+          to: entry.to,
+        })
+        continue
+      }
+      if (isoCurrencyCodes.has(entry.value.toLowerCase())) continue
+      diagnostics.push({
+        message: `Invalid value "${entry.value}" for "#currency". Expected an ISO 4217 currency code.`,
+        from: entry.valueFrom ?? entry.from,
+        to: entry.valueTo ?? entry.to,
       })
       continue
     }

--- a/lang/metadata.ts
+++ b/lang/metadata.ts
@@ -5,6 +5,37 @@ import {getFile} from './util.ts'
 let embeddedMetadataPair = /(^|\s)(#)([A-Za-z0-9_-]+)(?:\s*=\s*("(?:[^"\\]|\\.)*"|[^\s#]+)|(?=(?:\s*(?:#|--|$))))/g
 
 type CommentKind = 'dash' | 'hash'
+export type MetadataEntry = {
+  key: string
+  value: string
+  rawValue?: string
+  from: number
+  to: number
+  valueFrom?: number
+  valueTo?: number
+  hasValue: boolean
+}
+
+export type MetadataDiagnostic = {
+  message: string
+  from: number
+  to: number
+}
+
+let metadataKeyRules = {
+  ratio: {kind: 'flag'},
+  pct: {kind: 'flag'},
+  hide: {kind: 'flag'},
+  pii: {kind: 'flag'},
+  units: {kind: 'enum', values: ['usd', 'eur', 'gbp', 'cad', 'aud', 'jpy', 'count', 'seconds']},
+  timeGrain: {kind: 'enum', values: ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second']},
+  timeOrdinal: {kind: 'enum', values: ['hour_of_day', 'day_of_month', 'day_of_year', 'week_of_year', 'month_of_year', 'quarter_of_year', 'dow_0s', 'dow_1s', 'dow_1m']},
+  description: {kind: 'string'},
+  format: {kind: 'string'},
+  color: {kind: 'string'},
+} as const
+
+let validMetadataKeys = Object.keys(metadataKeyRules)
 
 // Extract metadata from comments that appear directly above a syntax node.
 // Rules:
@@ -14,8 +45,12 @@ type CommentKind = 'dash' | 'hash'
 // - Adjacency required: we scan upward; a blank or non-comment line stops the scan.
 // - If the node is not the first token on its line, ignore leading comments.
 export function extractLeadingMetadata(node: SyntaxNode): Record<string, string> {
+  return extractLeadingMetadataDetails(node).metadata
+}
+
+export function extractLeadingMetadataDetails(node: SyntaxNode): {metadata: Record<string, string>; entries: MetadataEntry[]} {
   let src = getFile(node).contents
-  if (!src) return {}
+  if (!src) return {metadata: {}, entries: []}
 
   let pos = node.from
   let currentLineStart = src.lastIndexOf('\n', Math.max(0, pos - 1)) + 1
@@ -23,14 +58,15 @@ export function extractLeadingMetadata(node: SyntaxNode): Record<string, string>
   let beforeOnLine = src.slice(currentLineStart, pos)
   let isFirstTokenOnLine = !/[^\s]/.test(beforeOnLine)
 
-  let comments: {kind: CommentKind; text: string}[] = []
+  let comments: {kind: CommentKind; text: string; from: number; markerFrom: number}[] = []
   if (isFirstTokenOnLine && endOfPrevLine >= 0) {
     let cursor = endOfPrevLine
     while (cursor >= 0) {
       let startOfLine = src.lastIndexOf('\n', Math.max(0, cursor - 1)) + 1
-      let trimmed = src.slice(startOfLine, cursor).trim()
+      let line = src.slice(startOfLine, cursor)
+      let trimmed = line.trim()
       if (!trimmed) break
-      let comment = parseCommentLine(trimmed)
+      let comment = parseCommentLine(line, startOfLine)
       if (!comment) break
       comments.push(comment)
       cursor = startOfLine - 1
@@ -40,25 +76,72 @@ export function extractLeadingMetadata(node: SyntaxNode): Record<string, string>
 
   let metadata: Record<string, string> = {}
   let descriptionLines: string[] = []
-  for (let comment of comments) consumeComment(comment, metadata, descriptionLines)
+  let entries: MetadataEntry[] = []
+  for (let comment of comments) consumeComment(comment, metadata, descriptionLines, entries)
 
   let endPos = node.to
   let endOfLine = src.indexOf('\n', endPos)
   if (endOfLine === -1) endOfLine = src.length
   let after = src.slice(endPos, endOfLine)
-  let trailing = parseTrailingComment(after)
-  if (trailing) consumeComment(trailing, metadata, descriptionLines)
+  let trailing = parseTrailingComment(after, endPos)
+  if (trailing) consumeComment(trailing, metadata, descriptionLines, entries)
 
   if (descriptionLines.length) metadata.description = descriptionLines.join(' ')
-  return metadata
+  return {metadata, entries}
 }
 
-function parseCommentLine(trimmed: string): {kind: CommentKind; text: string} | undefined {
-  if (trimmed.startsWith('--')) return {kind: 'dash', text: trimmed.slice(2).trimStart()}
-  if (trimmed.startsWith('#')) return {kind: 'hash', text: trimmed.slice(1).trimStart()}
+export function validateMetadataEntries(entries: MetadataEntry[]): MetadataDiagnostic[] {
+  let diagnostics: MetadataDiagnostic[] = []
+  for (let entry of entries) {
+    let rule = metadataKeyRules[entry.key as keyof typeof metadataKeyRules]
+    if (!rule) {
+      diagnostics.push({
+        message: `Unknown metadata key "#${entry.key}". Expected one of: ${validMetadataKeys.join(', ')}`,
+        from: entry.from,
+        to: entry.to,
+      })
+      continue
+    }
+
+    if (rule.kind == 'flag') {
+      if (!entry.hasValue || entry.rawValue == 'true') continue
+      diagnostics.push({
+        message: `Metadata "#${entry.key}" is a flag; use "#${entry.key}" or "#${entry.key}=true".`,
+        from: entry.valueFrom ?? entry.from,
+        to: entry.valueTo ?? entry.to,
+      })
+      continue
+    }
+
+    if (rule.kind == 'string') {
+      if (entry.hasValue && entry.value.trim()) continue
+      diagnostics.push({
+        message: `Metadata "#${entry.key}" requires a value.`,
+        from: entry.from,
+        to: entry.to,
+      })
+      continue
+    }
+
+    if (rule.values.includes(entry.value as never)) continue
+    diagnostics.push({
+      message: `Invalid value "${entry.value}" for "#${entry.key}". Expected one of: ${rule.values.join(', ')}`,
+      from: entry.valueFrom ?? entry.from,
+      to: entry.valueTo ?? entry.to,
+    })
+  }
+  return diagnostics
 }
 
-function parseTrailingComment(after: string): {kind: CommentKind; text: string} | undefined {
+function parseCommentLine(line: string, lineStart: number): {kind: CommentKind; text: string; from: number; markerFrom: number} | undefined {
+  let leading = line.match(/^\s*/)?.[0].length || 0
+  let markerFrom = lineStart + leading
+  let trimmed = line.slice(leading)
+  if (trimmed.startsWith('--')) return withTrimmedText('dash', line, lineStart, markerFrom, leading + 2)
+  if (trimmed.startsWith('#')) return withTrimmedText('hash', line, lineStart, markerFrom, leading + 1)
+}
+
+function parseTrailingComment(after: string, afterStart: number): {kind: CommentKind; text: string; from: number; markerFrom: number} | undefined {
   let dashIdx = after.indexOf('--')
   let hashIdx = after.indexOf('#')
   let commentIdx = minNonNegative(dashIdx, hashIdx)
@@ -67,13 +150,19 @@ function parseTrailingComment(after: string): {kind: CommentKind; text: string} 
   let between = after.slice(0, commentIdx)
   if (!/^[\s,]*$/.test(between)) return undefined
 
-  if (hashIdx !== -1 && hashIdx === commentIdx) return {kind: 'hash', text: after.slice(hashIdx + 1).trimStart()}
-  return {kind: 'dash', text: after.slice(dashIdx + 2).trimStart()}
+  let markerFrom = afterStart + commentIdx
+  if (hashIdx !== -1 && hashIdx === commentIdx) return withTrimmedText('hash', after, afterStart, markerFrom, hashIdx + 1)
+  return withTrimmedText('dash', after, afterStart, markerFrom, dashIdx + 2)
 }
 
-function consumeComment(comment: {kind: CommentKind; text: string}, metadata: Record<string, string>, descriptionLines: string[]) {
+function withTrimmedText(kind: CommentKind, raw: string, rawFrom: number, markerFrom: number, textStart: number) {
+  let whitespace = raw.slice(textStart).match(/^\s*/)?.[0].length || 0
+  return {kind, text: raw.slice(textStart + whitespace), from: rawFrom + textStart + whitespace, markerFrom}
+}
+
+function consumeComment(comment: {kind: CommentKind; text: string; from: number; markerFrom: number}, metadata: Record<string, string>, descriptionLines: string[], entries: MetadataEntry[]) {
   if (comment.kind === 'hash') {
-    let cleaned = extractHashMetadata(comment.text, metadata)
+    let cleaned = extractHashMetadata(comment, metadata, entries)
     let trailingDescription = parseHashCommentDescription(cleaned)
     if (trailingDescription) descriptionLines.push(trailingDescription)
     return
@@ -82,34 +171,68 @@ function consumeComment(comment: {kind: CommentKind; text: string}, metadata: Re
   // `--# ...` was the old metadata syntax. Do not keep it working.
   if (comment.text.startsWith('#')) return
 
-  let description = extractMetadataPairs(comment.text, metadata)
+  let description = extractMetadataPairs(comment.text, comment.from, metadata, entries)
   if (description) descriptionLines.push(description)
 }
 
-function extractHashMetadata(text: string, metadata: Record<string, string>) {
+function extractHashMetadata(comment: {text: string; from: number; markerFrom: number}, metadata: Record<string, string>, entries: MetadataEntry[]) {
+  let text = comment.text
   let cursor = skipWhitespace(text, 0)
-  let pair = matchMetadataToken(text, cursor, false)
+  let pair = matchMetadataToken(text, cursor, false, comment.from, comment.markerFrom)
   if (!pair) return text.trim()
 
-  metadata[pair.key] = parseMetadataValue(pair.rawValue)
+  consumePair(pair, metadata, entries)
   cursor = pair.end
 
   while (true) {
     let nextStart = skipWhitespace(text, cursor)
     if (text[nextStart] !== '#') return text.slice(nextStart).trim()
-    let nextPair = matchMetadataToken(text, nextStart, true)
+    let nextPair = matchMetadataToken(text, nextStart, true, comment.from)
     if (!nextPair) return text.slice(nextStart).trim()
-    metadata[nextPair.key] = parseMetadataValue(nextPair.rawValue)
+    consumePair(nextPair, metadata, entries)
     cursor = nextPair.end
   }
 }
 
-function extractMetadataPairs(text: string, metadata: Record<string, string>) {
-  let cleaned = text.replace(embeddedMetadataPair, (_match, leadingSpace, _hash, key, rawValue) => {
-    if (key) metadata[key] = parseMetadataValue(rawValue)
+function extractMetadataPairs(text: string, textFrom: number, metadata: Record<string, string>, entries: MetadataEntry[]) {
+  let cleaned = text.replace(embeddedMetadataPair, (match, leadingSpace, _hash, key, rawValue, offset) => {
+    if (key) {
+      let hashStart = textFrom + offset + leadingSpace.length
+      let valueOffset = rawValue ? match.indexOf(rawValue) : -1
+      consumePair(
+        {
+          key,
+          rawValue,
+          keyFrom: hashStart + 1,
+          keyTo: hashStart + 1 + key.length,
+          from: hashStart,
+          to: hashStart + 1 + key.length,
+          valueFrom: valueOffset >= 0 ? textFrom + offset + valueOffset : undefined,
+          valueTo: valueOffset >= 0 ? textFrom + offset + valueOffset + rawValue.length : undefined,
+          end: offset + match.length,
+        },
+        metadata,
+        entries,
+      )
+    }
     return leadingSpace ? ' ' : ''
   })
   return cleaned.replace(/\s+/g, ' ').trim()
+}
+
+function consumePair(pair: MetadataToken, metadata: Record<string, string>, entries: MetadataEntry[]) {
+  let value = parseMetadataValue(pair.rawValue)
+  metadata[pair.key] = value
+  entries.push({
+    key: pair.key,
+    value,
+    rawValue: pair.rawValue,
+    from: pair.from,
+    to: pair.to,
+    valueFrom: pair.valueFrom,
+    valueTo: pair.valueTo,
+    hasValue: pair.rawValue != null,
+  })
 }
 
 function parseMetadataValue(rawValue?: string) {
@@ -124,23 +247,38 @@ function parseHashCommentDescription(cleaned: string) {
   return description || undefined
 }
 
-function matchMetadataToken(text: string, start: number, hasHashPrefix: boolean) {
+type MetadataToken = {
+  key: string
+  rawValue?: string
+  keyFrom: number
+  keyTo: number
+  from: number
+  to: number
+  valueFrom?: number
+  valueTo?: number
+  end: number
+}
+
+function matchMetadataToken(text: string, start: number, hasHashPrefix: boolean, textFrom: number, firstHashFrom?: number): MetadataToken | undefined {
   let cursor = hasHashPrefix ? start + 1 : start
   let keyStart = cursor
   while (/[A-Za-z0-9_-]/.test(text[cursor] || '')) cursor++
   if (cursor === keyStart) return undefined
 
   let key = text.slice(keyStart, cursor)
+  let from = hasHashPrefix ? textFrom + start : (firstHashFrom ?? textFrom + keyStart)
+  let keyFrom = textFrom + keyStart
+  let keyTo = textFrom + cursor
   let afterKey = skipWhitespace(text, cursor)
   if (text[afterKey] === '=') {
     let valueStart = skipWhitespace(text, afterKey + 1)
     let value = readMetadataValue(text, valueStart)
     if (!value) return undefined
-    return {key, rawValue: value.rawValue, end: value.end}
+    return {key, rawValue: value.rawValue, keyFrom, keyTo, from, to: keyTo, valueFrom: textFrom + valueStart, valueTo: textFrom + value.end, end: value.end}
   }
 
   if (afterKey >= text.length || text[afterKey] === '#' || text.startsWith('--', afterKey)) {
-    return {key, rawValue: undefined, end: afterKey}
+    return {key, rawValue: undefined, keyFrom, keyTo, from, to: keyTo, end: afterKey}
   }
 }
 

--- a/lang/metadata.ts
+++ b/lang/metadata.ts
@@ -27,7 +27,6 @@ let isoCurrencyCodes = new Set(Intl.supportedValuesOf('currency').map(code => co
 let metadataKeyRules = {
   ratio: {kind: 'flag'},
   pct: {kind: 'flag'},
-  hide: {kind: 'flag'},
   pii: {kind: 'flag'},
   currency: {kind: 'currency'},
   unit: {kind: 'string'},

--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -406,7 +406,7 @@ function valueFormatting(config: NormalConfig, fields: Field[]) {
   let valueAxes = [...config.xAxis, ...config.yAxis].filter(axis => axis?.type === 'value' && !axis.field?.metadata?.timeOrdinal)
   for (let axis of valueAxes) {
     if (axis.axisLabel?.formatter != null) continue
-    axis.axisLabel = {...axis.axisLabel, formatter: makeValueFormatter(axis.field ? [axis.field] : [])}
+    axis.axisLabel = {...axis.axisLabel, formatter: makeValueFormatter(axis.field ? [axis.field] : [], {unitStyle: 'axis'})}
   }
 
   for (let series of config.series) {
@@ -508,22 +508,24 @@ function barLabelPositioning(config: NormalConfig) {
   }
 }
 
-// Match series data labels to the assigned y-axis formatter when labels are enabled.
-// This keeps label formatting in sync with the y-axis without asking callers to repeat it.
-// labelsUseYAxisFormat depends on valueAxisFormatting running first so labels inherit axis formatting.
+// Match series data labels to the assigned value field when labels are enabled.
+// This keeps label formatting in sync with tooltips without asking callers to repeat it.
+// labelsUseYAxisFormat depends on valueFormatting running first so labels inherit axis formatting.
 function labelsUseYAxisFormat(config: NormalConfig, fields: Field[]) {
   for (let series of config.series) {
     // No-op when labels are off or already explicitly formatted.
     if (!series?.label || series.label.show !== true || series.label.formatter != null) continue
 
-    let yField = getSeriesValueField(series, fields)?.name
+    let valueField = getSeriesValueField(series, fields)
+    let yField = valueField?.name
     let axisIndex = Number(series.yAxisIndex ?? 0)
     let axisFormatter = config.yAxis[axisIndex]?.axisLabel?.formatter
-    if (typeof axisFormatter !== 'function') continue
+    let labelFormatter = valueField ? makeValueFormatter([valueField]) : axisFormatter
+    if (typeof labelFormatter !== 'function') continue
 
     // ECharts can pass different value shapes depending on series/transform shape.
     // We resolve the numeric value in a few fallback steps so labels always use the
-    // same value the y-axis is formatting.
+    // same field that tooltips format.
     series.label.formatter = (params: unknown) => {
       let typed = params as {value?: unknown; data?: Record<string, unknown>}
       let value = typed?.value
@@ -535,7 +537,7 @@ function labelsUseYAxisFormat(config: NormalConfig, fields: Field[]) {
         }
       }
 
-      return formatAxisValue(axisFormatter, value)
+      return formatAxisValue(labelFormatter, value)
     }
   }
 }

--- a/ui/component-utilities/format.ts
+++ b/ui/component-utilities/format.ts
@@ -11,6 +11,8 @@ const yearMonths = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep
 const titleCaseAcronyms = ['id', 'gdp']
 const titleCaseLowerWords = ['of', 'the', 'and', 'in', 'on']
 
+type ValueFormatterOptions = {unitStyle?: 'label' | 'axis'}
+
 // Formats a raw column name into a readable title.
 export function formatTitle(column: string) {
   let cleaned = column.replace(/"/g, '').replace(/_/g, ' ')
@@ -24,15 +26,15 @@ export function formatTitle(column: string) {
 // ECharts valueFormatter will take different arguments depending on the chart type.
 // For bar/line/area it's just a number
 // for scatter, it's [x,y], for candlestick [open, close, low, high], etc
-export function makeValueFormatter(fields: Field[] = []) {
+export function makeValueFormatter(fields: Field[] = [], options: ValueFormatterOptions = {}) {
   return (value: unknown) => {
-    if (Array.isArray(value)) return value.map((entry, index) => formatSingleValue(entry, fields[index] || fields[0])).join(', ')
-    return formatSingleValue(value, fields[0])
+    if (Array.isArray(value)) return value.map((entry, index) => formatSingleValue(entry, fields[index] || fields[0], options)).join(', ')
+    return formatSingleValue(value, fields[0], options)
   }
 }
 
 // Formats one numeric value with field metadata (currency, ratio/pct, compact notation).
-export function formatSingleValue(value: any, field?: Field) {
+export function formatSingleValue(value: any, field?: Field, options: ValueFormatterOptions = {}) {
   let amount = Number(value)
   if (!Number.isFinite(amount)) return String(value ?? '')
 
@@ -46,25 +48,34 @@ export function formatSingleValue(value: any, field?: Field) {
     return `${sign}${formatCurrencySymbol(currency)}${formatted}`
   }
 
-  if (amount === 0) return '0'
+  if (amount === 0) return addUnit('0', field, options)
   let sign = amount < 0 ? '-' : ''
   let absolute = Math.abs(amount)
+  let formatted = ''
 
-  if (absolute >= 1e12) return `${sign}${compactValue(absolute / 1e12)}T`
-  if (absolute >= 1e9) return `${sign}${compactValue(absolute / 1e9)}B`
-  if (absolute >= 1e6) return `${sign}${compactValue(absolute / 1e6)}M`
-  if (absolute >= 1e3) return `${sign}${compactValue(absolute / 1e3)}k`
-  if (absolute >= 1) return `${sign}${compactValue(absolute)}`
-  if (absolute >= 1e-3) return `${sign}${compactValue(absolute)}`
-  if (absolute >= 1e-6) return `${sign}${compactValue(absolute * 1e3)}m`
-  if (absolute >= 1e-9) return `${sign}${compactValue(absolute * 1e6)}u`
-  if (absolute >= 1e-12) return `${sign}${compactValue(absolute * 1e9)}n`
-  return `${sign}${compactValue(absolute)}`
+  if (absolute >= 1e12) formatted = `${compactValue(absolute / 1e12)}T`
+  else if (absolute >= 1e9) formatted = `${compactValue(absolute / 1e9)}B`
+  else if (absolute >= 1e6) formatted = `${compactValue(absolute / 1e6)}M`
+  else if (absolute >= 1e3) formatted = `${compactValue(absolute / 1e3)}k`
+  else if (absolute >= 1) formatted = compactValue(absolute)
+  else if (absolute >= 1e-3) formatted = compactValue(absolute)
+  else if (absolute >= 1e-6) formatted = `${compactValue(absolute * 1e3)}m`
+  else if (absolute >= 1e-9) formatted = `${compactValue(absolute * 1e6)}u`
+  else if (absolute >= 1e-12) formatted = `${compactValue(absolute * 1e9)}n`
+  else formatted = compactValue(absolute)
+
+  return addUnit(`${sign}${formatted}`, field, options)
 }
 
 function formatCurrencySymbol(currency: string) {
   let parts = new Intl.NumberFormat('en-US', {style: 'currency', currency, currencyDisplay: 'symbol', maximumFractionDigits: 0}).formatToParts(0)
   return parts.find(part => part.type === 'currency')?.value || currency
+}
+
+function addUnit(value: string, field: Field | undefined, options: ValueFormatterOptions) {
+  let unit = field?.metadata?.unit?.trim()
+  if (!unit) return value
+  return options.unitStyle === 'axis' ? `${value} (${unit})` : `${value} ${unit}`
 }
 
 // Creates a formatter function that renders date/timestamp values based on field metadata.timeGrain.

--- a/ui/component-utilities/format.ts
+++ b/ui/component-utilities/format.ts
@@ -1,6 +1,6 @@
 import type {Field} from './types.ts'
 
-const currencySymbols = {usd: '$', eur: '€', gbp: '£', cad: 'C$', aud: 'A$', jpy: '¥'} as const
+const supportedCurrencyCodes = new Set(Intl.supportedValuesOf('currency'))
 const percent = new Intl.NumberFormat('en-US', {maximumFractionDigits: 0})
 const currencyCompact = new Intl.NumberFormat('en-US', {notation: 'compact', maximumFractionDigits: 1})
 const monthYearFormatter = new Intl.DateTimeFormat('en-US', {month: 'long', year: 'numeric'})
@@ -31,7 +31,7 @@ export function makeValueFormatter(fields: Field[] = []) {
   }
 }
 
-// Formats one numeric value with field metadata (units, ratio/pct, compact notation).
+// Formats one numeric value with field metadata (currency, ratio/pct, compact notation).
 export function formatSingleValue(value: any, field?: Field) {
   let amount = Number(value)
   if (!Number.isFinite(amount)) return String(value ?? '')
@@ -39,12 +39,11 @@ export function formatSingleValue(value: any, field?: Field) {
   if (field?.metadata?.ratio) return `${percent.format(amount * 100)}%`
   if (field?.metadata?.pct) return `${percent.format(amount)}%`
 
-  let unit = field?.metadata?.units?.toLowerCase() as keyof typeof currencySymbols | undefined
-  let currencyUnit = unit != null && unit in currencySymbols ? unit : undefined
-  if (currencyUnit) {
+  let currency = field?.metadata?.currency?.toUpperCase()
+  if (currency && supportedCurrencyCodes.has(currency)) {
     let sign = amount < 0 ? '-' : ''
     let formatted = currencyCompact.format(Math.abs(amount)).replace('K', 'k').replace('M', 'm').replace('B', 'b')
-    return `${sign}${currencySymbols[currencyUnit]}${formatted}`
+    return `${sign}${formatCurrencySymbol(currency)}${formatted}`
   }
 
   if (amount === 0) return '0'
@@ -61,6 +60,11 @@ export function formatSingleValue(value: any, field?: Field) {
   if (absolute >= 1e-9) return `${sign}${compactValue(absolute * 1e6)}u`
   if (absolute >= 1e-12) return `${sign}${compactValue(absolute * 1e9)}n`
   return `${sign}${compactValue(absolute)}`
+}
+
+function formatCurrencySymbol(currency: string) {
+  let parts = new Intl.NumberFormat('en-US', {style: 'currency', currency, currencyDisplay: 'symbol', maximumFractionDigits: 0}).formatToParts(0)
+  return parts.find(part => part.type === 'currency')?.value || currency
 }
 
 // Creates a formatter function that renders date/timestamp values based on field metadata.timeGrain.

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -90,6 +90,18 @@ test('check with mdFile reports unsupported chart wrapper props', async () => {
   expect(outputLines()).toContain('ERROR: mock.md line 4: Unsupported prop "yFmt" on BarChart. Use field metadata or ECharts for custom formatting.')
 })
 
+test('check reports invalid metadata annotations', async () => {
+  mockFileMap['tmp_bad_metadata.gsql'] = trimIndentation(`
+    table tmp_bad_metadata (
+      rate number #ratio=false
+    )
+  `)
+
+  let result = await check({fileArg: 'tmp_bad_metadata.gsql', log})
+  expect(result).toBe(false)
+  expect(outputLines()).toContain('ERROR: tmp_bad_metadata.gsql line 2: Metadata "#ratio" is a flag; use "#ratio" or "#ratio=true".')
+})
+
 test('cli run with md file reports dynamic unsupported chart wrapper props', async ({server, page}) => {
   server.mockFile(
     '/index.md',

--- a/ui/tests/snapshots/value.test.ts/unit-formatting.png
+++ b/ui/tests/snapshots/value.test.ts/unit-formatting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a96aa4b5c1c21c6358e8751dee4ba2a45ccceb435fee1ee59bfc018fd5e1b7fc
+size 1814

--- a/ui/tests/snapshots/viz.test.ts/line-chart-unit-metadata-axis-tooltip.png
+++ b/ui/tests/snapshots/viz.test.ts/line-chart-unit-metadata-axis-tooltip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28bd0a902f7ede06439433c96bc9b2d35f595ce1a96e209ef7985694df6beca0
+size 13424

--- a/ui/tests/testData.ts
+++ b/ui/tests/testData.ts
@@ -11,7 +11,7 @@ export function singleDim(): TableRows {
   let rows = Object.keys(result).map(category => ({category, value: result[category]}))
   let fields: Field[] = [
     {name: 'category', type: 'string'},
-    {name: 'value', type: 'number', metadata: {units: 'usd'}},
+    {name: 'value', type: 'number', metadata: {currency: 'USD'}},
   ]
   return withFields(rows, fields)
 }
@@ -25,7 +25,7 @@ export function timeseries(): TableRows {
   let rows = Object.keys(result).map(month => ({month: new Date(month), sales_usd0k: result[month]}))
   let fields: Field[] = [
     {name: 'month', type: 'date', metadata: {timeGrain: 'month'}},
-    {name: 'sales_usd0k', type: 'number', metadata: {units: 'usd'}},
+    {name: 'sales_usd0k', type: 'number', metadata: {currency: 'USD'}},
   ]
   return withFields(rows, fields)
 }
@@ -35,7 +35,7 @@ export function timeseriesGrouped(): TableRows {
   let fields: Field[] = [
     {name: 'month', type: 'date', metadata: {timeGrain: 'month'}},
     {name: 'category', type: 'string'},
-    {name: 'sales_usd0k', type: 'number', metadata: {units: 'usd'}},
+    {name: 'sales_usd0k', type: 'number', metadata: {currency: 'USD'}},
   ]
   return withFields(rows, fields)
 }
@@ -58,7 +58,7 @@ export function sparseGroupedMonthRows(): TableRows {
   let fields: Field[] = [
     {name: 'month', type: 'date', metadata: {timeGrain: 'month'}},
     {name: 'metric', type: 'string'},
-    {name: 'value', type: 'number', metadata: {units: 'count'}},
+    {name: 'value', type: 'number', metadata: {unit: 'count'}},
   ]
   return withFields(rows, fields)
 }
@@ -75,7 +75,7 @@ export function timeseriesWithDateSeries(): TableRows {
   let fields: Field[] = [
     {name: 'quarter', type: 'date', metadata: {timeGrain: 'quarter'}},
     {name: 'category', type: 'string'},
-    {name: 'sales', type: 'number', metadata: {units: 'usd'}},
+    {name: 'sales', type: 'number', metadata: {currency: 'USD'}},
   ]
   return withFields(rows, fields)
 }
@@ -91,7 +91,7 @@ export function yearlyCounts(): TableRows {
   ]
   let fields: Field[] = [
     {name: 'year', type: 'number', metadata: {timeGrain: 'year'}},
-    {name: 'flights', type: 'number', metadata: {units: 'count'}},
+    {name: 'flights', type: 'number', metadata: {unit: 'count'}},
   ]
   return withFields(rows, fields)
 }
@@ -109,7 +109,7 @@ export function denseTimeseries(points = 365): TableRows {
 
   let fields: Field[] = [
     {name: 'ts', type: 'date', metadata: {timeGrain: 'day'}},
-    {name: 'value', type: 'number', metadata: {units: 'count'}},
+    {name: 'value', type: 'number', metadata: {unit: 'count'}},
   ]
   return withFields(rows, fields)
 }
@@ -118,7 +118,7 @@ export function categoricalSeries(count: number): TableRows {
   let rows = Array.from({length: count}, (_, index) => ({category: `Bucket ${index + 1}`, value: 100 + Math.sin(index / 2) * 20}))
   let fields: Field[] = [
     {name: 'category', type: 'string'},
-    {name: 'value', type: 'number', metadata: {units: 'count'}},
+    {name: 'value', type: 'number', metadata: {unit: 'count'}},
   ]
   return withFields(rows, fields)
 }
@@ -144,7 +144,7 @@ export function tableDataWithDates(): TableRows {
   ]
   let fields: Field[] = [
     {name: 'month', type: 'date', metadata: {timeGrain: 'month'}},
-    {name: 'sales', type: 'number', metadata: {units: 'usd'}},
+    {name: 'sales', type: 'number', metadata: {currency: 'USD'}},
   ]
   return withFields(rows, fields)
 }
@@ -156,7 +156,7 @@ export function tableDataForPagination(count = 15): TableRows {
   }))
   let fields: Field[] = [
     {name: 'item', type: 'string'},
-    {name: 'value', type: 'number', metadata: {units: 'count'}},
+    {name: 'value', type: 'number', metadata: {unit: 'count'}},
   ]
   return withFields(rows, fields)
 }
@@ -173,7 +173,7 @@ export function groupedDataForSection(): TableRows {
   let fields: Field[] = [
     {name: 'time_horizon', type: 'string'},
     {name: 'sku', type: 'string'},
-    {name: 'units', type: 'number', metadata: {units: 'count'}},
+    {name: 'units', type: 'number', metadata: {unit: 'count'}},
   ]
   return withFields(rows, fields)
 }

--- a/ui/tests/testData.ts
+++ b/ui/tests/testData.ts
@@ -58,7 +58,7 @@ export function sparseGroupedMonthRows(): TableRows {
   let fields: Field[] = [
     {name: 'month', type: 'date', metadata: {timeGrain: 'month'}},
     {name: 'metric', type: 'string'},
-    {name: 'value', type: 'number', metadata: {unit: 'count'}},
+    {name: 'value', type: 'number'},
   ]
   return withFields(rows, fields)
 }
@@ -91,7 +91,7 @@ export function yearlyCounts(): TableRows {
   ]
   let fields: Field[] = [
     {name: 'year', type: 'number', metadata: {timeGrain: 'year'}},
-    {name: 'flights', type: 'number', metadata: {unit: 'count'}},
+    {name: 'flights', type: 'number'},
   ]
   return withFields(rows, fields)
 }
@@ -109,7 +109,7 @@ export function denseTimeseries(points = 365): TableRows {
 
   let fields: Field[] = [
     {name: 'ts', type: 'date', metadata: {timeGrain: 'day'}},
-    {name: 'value', type: 'number', metadata: {unit: 'count'}},
+    {name: 'value', type: 'number'},
   ]
   return withFields(rows, fields)
 }
@@ -118,7 +118,7 @@ export function categoricalSeries(count: number): TableRows {
   let rows = Array.from({length: count}, (_, index) => ({category: `Bucket ${index + 1}`, value: 100 + Math.sin(index / 2) * 20}))
   let fields: Field[] = [
     {name: 'category', type: 'string'},
-    {name: 'value', type: 'number', metadata: {unit: 'count'}},
+    {name: 'value', type: 'number'},
   ]
   return withFields(rows, fields)
 }
@@ -156,7 +156,7 @@ export function tableDataForPagination(count = 15): TableRows {
   }))
   let fields: Field[] = [
     {name: 'item', type: 'string'},
-    {name: 'value', type: 'number', metadata: {unit: 'count'}},
+    {name: 'value', type: 'number'},
   ]
   return withFields(rows, fields)
 }
@@ -173,7 +173,7 @@ export function groupedDataForSection(): TableRows {
   let fields: Field[] = [
     {name: 'time_horizon', type: 'string'},
     {name: 'sku', type: 'string'},
-    {name: 'units', type: 'number', metadata: {unit: 'count'}},
+    {name: 'units', type: 'number'},
   ]
   return withFields(rows, fields)
 }

--- a/ui/tests/value.test.ts
+++ b/ui/tests/value.test.ts
@@ -17,9 +17,10 @@ describe('<Value/>', () => {
     await expect(sharedPage.getByText('31%')).toBeVisible()
   })
 
-  test('unit formatting', async ({mount, sharedPage}) => {
+  test('unit formatting', async ({mount, sharedPage, chart}) => {
     await mount('components/Value.svelte', {data: unitData(), column: 'duration'})
     await expect(sharedPage.getByText('42 minutes')).toBeVisible()
+    await expect(chart.el).screenshot('unit-formatting')
   })
 
   test('null renders em dash', async ({mount, sharedPage}) => {

--- a/ui/tests/value.test.ts
+++ b/ui/tests/value.test.ts
@@ -17,6 +17,11 @@ describe('<Value/>', () => {
     await expect(sharedPage.getByText('31%')).toBeVisible()
   })
 
+  test('unit formatting', async ({mount, sharedPage}) => {
+    await mount('components/Value.svelte', {data: unitData(), column: 'duration'})
+    await expect(sharedPage.getByText('42 minutes')).toBeVisible()
+  })
+
   test('null renders em dash', async ({mount, sharedPage}) => {
     await mount('components/Value.svelte', {data: nullValueData(), column: 'value'})
     await expect(sharedPage.getByText('—')).toBeVisible()
@@ -39,6 +44,12 @@ describe('<Value/>', () => {
   function nullValueData() {
     let rows = [{value: null}] as any
     let fields = [{name: 'value', type: 'number'}] as any
+    return {rows, fields}
+  }
+
+  function unitData() {
+    let rows = [{duration: 42}] as any
+    let fields = [{name: 'duration', type: 'number', metadata: {unit: 'minutes'}}] as any
     return {rows, fields}
   }
 

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -25,8 +25,8 @@ function timeseriesWithMultipleY() {
       cost_usd0k: row.sales_usd0k * (0.68 - jitter),
     }
   })
-  data.fields.push({name: 'profit_usd0k', type: scalarType('number'), metadata: {units: 'usd'}})
-  data.fields.push({name: 'cost_usd0k', type: scalarType('number'), metadata: {units: 'usd'}})
+  data.fields.push({name: 'profit_usd0k', type: scalarType('number'), metadata: {currency: 'USD'}})
+  data.fields.push({name: 'cost_usd0k', type: scalarType('number'), metadata: {currency: 'USD'}})
   return data
 }
 
@@ -101,7 +101,7 @@ test('echarts supports splitBy=[group,stack] for grouped+stacked bars', async ({
     {name: 'month', type: scalarType('date'), metadata: {timeGrain: 'month'}},
     {name: 'region', type: scalarType('string')},
     {name: 'channel', type: scalarType('string')},
-    {name: 'revenue', type: scalarType('number'), metadata: {units: 'usd'}},
+    {name: 'revenue', type: scalarType('number'), metadata: {currency: 'USD'}},
   ]
 
   await mount('components/ECharts.svelte', {
@@ -133,7 +133,7 @@ test('bar chart supports expression fields with commas', async ({mount, chart}) 
     ],
     fields: [
       {name: "date_trunc('month', dep_time)", type: scalarType('date'), metadata: {timeGrain: 'month'}},
-      {name: 'count()', type: scalarType('number'), metadata: {units: 'count'}},
+      {name: 'count()', type: scalarType('number'), metadata: {unit: 'count'}},
     ],
   }
 
@@ -158,7 +158,7 @@ test('bar chart with just 0,1 has sensible y axis ticks', async ({mount, chart})
   ]
   let fields = [
     {name: 'category', type: scalarType('string')},
-    {name: 'count', type: scalarType('number'), metadata: {units: 'count'}},
+    {name: 'count', type: scalarType('number'), metadata: {unit: 'count'}},
   ]
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'category', y: 'count'})
   await expect(chart.el).screenshot('bar-chart-0-to-1')
@@ -184,7 +184,7 @@ test('bar chart bounds numeric year x axis from metadata', async ({mount, chart}
   let fields = [
     {name: 'year', type: scalarType('number'), metadata: {timePart: 'year'}},
     {name: 'status', type: scalarType('string')},
-    {name: 'flights', type: scalarType('number'), metadata: {units: 'count'}},
+    {name: 'flights', type: scalarType('number'), metadata: {unit: 'count'}},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'year', y: 'flights', splitBy: 'status', arrange: 'stack', title: 'Flight Status by Year'})
@@ -200,7 +200,7 @@ test('horizontal bar chart auto-expands height for many categories', async ({mou
   let rows = Array.from({length: 14}, (_, index) => ({category: `Category ${index + 1}`, value: (index + 1) * 10}))
   let fields = [
     {name: 'category', type: scalarType('string')},
-    {name: 'value', type: scalarType('number'), metadata: {units: 'count'}},
+    {name: 'value', type: scalarType('number'), metadata: {unit: 'count'}},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'value', y: 'category'})
@@ -215,8 +215,8 @@ test('horizontal bar chart supports multiple x fields', async ({mount, chart}) =
   ]
   let fields = [
     {name: 'category', type: scalarType('string')},
-    {name: 'current', type: scalarType('number'), metadata: {units: 'count'}},
-    {name: 'previous', type: scalarType('number'), metadata: {units: 'count'}},
+    {name: 'current', type: scalarType('number'), metadata: {unit: 'count'}},
+    {name: 'previous', type: scalarType('number'), metadata: {unit: 'count'}},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'current,previous', y: 'category'})
@@ -236,7 +236,7 @@ test('area chart supports multiple y fields', async ({mount, chart}) => {
 test('area chart supports secondary y axis line', async ({mount, chart}) => {
   let data = timeseries() as any
   data.rows = data.rows.map((r: any) => ({...r, profit_usd0k: r.sales_usd0k / 10}))
-  data.fields.push({name: 'profit_usd0k', type: scalarType('number'), metadata: {units: 'usd'}})
+  data.fields.push({name: 'profit_usd0k', type: scalarType('number'), metadata: {currency: 'USD'}})
   await mount('components/AreaChart.svelte', {data, x: 'month', y: 'sales_usd0k', y2: 'profit_usd0k'})
   await expect(chart.el).screenshot('area-chart-secondary-axis-line')
 })
@@ -264,7 +264,7 @@ test('line chart supports multiple y fields', async ({mount, chart}) => {
 test('line chart supports secondary y axis', async ({mount, chart}) => {
   let data = timeseries() as any
   data.rows = data.rows.map((r: any) => ({...r, profit_usd0k: r.sales_usd0k / 10}))
-  data.fields.push({name: 'profit_usd0k', type: scalarType('number'), metadata: {units: 'usd'}})
+  data.fields.push({name: 'profit_usd0k', type: scalarType('number'), metadata: {currency: 'USD'}})
   await mount('components/LineChart.svelte', {data, x: 'month', y: 'sales_usd0k', y2: 'profit_usd0k'})
   await expect(chart.el).screenshot('line-chart-dual-axis')
 })
@@ -324,7 +324,7 @@ test('hour_of_day ordinal axis labels and tooltip formatting', async ({mount, ch
   ]
   let fields = [
     {name: 'hour_of_day', type: scalarType('number'), metadata: {timeOrdinal: 'hour_of_day'}},
-    {name: 'flights', type: scalarType('number'), metadata: {units: 'count'}},
+    {name: 'flights', type: scalarType('number'), metadata: {unit: 'count'}},
   ]
 
   await mount('components/LineChart.svelte', {data: {rows, fields}, x: 'hour_of_day', y: 'flights', title: 'Hour Ordinal'})
@@ -348,7 +348,7 @@ test('day_of_week ordinal axis labels and tooltip formatting', async ({mount, ch
   ]
   let fields = [
     {name: 'day_of_week', type: scalarType('number'), metadata: {timeOrdinal: 'dow_1m'}},
-    {name: 'flights', type: scalarType('number'), metadata: {units: 'count'}},
+    {name: 'flights', type: scalarType('number'), metadata: {unit: 'count'}},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'day_of_week', y: 'flights', title: 'Weekday Ordinal'})
@@ -372,7 +372,7 @@ test('month_of_year ordinal axis labels and tooltip formatting', async ({mount, 
   ]
   let fields = [
     {name: 'month_of_year', type: scalarType('number'), metadata: {timeOrdinal: 'month_of_year'}},
-    {name: 'revenue', type: scalarType('number'), metadata: {units: 'usd'}},
+    {name: 'revenue', type: scalarType('number'), metadata: {currency: 'USD'}},
   ]
 
   await mount('components/LineChart.svelte', {data: {rows, fields}, x: 'month_of_year', y: 'revenue', title: 'Month Ordinal'})
@@ -394,7 +394,7 @@ test('quarter_of_year ordinal axis labels and tooltip formatting', async ({mount
   ]
   let fields = [
     {name: 'quarter_of_year', type: scalarType('number'), metadata: {timeOrdinal: 'quarter_of_year'}},
-    {name: 'value', type: scalarType('number'), metadata: {units: 'count'}},
+    {name: 'value', type: scalarType('number'), metadata: {unit: 'count'}},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'quarter_of_year', y: 'value', title: 'Quarter Ordinal'})
@@ -483,7 +483,7 @@ test('categorical stacked bar charts sort by total value descending', async ({mo
   let fields = [
     {name: 'segment', type: scalarType('string')},
     {name: 'metric', type: scalarType('string')},
-    {name: 'value', type: scalarType('number'), metadata: {units: 'count'}},
+    {name: 'value', type: scalarType('number'), metadata: {unit: 'count'}},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'segment', y: 'value', splitBy: 'metric', arrange: 'stack', title: 'Stacked Category Sort'})
@@ -503,7 +503,7 @@ test('bar chart explicit sort orders categories by another column', async ({moun
   let fields = [
     {name: 'segment', type: scalarType('string')},
     {name: 'metric', type: scalarType('string')},
-    {name: 'value', type: scalarType('number'), metadata: {units: 'count'}},
+    {name: 'value', type: scalarType('number'), metadata: {unit: 'count'}},
     {name: 'sort_rank', type: scalarType('number')},
   ]
 
@@ -705,7 +705,7 @@ test('bar chart applies secondary axis assignment', async ({mount, chart}) => {
     let delta = (nextRandom() - 0.5) * 0.08
     return {...r, profit_usd0k: r.sales_usd0k * (0.15 + delta)}
   })
-  data.fields.push({name: 'profit_usd0k', type: scalarType('number'), metadata: {units: 'usd'}})
+  data.fields.push({name: 'profit_usd0k', type: scalarType('number'), metadata: {currency: 'USD'}})
   await mount('components/BarChart.svelte', {data, x: 'month', y: 'sales_usd0k', y2: 'profit_usd0k'})
   await expect(chart.el).screenshot('bar-chart-secondary-axis-line')
 })

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -279,7 +279,7 @@ test('line chart uses ratio metadata for axis and tooltip percentage formatting'
   await expect(chart.el).screenshot('line-chart-ratio-metadata-percent-axis')
 })
 
-test('line chart uses unit metadata for axis and tooltip formatting', async ({mount, sharedPage}) => {
+test('line chart uses unit metadata for axis and tooltip formatting', async ({mount, sharedPage, chart}) => {
   let rows = [
     {month: 'Jan', duration: 42},
     {month: 'Feb', duration: 58},
@@ -303,6 +303,8 @@ test('line chart uses unit metadata for axis and tooltip formatting', async ({mo
   })
 
   expect(formatted).toEqual({axis: '42 (minutes)', tooltip: '42 minutes'})
+  await chart.chartDispatchAction({type: 'showTip', seriesIndex: 0, dataIndex: 0})
+  await expect(chart.el).screenshot('line-chart-unit-metadata-axis-tooltip')
 })
 
 test('time tooltip uses readable timeGrain formatting', async ({mount, chart}) => {

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -133,7 +133,7 @@ test('bar chart supports expression fields with commas', async ({mount, chart}) 
     ],
     fields: [
       {name: "date_trunc('month', dep_time)", type: scalarType('date'), metadata: {timeGrain: 'month'}},
-      {name: 'count()', type: scalarType('number'), metadata: {unit: 'count'}},
+      {name: 'count()', type: scalarType('number')},
     ],
   }
 
@@ -158,7 +158,7 @@ test('bar chart with just 0,1 has sensible y axis ticks', async ({mount, chart})
   ]
   let fields = [
     {name: 'category', type: scalarType('string')},
-    {name: 'count', type: scalarType('number'), metadata: {unit: 'count'}},
+    {name: 'count', type: scalarType('number')},
   ]
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'category', y: 'count'})
   await expect(chart.el).screenshot('bar-chart-0-to-1')
@@ -184,7 +184,7 @@ test('bar chart bounds numeric year x axis from metadata', async ({mount, chart}
   let fields = [
     {name: 'year', type: scalarType('number'), metadata: {timePart: 'year'}},
     {name: 'status', type: scalarType('string')},
-    {name: 'flights', type: scalarType('number'), metadata: {unit: 'count'}},
+    {name: 'flights', type: scalarType('number')},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'year', y: 'flights', splitBy: 'status', arrange: 'stack', title: 'Flight Status by Year'})
@@ -200,7 +200,7 @@ test('horizontal bar chart auto-expands height for many categories', async ({mou
   let rows = Array.from({length: 14}, (_, index) => ({category: `Category ${index + 1}`, value: (index + 1) * 10}))
   let fields = [
     {name: 'category', type: scalarType('string')},
-    {name: 'value', type: scalarType('number'), metadata: {unit: 'count'}},
+    {name: 'value', type: scalarType('number')},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'value', y: 'category'})
@@ -215,8 +215,8 @@ test('horizontal bar chart supports multiple x fields', async ({mount, chart}) =
   ]
   let fields = [
     {name: 'category', type: scalarType('string')},
-    {name: 'current', type: scalarType('number'), metadata: {unit: 'count'}},
-    {name: 'previous', type: scalarType('number'), metadata: {unit: 'count'}},
+    {name: 'current', type: scalarType('number')},
+    {name: 'previous', type: scalarType('number')},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'current,previous', y: 'category'})
@@ -279,6 +279,32 @@ test('line chart uses ratio metadata for axis and tooltip percentage formatting'
   await expect(chart.el).screenshot('line-chart-ratio-metadata-percent-axis')
 })
 
+test('line chart uses unit metadata for axis and tooltip formatting', async ({mount, sharedPage}) => {
+  let rows = [
+    {month: 'Jan', duration: 42},
+    {month: 'Feb', duration: 58},
+  ]
+
+  let fields = [
+    {name: 'month', type: scalarType('string')},
+    {name: 'duration', type: scalarType('number'), metadata: {unit: 'minutes'}},
+  ]
+
+  await mount('components/LineChart.svelte', {data: {rows, fields}, x: 'month', y: 'duration', title: 'Duration'})
+  let formatted = await sharedPage.evaluate(() => {
+    let domNode = document.querySelector('#component-test .echarts') as HTMLElement
+    let option = window.$GRAPHENE.getChart(domNode).getOption()
+    let yAxis = Array.isArray(option.yAxis) ? option.yAxis[0] : option.yAxis
+    let series = Array.isArray(option.series) ? option.series[0] : option.series
+    return {
+      axis: yAxis.axisLabel.formatter(42),
+      tooltip: series.tooltip.valueFormatter(42),
+    }
+  })
+
+  expect(formatted).toEqual({axis: '42 (minutes)', tooltip: '42 minutes'})
+})
+
 test('time tooltip uses readable timeGrain formatting', async ({mount, chart}) => {
   let rows = [
     {period: '2023-01-01', value: 10},
@@ -324,7 +350,7 @@ test('hour_of_day ordinal axis labels and tooltip formatting', async ({mount, ch
   ]
   let fields = [
     {name: 'hour_of_day', type: scalarType('number'), metadata: {timeOrdinal: 'hour_of_day'}},
-    {name: 'flights', type: scalarType('number'), metadata: {unit: 'count'}},
+    {name: 'flights', type: scalarType('number')},
   ]
 
   await mount('components/LineChart.svelte', {data: {rows, fields}, x: 'hour_of_day', y: 'flights', title: 'Hour Ordinal'})
@@ -348,7 +374,7 @@ test('day_of_week ordinal axis labels and tooltip formatting', async ({mount, ch
   ]
   let fields = [
     {name: 'day_of_week', type: scalarType('number'), metadata: {timeOrdinal: 'dow_1m'}},
-    {name: 'flights', type: scalarType('number'), metadata: {unit: 'count'}},
+    {name: 'flights', type: scalarType('number')},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'day_of_week', y: 'flights', title: 'Weekday Ordinal'})
@@ -394,7 +420,7 @@ test('quarter_of_year ordinal axis labels and tooltip formatting', async ({mount
   ]
   let fields = [
     {name: 'quarter_of_year', type: scalarType('number'), metadata: {timeOrdinal: 'quarter_of_year'}},
-    {name: 'value', type: scalarType('number'), metadata: {unit: 'count'}},
+    {name: 'value', type: scalarType('number')},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'quarter_of_year', y: 'value', title: 'Quarter Ordinal'})
@@ -483,7 +509,7 @@ test('categorical stacked bar charts sort by total value descending', async ({mo
   let fields = [
     {name: 'segment', type: scalarType('string')},
     {name: 'metric', type: scalarType('string')},
-    {name: 'value', type: scalarType('number'), metadata: {unit: 'count'}},
+    {name: 'value', type: scalarType('number')},
   ]
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'segment', y: 'value', splitBy: 'metric', arrange: 'stack', title: 'Stacked Category Sort'})
@@ -503,7 +529,7 @@ test('bar chart explicit sort orders categories by another column', async ({moun
   let fields = [
     {name: 'segment', type: scalarType('string')},
     {name: 'metric', type: scalarType('string')},
-    {name: 'value', type: scalarType('number'), metadata: {unit: 'count'}},
+    {name: 'value', type: scalarType('number')},
     {name: 'sort_rank', type: scalarType('number')},
   ]
 

--- a/vscode/tests/grammar.test.ts
+++ b/vscode/tests/grammar.test.ts
@@ -147,30 +147,30 @@ select tag
     let lines = await tokenize(
       `
 table revenue (
-  #color=green #hide #format="US Dollar"
+  #currency=USD #hide #description="Gross revenue"
   amount int
 )
 `.trim(),
     )
 
-    expect(findToken(lines[1], 'color').scopes).toContain('entity.other.attribute-name.metadata.gsql')
-    expect(findToken(lines[1], 'green').scopes).toContain('string.other.metadata.gsql')
+    expect(findToken(lines[1], 'currency').scopes).toContain('entity.other.attribute-name.metadata.gsql')
+    expect(findToken(lines[1], 'USD').scopes).toContain('string.other.metadata.gsql')
     expect(findToken(lines[1], 'hide').scopes).toContain('entity.other.attribute-name.metadata.gsql')
-    expect(findToken(lines[1], 'format').scopes).toContain('entity.other.attribute-name.metadata.gsql')
-    expect(findToken(lines[1], 'US Dollar').scopes).toContain('string.other.metadata.gsql')
+    expect(findToken(lines[1], 'description').scopes).toContain('entity.other.attribute-name.metadata.gsql')
+    expect(findToken(lines[1], 'Gross revenue').scopes).toContain('string.other.metadata.gsql')
   })
 
   it('highlights metadata pairs embedded in dash comments', async () => {
     let lines = await tokenize(
       `
 table revenue (
-  amount int -- gross revenue #hide #format="US Dollar"
+  amount int -- gross revenue #hide #currency=USD
 )
 `.trim(),
     )
 
     expect(findToken(lines[1], 'gross').scopes).toContain('comment.line.double-dash.gsql')
     expect(findToken(lines[1], 'hide').scopes).toContain('entity.other.attribute-name.metadata.gsql')
-    expect(findToken(lines[1], 'format').scopes).toContain('entity.other.attribute-name.metadata.gsql')
+    expect(findToken(lines[1], 'currency').scopes).toContain('entity.other.attribute-name.metadata.gsql')
   })
 })

--- a/vscode/tests/grammar.test.ts
+++ b/vscode/tests/grammar.test.ts
@@ -147,7 +147,7 @@ select tag
     let lines = await tokenize(
       `
 table revenue (
-  #currency=USD #hide #description="Gross revenue"
+  #currency=USD #pii #description="Gross revenue"
   amount int
 )
 `.trim(),
@@ -155,7 +155,7 @@ table revenue (
 
     expect(findToken(lines[1], 'currency').scopes).toContain('entity.other.attribute-name.metadata.gsql')
     expect(findToken(lines[1], 'USD').scopes).toContain('string.other.metadata.gsql')
-    expect(findToken(lines[1], 'hide').scopes).toContain('entity.other.attribute-name.metadata.gsql')
+    expect(findToken(lines[1], 'pii').scopes).toContain('entity.other.attribute-name.metadata.gsql')
     expect(findToken(lines[1], 'description').scopes).toContain('entity.other.attribute-name.metadata.gsql')
     expect(findToken(lines[1], 'Gross revenue').scopes).toContain('string.other.metadata.gsql')
   })
@@ -164,13 +164,13 @@ table revenue (
     let lines = await tokenize(
       `
 table revenue (
-  amount int -- gross revenue #hide #currency=USD
+  amount int -- gross revenue #pii #currency=USD
 )
 `.trim(),
     )
 
     expect(findToken(lines[1], 'gross').scopes).toContain('comment.line.double-dash.gsql')
-    expect(findToken(lines[1], 'hide').scopes).toContain('entity.other.attribute-name.metadata.gsql')
+    expect(findToken(lines[1], 'pii').scopes).toContain('entity.other.attribute-name.metadata.gsql')
     expect(findToken(lines[1], 'currency').scopes).toContain('entity.other.attribute-name.metadata.gsql')
   })
 })


### PR DESCRIPTION
This feels like a good opportunity to do a pass on our supported metadata. Personally I find it _very_ weird for us to use `#units` to specify currency (as well as physical units? At least there was an existing example in `lang.test.ts` with `#units=seconds`. It's also strikes me as weird that it's pluralized, it should be `#unit`). Could we use a dedicated `#currency` metadata, and reserve `#unit` for physical dimensions?