### PR TITLE
CLI update notifier

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -16,6 +16,7 @@ import {getConnection, runQuery} from './connections/index.ts'
 import {printDiagnostics, printTable} from './printer.ts'
 import {listMdFileQueries, runMdFile, runNamedQueryFromMd} from './run.ts'
 import {CliTelemetry, getPresentFlags, getWorkspaceScanCounts, type TelemetryCommand} from './telemetry/index.ts'
+import {checkForUpdate, showCachedUpdateNotice} from './updateNotifier.ts'
 
 const program = new Command()
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -298,6 +299,7 @@ function withTelemetry(command: TelemetryCommand, action: (exit: (code?: number)
     let caughtError: unknown
 
     telemetry.event('cli_command_started', {command, flags: getPresentFlags(command, process.argv.slice(2))})
+    await showCachedUpdateNotice({config, currentVersion: libPkg.version, packageIsPrivate: libPkg.private})
 
     let exit = (code: number = 0): never => {
       exitCalled = true
@@ -319,6 +321,7 @@ function withTelemetry(command: TelemetryCommand, action: (exit: (code?: number)
         if (fromVersion) telemetry.event('cli_upgraded', {from_version: fromVersion, to_version: libPkg.version})
       }
       telemetry.event('cli_command_completed', {command, success, exit_code: exitCode, duration_ms: Date.now() - startedAt})
+      await checkForUpdate({config, currentVersion: libPkg.version, packageIsPrivate: libPkg.private})
     }
 
     if (caughtError) throw caughtError

--- a/cli/updateNotifier.test.ts
+++ b/cli/updateNotifier.test.ts
@@ -155,6 +155,54 @@ describe('cli update notifier', () => {
     }
   })
 
+  it('stores default update state in the project node_modules cache', async () => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-cache-'))
+    let stderr = testStderr()
+
+    try {
+      await writePackageJson(tmpDir, {name: 'tmp-graphene', graphene: {duckdb: {}}})
+      await fsp.mkdir(path.join(tmpDir, 'node_modules'))
+      await checkForUpdate({
+        config: testConfig(tmpDir),
+        currentVersion: '0.0.17',
+        env: {},
+        stderr,
+        now: 1_000,
+        fetchLatestVersion: () => Promise.resolve('0.0.18'),
+      })
+
+      let state = JSON.parse(await fsp.readFile(path.join(tmpDir, 'node_modules/.graphene/update-check.json'), 'utf-8'))
+      expect(state.latestVersion).toBe('0.0.18')
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('does not create node_modules just to persist update state', async () => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-no-node-modules-'))
+    let fetchCalls = 0
+
+    try {
+      await writePackageJson(tmpDir, {name: 'tmp-graphene', graphene: {duckdb: {}}})
+      await checkForUpdate({
+        config: testConfig(tmpDir),
+        currentVersion: '0.0.17',
+        env: {},
+        stderr: testStderr(),
+        now: 1_000,
+        fetchLatestVersion: () => {
+          fetchCalls++
+          return Promise.resolve('0.0.18')
+        },
+      })
+
+      expect(fetchCalls).toBe(0)
+      await expect(fsp.access(path.join(tmpDir, 'node_modules'))).rejects.toBeTruthy()
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
   it('detects package managers and preserves dev dependency installs', async () => {
     let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-package-manager-'))
     let projectDir = path.join(tmpDir, 'packages/app')

--- a/cli/updateNotifier.test.ts
+++ b/cli/updateNotifier.test.ts
@@ -1,0 +1,179 @@
+/// <reference types="vitest/globals" />
+import * as fsp from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import type {Config} from '../lang/config.ts'
+
+import {checkForUpdate, detectPackageManager, getUpgradeCommand, isNewerVersion, isUpdateNotifierEnabled, showCachedUpdateNotice} from './updateNotifier.ts'
+
+function testConfig(root: string, overrides: Partial<Config> = {}): Config {
+  return {dialect: 'duckdb', envFile: ['.env'], ignoredFiles: [], root, ...overrides}
+}
+
+function testStderr() {
+  return {
+    isTTY: true,
+    output: '',
+    write(chunk: string) {
+      this.output += chunk
+      return true
+    },
+  }
+}
+
+async function writePackageJson(dir: string, pkg: any) {
+  await fsp.writeFile(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n')
+}
+
+describe('cli update notifier', () => {
+  it('compares strict semver versions', () => {
+    expect(isNewerVersion('0.0.18', '0.0.17')).toBe(true)
+    expect(isNewerVersion('0.1.0', '0.0.99')).toBe(true)
+    expect(isNewerVersion('1.0.0', '9.9.9')).toBe(false)
+    expect(isNewerVersion('0.0.17', '0.0.17')).toBe(false)
+    expect(isNewerVersion('0.0.18-beta.1', '0.0.17')).toBe(false)
+  })
+
+  it('respects opt-out and non-interactive conditions', () => {
+    let cfg = testConfig('/tmp')
+    let env = {}
+    expect(isUpdateNotifierEnabled(cfg, env, {isTTY: true}, false)).toBe(true)
+    expect(isUpdateNotifierEnabled({...cfg, updateNotifier: false}, env, {isTTY: true}, false)).toBe(false)
+    expect(isUpdateNotifierEnabled(cfg, {GRAPHENE_NO_UPDATE_NOTIFIER: '1'}, {isTTY: true}, false)).toBe(false)
+    expect(isUpdateNotifierEnabled(cfg, {NODE_ENV: 'test'}, {isTTY: true}, false)).toBe(false)
+    expect(isUpdateNotifierEnabled(cfg, {CI: 'true'}, {isTTY: true}, false)).toBe(false)
+    expect(isUpdateNotifierEnabled(cfg, env, {isTTY: false}, false)).toBe(false)
+    expect(isUpdateNotifierEnabled(cfg, env, {isTTY: true}, true)).toBe(false)
+  })
+
+  it('checks daily and shows cached notices weekly per version', async () => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-notifier-'))
+    let statePath = path.join(tmpDir, 'update-check.json')
+    let stderr = testStderr()
+    let env = {}
+    let fetchCalls = 0
+
+    try {
+      await writePackageJson(tmpDir, {name: 'tmp-graphene', dependencies: {'@graphenedata/cli': '0.0.17'}, graphene: {duckdb: {}}})
+      let cfg = testConfig(tmpDir)
+
+      await checkForUpdate({
+        config: cfg,
+        currentVersion: '0.0.17',
+        env,
+        statePath,
+        stderr,
+        now: 1_000,
+        fetchLatestVersion: () => {
+          fetchCalls++
+          return Promise.resolve('0.0.18')
+        },
+      })
+      expect(fetchCalls).toBe(1)
+
+      await showCachedUpdateNotice({config: cfg, currentVersion: '0.0.17', env, statePath, stderr, now: 2_000})
+      expect(stderr.output).toContain('Graphene 0.0.18 is available. You are using 0.0.17.')
+      expect(stderr.output).toContain('Update: npm install @graphenedata/cli@latest')
+      expect(stderr.output).toContain('Release notes: https://github.com/graphene-data/graphene/releases/tag/v0.0.18')
+
+      stderr.output = ''
+      await showCachedUpdateNotice({config: cfg, currentVersion: '0.0.17', env, statePath, stderr, now: 3_000})
+      expect(stderr.output).toBe('')
+
+      await checkForUpdate({
+        config: cfg,
+        currentVersion: '0.0.17',
+        env,
+        statePath,
+        stderr,
+        now: 2_000 + 24 * 60 * 60 * 1000,
+        fetchLatestVersion: () => {
+          fetchCalls++
+          return Promise.resolve('0.0.19')
+        },
+      })
+      await showCachedUpdateNotice({config: cfg, currentVersion: '0.0.17', env, statePath, stderr, now: 4_000})
+      expect(stderr.output).toContain('Graphene 0.0.19 is available. You are using 0.0.17.')
+      expect(fetchCalls).toBe(2)
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('records failed checks so they do not retry every command', async () => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-failed-'))
+    let statePath = path.join(tmpDir, 'update-check.json')
+    let stderr = testStderr()
+    let fetchCalls = 0
+
+    try {
+      await writePackageJson(tmpDir, {name: 'tmp-graphene', graphene: {duckdb: {}}})
+      let cfg = testConfig(tmpDir)
+      let options = {
+        config: cfg,
+        currentVersion: '0.0.17',
+        env: {},
+        statePath,
+        stderr,
+        now: 1_000,
+        fetchLatestVersion: () => {
+          fetchCalls++
+          return Promise.resolve(null)
+        },
+      }
+
+      await checkForUpdate(options)
+      await checkForUpdate({...options, now: 2_000})
+      expect(fetchCalls).toBe(1)
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('recovers from corrupt state', async () => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-corrupt-'))
+    let statePath = path.join(tmpDir, 'update-check.json')
+
+    try {
+      await writePackageJson(tmpDir, {name: 'tmp-graphene', graphene: {duckdb: {}}})
+      await fsp.writeFile(statePath, 'not json')
+      await checkForUpdate({
+        config: testConfig(tmpDir),
+        currentVersion: '0.0.17',
+        env: {},
+        statePath,
+        stderr: testStderr(),
+        now: 1_000,
+        fetchLatestVersion: () => Promise.resolve('0.0.18'),
+      })
+
+      let state = JSON.parse(await fsp.readFile(statePath, 'utf-8'))
+      expect(state.latestVersion).toBe('0.0.18')
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it('detects package managers and preserves dev dependency installs', async () => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-package-manager-'))
+    let projectDir = path.join(tmpDir, 'packages/app')
+
+    try {
+      await fsp.mkdir(projectDir, {recursive: true})
+      await writePackageJson(tmpDir, {packageManager: 'yarn@4.0.0'})
+      await writePackageJson(projectDir, {name: 'app', devDependencies: {'@graphenedata/cli': '0.0.17'}, graphene: {duckdb: {}}})
+      expect(await detectPackageManager(projectDir, {})).toBe('yarn')
+      expect(await getUpgradeCommand(projectDir, {})).toBe('yarn add @graphenedata/cli@latest -D')
+
+      await writePackageJson(tmpDir, {})
+      await fsp.writeFile(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+      expect(await detectPackageManager(projectDir, {})).toBe('pnpm')
+
+      await fsp.rm(path.join(tmpDir, 'pnpm-lock.yaml'))
+      expect(await detectPackageManager(projectDir, {npm_config_user_agent: 'bun/1.2.0 npm/? node/?'})).toBe('bun')
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+})

--- a/cli/updateNotifier.ts
+++ b/cli/updateNotifier.ts
@@ -1,16 +1,15 @@
 import ci from 'ci-info'
 import {randomUUID} from 'node:crypto'
 import * as fs from 'node:fs/promises'
-import os from 'node:os'
 import path from 'node:path'
 
 import type {Config} from '../lang/config.ts'
 
 // The update notifier periodically checks for the latest Graphene version and caches
-// that state in `${XDG_CONFIG_HOME || ~/.config}/graphene/update-check.json`. We keep
-// state so every command can avoid a network request and so users only see one notice
-// per newer version each week. Cached notices are shown before command output, while
-// refreshes happen after the command finishes and fail silently.
+// that state in `node_modules/.graphene/update-check.json`. We keep state so every
+// command can avoid a network request and so users only see one notice per newer
+// version each week. Cached notices are shown before command output, while refreshes
+// happen after the command finishes and fail silently.
 
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
 const NOTICE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000
@@ -37,6 +36,10 @@ interface UpdateState {
 }
 
 type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun'
+interface StateTarget {
+  filePath: string
+  requiredDir?: string
+}
 
 export async function notifyAboutUpdate(options: UpdateNotifierOptions) {
   await showCachedUpdateNotice(options)
@@ -50,15 +53,17 @@ export async function showCachedUpdateNotice(options: UpdateNotifierOptions) {
   if (!isUpdateNotifierEnabled(options.config, env, stderr, options.packageIsPrivate)) return
 
   let now = options.now || Date.now()
-  let statePath = options.statePath || getUpdateStatePath(env)
-  let state = await readUpdateState(statePath)
+  let stateTarget = await getUpdateStateTarget(options)
+  if (!stateTarget) return
+
+  let state = await readUpdateState(stateTarget.filePath)
   if (state.latestVersion && isNewerVersion(state.latestVersion, options.currentVersion) && shouldShowNotice(state, now)) {
     let command = await getUpgradeCommand(options.config.root, env)
     stderr.write(`Graphene ${state.latestVersion} is available. You are using ${options.currentVersion}.\n`)
     stderr.write(`Update: ${command}\n`)
     stderr.write(`Release notes: ${GITHUB_RELEASE_URL}/v${state.latestVersion}\n`)
     state = {...state, lastNoticeVersion: state.latestVersion, lastNoticeAt: now}
-    await writeUpdateState(statePath, state)
+    await writeUpdateState(stateTarget, state)
   }
 }
 
@@ -69,14 +74,16 @@ export async function checkForUpdate(options: UpdateNotifierOptions) {
   if (!isUpdateNotifierEnabled(options.config, env, stderr, options.packageIsPrivate)) return
 
   let now = options.now || Date.now()
-  let statePath = options.statePath || getUpdateStatePath(env)
-  let state = await readUpdateState(statePath)
+  let stateTarget = await getUpdateStateTarget(options)
+  if (!stateTarget) return
+
+  let state = await readUpdateState(stateTarget.filePath)
 
   if (!shouldCheckForUpdate(state, now)) return
-  await writeUpdateState(statePath, {...state, lastCheckedAt: now})
+  await writeUpdateState(stateTarget, {...state, lastCheckedAt: now})
 
   let latestVersion = await (options.fetchLatestVersion || fetchLatestVersion)(env.GRAPHENE_UPDATE_CHECK_URL || DEFAULT_UPDATE_CHECK_URL)
-  if (latestVersion && isStrictSemver(latestVersion)) await writeUpdateState(statePath, {...state, lastCheckedAt: now, latestVersion})
+  if (latestVersion && isStrictSemver(latestVersion)) await writeUpdateState(stateTarget, {...state, lastCheckedAt: now, latestVersion})
 }
 
 export function isUpdateNotifierEnabled(config: Config, env: NodeJS.ProcessEnv = process.env, stderr: Pick<NodeJS.WriteStream, 'isTTY'> = process.stderr, packageIsPrivate = false) {
@@ -145,9 +152,17 @@ async function fetchLatestVersion(url: string) {
   }
 }
 
-function getUpdateStatePath(env: NodeJS.ProcessEnv = process.env) {
-  let configDir = env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config')
-  return path.join(configDir, 'graphene', 'update-check.json')
+async function getUpdateStateTarget(options: UpdateNotifierOptions): Promise<StateTarget | null> {
+  if (options.statePath) return {filePath: options.statePath}
+
+  let nodeModulesPath = path.join(options.config.root, 'node_modules')
+  try {
+    if (!(await fs.stat(nodeModulesPath)).isDirectory()) return null
+  } catch {
+    return null
+  }
+
+  return {filePath: path.join(nodeModulesPath, '.graphene', 'update-check.json'), requiredDir: nodeModulesPath}
 }
 
 async function readUpdateState(filePath: string): Promise<UpdateState> {
@@ -158,9 +173,11 @@ async function readUpdateState(filePath: string): Promise<UpdateState> {
   }
 }
 
-async function writeUpdateState(filePath: string, state: UpdateState) {
+async function writeUpdateState(target: StateTarget, state: UpdateState) {
+  let filePath = target.filePath
   let tmpPath = `${filePath}.tmp-${randomUUID()}`
   try {
+    if (target.requiredDir && !(await fs.stat(target.requiredDir)).isDirectory()) return
     await fs.mkdir(path.dirname(filePath), {recursive: true})
     await fs.writeFile(tmpPath, JSON.stringify(state, null, 2) + '\n')
     await fs.rename(tmpPath, filePath)

--- a/cli/updateNotifier.ts
+++ b/cli/updateNotifier.ts
@@ -1,0 +1,266 @@
+import ci from 'ci-info'
+import {randomUUID} from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import type {Config} from '../lang/config.ts'
+
+// The update notifier periodically checks for the latest Graphene version and caches
+// that state in `${XDG_CONFIG_HOME || ~/.config}/graphene/update-check.json`. We keep
+// state so every command can avoid a network request and so users only see one notice
+// per newer version each week. Cached notices are shown before command output, while
+// refreshes happen after the command finishes and fail silently.
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+const NOTICE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000
+const DEFAULT_UPDATE_CHECK_URL = 'https://registry.npmjs.org/%40graphenedata%2Fcli/latest'
+const GITHUB_RELEASE_URL = 'https://github.com/graphene-data/graphene/releases/tag'
+const PACKAGE_NAME = '@graphenedata/cli'
+
+export interface UpdateNotifierOptions {
+  config: Config
+  currentVersion: string
+  packageIsPrivate?: boolean
+  env?: NodeJS.ProcessEnv
+  now?: number
+  statePath?: string
+  stderr?: Pick<NodeJS.WriteStream, 'write' | 'isTTY'>
+  fetchLatestVersion?: (url: string) => Promise<string | null>
+}
+
+interface UpdateState {
+  lastCheckedAt?: number
+  latestVersion?: string
+  lastNoticeVersion?: string
+  lastNoticeAt?: number
+}
+
+type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun'
+
+export async function notifyAboutUpdate(options: UpdateNotifierOptions) {
+  await showCachedUpdateNotice(options)
+  await checkForUpdate(options)
+}
+
+// Shows only cached update information so command startup does not wait on the network.
+export async function showCachedUpdateNotice(options: UpdateNotifierOptions) {
+  let env = options.env || process.env
+  let stderr = options.stderr || process.stderr
+  if (!isUpdateNotifierEnabled(options.config, env, stderr, options.packageIsPrivate)) return
+
+  let now = options.now || Date.now()
+  let statePath = options.statePath || getUpdateStatePath(env)
+  let state = await readUpdateState(statePath)
+  if (state.latestVersion && isNewerVersion(state.latestVersion, options.currentVersion) && shouldShowNotice(state, now)) {
+    let command = await getUpgradeCommand(options.config.root, env)
+    stderr.write(`Graphene ${state.latestVersion} is available. You are using ${options.currentVersion}.\n`)
+    stderr.write(`Update: ${command}\n`)
+    stderr.write(`Release notes: ${GITHUB_RELEASE_URL}/v${state.latestVersion}\n`)
+    state = {...state, lastNoticeVersion: state.latestVersion, lastNoticeAt: now}
+    await writeUpdateState(statePath, state)
+  }
+}
+
+// Refreshes the cached latest version at most once per day after a command finishes.
+export async function checkForUpdate(options: UpdateNotifierOptions) {
+  let env = options.env || process.env
+  let stderr = options.stderr || process.stderr
+  if (!isUpdateNotifierEnabled(options.config, env, stderr, options.packageIsPrivate)) return
+
+  let now = options.now || Date.now()
+  let statePath = options.statePath || getUpdateStatePath(env)
+  let state = await readUpdateState(statePath)
+
+  if (!shouldCheckForUpdate(state, now)) return
+  await writeUpdateState(statePath, {...state, lastCheckedAt: now})
+
+  let latestVersion = await (options.fetchLatestVersion || fetchLatestVersion)(env.GRAPHENE_UPDATE_CHECK_URL || DEFAULT_UPDATE_CHECK_URL)
+  if (latestVersion && isStrictSemver(latestVersion)) await writeUpdateState(statePath, {...state, lastCheckedAt: now, latestVersion})
+}
+
+export function isUpdateNotifierEnabled(config: Config, env: NodeJS.ProcessEnv = process.env, stderr: Pick<NodeJS.WriteStream, 'isTTY'> = process.stderr, packageIsPrivate = false) {
+  if (packageIsPrivate) return false
+  if (config.updateNotifier === false) return false
+  if (env.GRAPHENE_NO_UPDATE_NOTIFIER == '1') return false
+  if (env.NODE_ENV == 'test') return false
+  if (isCiEnv(env)) return false
+  if (!stderr.isTTY) return false
+  return true
+}
+
+export function isNewerVersion(candidate: string, current: string) {
+  if (!isStrictSemver(candidate) || !isStrictSemver(current)) return false
+  let candidateParts = candidate.split('.').map(Number)
+  let currentParts = current.split('.').map(Number)
+
+  for (let i = 0; i < candidateParts.length; i++) {
+    if (candidateParts[i] > currentParts[i]) return true
+    if (candidateParts[i] < currentParts[i]) return false
+  }
+
+  return false
+}
+
+export async function getUpgradeCommand(projectRoot: string, env: NodeJS.ProcessEnv = process.env) {
+  let packageManager = await detectPackageManager(projectRoot, env)
+  let dependencyFlag = (await getGrapheneDependencyType(projectRoot)) == 'devDependencies' ? devDependencyFlag(packageManager) : ''
+  let command = `${packageManager} ${packageManager == 'npm' ? 'install' : 'add'} ${PACKAGE_NAME}@latest`
+  return dependencyFlag ? `${command} ${dependencyFlag}` : command
+}
+
+export async function detectPackageManager(projectRoot: string, env: NodeJS.ProcessEnv = process.env): Promise<PackageManager> {
+  let packageManager = await findPackageManagerField(projectRoot)
+  if (packageManager) return packageManager
+
+  let lockfilePackageManager = await findLockfilePackageManager(projectRoot)
+  if (lockfilePackageManager) return lockfilePackageManager
+
+  return parsePackageManager(env.npm_config_user_agent) || 'npm'
+}
+
+function shouldShowNotice(state: UpdateState, now: number) {
+  if (state.lastNoticeVersion != state.latestVersion) return true
+  return !state.lastNoticeAt || now - state.lastNoticeAt >= NOTICE_INTERVAL_MS
+}
+
+function shouldCheckForUpdate(state: UpdateState, now: number) {
+  return !state.lastCheckedAt || now - state.lastCheckedAt >= CHECK_INTERVAL_MS
+}
+
+async function fetchLatestVersion(url: string) {
+  let controller = new AbortController()
+  let timeout = setTimeout(() => controller.abort(), 500)
+  timeout.unref?.()
+
+  try {
+    let response = await fetch(url, {signal: controller.signal})
+    if (!response.ok) return null
+    let body = await response.json()
+    return typeof body.version == 'string' ? body.version : null
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function getUpdateStatePath(env: NodeJS.ProcessEnv = process.env) {
+  let configDir = env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config')
+  return path.join(configDir, 'graphene', 'update-check.json')
+}
+
+async function readUpdateState(filePath: string): Promise<UpdateState> {
+  try {
+    return normalizeUpdateState(JSON.parse(await fs.readFile(filePath, 'utf-8')))
+  } catch {
+    return {}
+  }
+}
+
+async function writeUpdateState(filePath: string, state: UpdateState) {
+  let tmpPath = `${filePath}.tmp-${randomUUID()}`
+  try {
+    await fs.mkdir(path.dirname(filePath), {recursive: true})
+    await fs.writeFile(tmpPath, JSON.stringify(state, null, 2) + '\n')
+    await fs.rename(tmpPath, filePath)
+  } catch {
+    try {
+      await fs.unlink(tmpPath)
+    } catch {
+      // Nothing to clean up if the temp file was never created.
+    }
+  }
+}
+
+function normalizeUpdateState(state: Partial<UpdateState>): UpdateState {
+  return {
+    ...(typeof state.lastCheckedAt == 'number' ? {lastCheckedAt: state.lastCheckedAt} : {}),
+    ...(typeof state.latestVersion == 'string' ? {latestVersion: state.latestVersion} : {}),
+    ...(typeof state.lastNoticeVersion == 'string' ? {lastNoticeVersion: state.lastNoticeVersion} : {}),
+    ...(typeof state.lastNoticeAt == 'number' ? {lastNoticeAt: state.lastNoticeAt} : {}),
+  }
+}
+
+async function findPackageManagerField(projectRoot: string): Promise<PackageManager | null> {
+  for (let dir of ancestorDirs(projectRoot)) {
+    let packageJson = await readPackageJson(path.join(dir, 'package.json'))
+    let packageManager = parsePackageManager(packageJson?.packageManager)
+    if (packageManager) return packageManager
+  }
+  return null
+}
+
+async function findLockfilePackageManager(projectRoot: string): Promise<PackageManager | null> {
+  let lockfiles: Array<[string, PackageManager]> = [
+    ['pnpm-lock.yaml', 'pnpm'],
+    ['yarn.lock', 'yarn'],
+    ['package-lock.json', 'npm'],
+    ['npm-shrinkwrap.json', 'npm'],
+    ['bun.lock', 'bun'],
+    ['bun.lockb', 'bun'],
+  ]
+
+  for (let dir of ancestorDirs(projectRoot)) {
+    for (let [file, packageManager] of lockfiles) {
+      try {
+        await fs.access(path.join(dir, file))
+        return packageManager
+      } catch {
+        // Keep walking upward until a package manager signal is found.
+      }
+    }
+  }
+
+  return null
+}
+
+async function getGrapheneDependencyType(projectRoot: string) {
+  let packageJson = await readPackageJson(path.join(projectRoot, 'package.json'))
+  if (packageJson?.devDependencies?.[PACKAGE_NAME]) return 'devDependencies'
+  if (packageJson?.dependencies?.[PACKAGE_NAME]) return 'dependencies'
+  return null
+}
+
+async function readPackageJson(filePath: string): Promise<any | null> {
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf-8'))
+  } catch {
+    return null
+  }
+}
+
+function parsePackageManager(value: unknown): PackageManager | null {
+  if (typeof value != 'string') return null
+  let normalized = value.toLowerCase()
+  if (normalized.includes('pnpm')) return 'pnpm'
+  if (normalized.includes('yarn')) return 'yarn'
+  if (normalized.includes('bun')) return 'bun'
+  if (normalized.includes('npm')) return 'npm'
+  return null
+}
+
+function devDependencyFlag(packageManager: PackageManager) {
+  if (packageManager == 'bun') return '-d'
+  return '-D'
+}
+
+function isStrictSemver(version: string) {
+  return /^\d+\.\d+\.\d+$/.test(version)
+}
+
+function isCiEnv(env: NodeJS.ProcessEnv) {
+  if (env === process.env) return ci.isCI
+  return env.CI == 'true' || env.CI == '1' || !!env.GITHUB_ACTIONS || !!env.BUILDKITE || !!env.CIRCLECI
+}
+
+function ancestorDirs(startDir: string) {
+  let dirs: string[] = []
+  let current = path.resolve(startDir)
+  while (true) {
+    dirs.push(current)
+    let parent = path.dirname(current)
+    if (parent == current) return dirs
+    current = parent
+  }
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -8,7 +8,8 @@ Graphene reads its configuration from the `graphene` object in your project's `p
     "duckdb": {"path": "./data.duckdb"},
     "defaultNamespace": "main",
     "ignoredFiles": ["**/readme.md", "**/agents.md", "**/claude.md"],
-    "envFile": [".env", "../../.env"]
+    "envFile": [".env", "../../.env"],
+    "updateNotifier": false
   }
 }
 ```
@@ -50,6 +51,10 @@ Hostname the dev server binds to. Defaults to `localhost`.
 ## `telemetry`
 
 Set to `false` to opt out of anonymous usage telemetry.
+
+## `updateNotifier`
+
+Set to `false` to opt out of CLI update notices. You can also set `GRAPHENE_NO_UPDATE_NOTIFIER=1` in the environment.
 
 # Database connections
 

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -8,6 +8,7 @@ export interface Config {
   defaultNamespace?: string
   ignoredFiles: string[]
   telemetry?: boolean
+  updateNotifier?: boolean
   port?: number
   host?: string
   envFile: string[] // array of paths where we can look for the env file


### PR DESCRIPTION
This PR adds a first pass at update notifications for the Graphene CLI. I did some research on best practices here and went with an approach similar to the [update-notifier](https://www.npmjs.com/package/update-notifier) package. To avoid slowing down CLI commands, the CLI periodically (no more than once a day) checks for new versions and stores the info in a cache file in `~/.config/graphene`. We check the cache data when running CLI commands and if we haven't notified about that version in the last week we notify (with a link to the changelog/GH release).