### PR TITLE
disable echart's smoothing

### DIFF
--- a/ui/component-utilities/theme.ts
+++ b/ui/component-utilities/theme.ts
@@ -111,7 +111,7 @@ registerTheme('graphene-theme', {
     containLabel: false,
   },
   line: {
-    smooth: true,
+    smooth: false,
     symbol: 'emptyCircle',
     symbolSize: 6,
     lineStyle: {width: 2},


### PR DESCRIPTION
maybe this is anomalous for my data (and opinion), but i found the ECharts smoothing rather jarring and not to my taste.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/094452cd-5cba-4d06-8501-e05c67e75146" />
