### PR TITLE
Fix root index.md always sorting to top of sidebar nav

### DIFF
--- a/ui/internal/PageNavGroup.svelte
+++ b/ui/internal/PageNavGroup.svelte
@@ -115,8 +115,8 @@
     return nodes
       .map(n => n.type === 'folder' && n.children?.length ? {...n, children: sortNodes(n.children)} : n)
       .sort((a, b) => {
-        if (a.label === 'Home') return -1
-        if (b.label === 'Home') return 1
+        if (a.path?.toLowerCase() === 'index.md') return -1
+        if (b.path?.toLowerCase() === 'index.md') return 1
         if (a.type !== b.type) return a.type === 'folder' ? -1 : 1
         return a.label.localeCompare(b.label)
       })

--- a/ui/tests/snapshots/markdown.test.ts/expanded-nav.png
+++ b/ui/tests/snapshots/markdown.test.ts/expanded-nav.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03d0fe73dcbf1997a163e027e4148c3c62ab638c5a918799bcac439bd7b7c32e
-size 26752
+oid sha256:c4fc6f39d823cc7f7bbd8954a80eb52c474915ef7ef0ddd881b2d6f3fb7f4acc
+size 26656


### PR DESCRIPTION
## Summary

- The sidebar `sortNodes` function was pinning the top position by checking `label === 'Home'`, but a root `index.md` with a custom `title` in its frontmatter gets that title as its label instead of `'Home'`, causing it to sort alphabetically instead of first.
- Fix checks `path === 'index.md'` directly, which is reliable regardless of the file's frontmatter title.
- This only affects the root `index.md` — nested `index.md` files are absorbed into their parent folder node during `buildTree` and never appear as sortable nodes.

## Test plan

- [ ] Project with a root `index.md` and no frontmatter title sorts to the top of the sidebar
- [ ] Project with a root `index.md` with a custom `title` in frontmatter also sorts to the top
- [ ] Nested `index.md` files continue to set their parent folder's route rather than appearing as separate nav items

https://claude.ai/code/session_01DLa71f97itjrGpZGwabcB3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLa71f97itjrGpZGwabcB3)_