### PR TITLE
document `<Dropdown multiple=true/>`

### DIFF
--- a/docs/references/dropdown.md
+++ b/docs/references/dropdown.md
@@ -24,6 +24,18 @@ from orders
 where status = $status_dropdown
 ```
 
+For multi-select dropdowns, filter with `in ($name)`:
+
+````markdown
+<Dropdown name=selected_statuses data=statuses value=status multiple=true />
+
+```sql
+select *
+from orders
+where status in ($selected_statuses)
+```
+````
+
 Dropdown selections also sync into the page URL query string. Single-select dropdowns use one key, and multi-select dropdowns repeat the key for each selected value.
 
 # Attributes


### PR DESCRIPTION
I'm going to say fixes #53, though the functionality was already there, just not documented well. Confirmed locally that multiselect works end-to-end, but the agent was only able to find an example of the `in ($array)` syntax in `inputs.test.ts`