### PR TITLE
regression test for conflicting joins

### DIFF
--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -993,6 +993,21 @@ describe('lang', () => {
     expect('table dup (id int, id text)').toHaveDiagnostic(/Table already has a field called "id"/i)
   })
 
+  it('reports diagnostics for duplicate join definitions', () => {
+    expect(`
+      table airports (
+        code text
+        join many flights on code = flights.origin
+        join many flights on code = flights.destination
+      )
+
+      table flights (
+        origin text
+        destination text
+      )
+    `).toHaveDiagnostic(/Table already has a field called "flights"/i)
+  })
+
   it('reports diagnostics for unsupported data types', () => {
     expect('table invalid (id int, value hyperthing)').toHaveDiagnostic(/Unsupported data type: hyperthing/i)
   })


### PR DESCRIPTION
Going to say fixes #48, though the behavior was already fixed. But this PR adds a regression test for conflicting modeled join fields.