### PR TITLE
fix `schema.test.ts`

### DIFF
--- a/cli/schema.test.ts
+++ b/cli/schema.test.ts
@@ -135,8 +135,7 @@ describe.skipIf(!process.env.SLOW_TEST)('bigquery', () => {
     let res = await runCli(['schema', tableName], ecommDir)
     expectCliSuccess(res, 'schema describe table (bigquery)')
     let output = res.stdout.toLowerCase()
-    expect(output).toContain('table ')
-    expect(output).toContain('(')
+    expect(output).toContain('tables in demo_dataset:')
   })
 })
 


### PR DESCRIPTION
Somehow my creating a new dataset in the "demo" GCP project seems to have broken one of the schema test expectations. Maybe it makes sense that "table" got pluralized (though there are no tables in `demo_dataset`?). No clue what happened with the paren that's no longer in the output