### PR TITLE
document `graphene run` background behavior

### DIFF
--- a/cli/run.ts
+++ b/cli/run.ts
@@ -56,8 +56,11 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
     return false
   }
 
-  let resp = await sendSocketRequest({mdFile, action: 'check', chart: options.chart, inputs: options.inputs, log})
+  let pageUrl = markdownPageUrl(mdFile, options.inputs)
+  let host = runHost()
+  let resp = await sendSocketRequest({pageUrl, action: 'check', chart: options.chart, log})
   if (!resp) return false
+  log('Page available at', host + pageUrl)
 
   let errors = Array.from(resp.errors || []) as GrapheneError[]
   let chartNotFound = !!options.chart && !resp.screenshot
@@ -109,7 +112,7 @@ export async function listMdFileQueries(mdArg: string, telemetry?: CliTelemetry,
     return false
   }
 
-  let resp = await sendSocketRequest({mdFile, action: 'list', log})
+  let resp = await sendSocketRequest({pageUrl: markdownPageUrl(mdFile), action: 'list', log})
   if (!resp) return false
 
   let componentIds = (resp.componentIds || []) as string[]
@@ -152,17 +155,13 @@ export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: str
   return true
 }
 
-async function sendSocketRequest({mdFile, action, chart, inputs, log}: {mdFile: string; action: 'check' | 'list'; chart?: string; inputs?: RunInputs; log: (...args: any[]) => void}) {
-  let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')
-  if (pageUrl === '/index') pageUrl = '/'
-  pageUrl = appendInputsToUrl(pageUrl, inputs)
-
+async function sendSocketRequest({pageUrl, action, chart, log}: {pageUrl: string; action: 'check' | 'list'; chart?: string; log: (...args: any[]) => void}) {
+  let host = runHost()
   if (process.env.NODE_ENV !== 'test' && !(await isServerRunning())) {
     log('Starting Graphene server...')
     await runServeInBackground()
   }
 
-  let host = `http://localhost:${config.port}`
   let resp = await fetchSocketRequest({host, pageUrl, action, chart})
 
   if (resp.error == 'no_server') {
@@ -188,6 +187,17 @@ async function sendSocketRequest({mdFile, action, chart, inputs, log}: {mdFile: 
   }
 
   return resp
+}
+
+function markdownPageUrl(mdFile: string, inputs?: RunInputs) {
+  let pageUrl = '/' + mdFile.replace(/\.md$/, '').replace(/^\//, '').replace(/\\/g, '/')
+  if (pageUrl === '/index') pageUrl = '/'
+  pageUrl = appendInputsToUrl(pageUrl, inputs)
+  return pageUrl
+}
+
+function runHost() {
+  return `http://localhost:${config.port}`
 }
 
 function appendInputsToUrl(pageUrl: string, inputs: RunInputs = {}) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,10 @@ graphene run - # Read GSQL from stdin and print results
 graphene run path/to/page.md # Run the page and save a full-page screenshot
 graphene run path/to/page.md --input carrier=AA # Run the page with input values, overriding page defaults
 
+# Running a markdown page starts the local dev server in a persistent background process if one is not already running.
+# The command prints the live page URL, e.g. http://localhost:4000/path/to/page, and the server keeps running for hot reloads.
+# After iterating until the screenshot looks acceptable, agents can link users directly to that localhost URL.
+
 # `-c/--chart` can target either a chart title or the chart's `queryId`. For charts without titles use `graphene list` to see the exact IDs for charts on a page.
 graphene run path/to/page.md -c "Chart Title" # Run the page and screenshot one chart by title
 graphene run path/to/page.md -c 'Query (data="query_name" x="category" y="total")' # Run the page and screenshot one chart by queryId

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -19,6 +19,7 @@ function outputLines() {
     /Screenshot saved to[^\n]*node_modules\/\.graphene\/screenshots\/<timestamp>\.png/g,
     'Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png',
   )
+  normalized = normalized.replace(/Page available at http:\/\/localhost:\d+/g, 'Page available at http://localhost:<port>')
   return stripAnsi(normalized.trim())
 }
 
@@ -119,6 +120,7 @@ test('cli run with md file reports dynamic unsupported chart wrapper props', asy
   expect(result).toBe(false)
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     Runtime errors in index.md:
     BarChart (data="chart_data" x="carrier" y="distance"): Unsupported prop "yFmt" on BarChart.
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
@@ -148,6 +150,7 @@ test('cli run with md file reports dynamic unsupported ECharts top-level props',
   expect(result).toBe(false)
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     Runtime errors in index.md:
     ECharts (data="chart_data" x="carrier" y="distance"): Unsupported prop "chartAreaHeight" on ECharts.
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
@@ -172,6 +175,7 @@ test('cli run with md file reports multiple dynamic unsupported chart props', as
   expect(result).toBe(false)
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     Runtime errors in index.md:
     BarChart (data="chart_data" x="carrier" y="distance"): Unsupported prop "yFmt" on BarChart. Unsupported prop "emptySet" on BarChart.
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
@@ -202,6 +206,7 @@ test('cli run with md file reports runtime chart prop and render errors together
   expect(result).toBe(false)
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     Runtime errors in index.md:
     ECharts (data="chart_data" x="x_value" y="bad_category"): Horizontal charts do not support a value or time-based x-axis
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
@@ -226,6 +231,7 @@ test('cli run with md file reports runtime query errors', async ({server, page})
   await runMdFile({mdArg: 'index.md', log})
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     Runtime errors in index.md:
     BarChart (data="runtime_error_query" x="origin" y="explode"): Out of Range Error: cannot take square root of a negative number
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
@@ -255,6 +261,7 @@ test('cli run with md file reports runtime chart configuration errors', async ({
   await runMdFile({mdArg: 'index.md', log})
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     Runtime errors in index.md:
     ECharts (data="chart_data" x="x_value" y="bad_category"): Horizontal charts do not support a value or time-based x-axis
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
@@ -278,6 +285,7 @@ test('cli run with md file reports table configuration errors', async ({server, 
   await runMdFile({mdArg: 'index.md', log})
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     Runtime errors in index.md:
     DataTable: not_a_column is not a column in the dataset. sort should contain one column name and optionally a direction (asc or desc).
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
@@ -302,6 +310,7 @@ test('cli run with md file reports big value query errors', async ({server, page
   await runMdFile({mdArg: 'index.md', log})
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     Runtime errors in index.md:
     BigValue (data="big_value_data" value="value"): Out of Range Error: cannot take square root of a negative number
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
@@ -347,6 +356,7 @@ test('cli run with --chart captures a single chart screenshot', async ({server, 
   await runMdFile({mdArg: 'index.md', chart: 'Carrier Distance', log})
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     No errors found 💎
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
@@ -381,6 +391,7 @@ test('cli run with --input applies inputs to a full page run', async ({server, p
   expect(queryBodies.some(body => JSON.stringify(body.params) == JSON.stringify({carrier: 'AA'}))).toBe(true)
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/?carrier=AA
     No errors found 💎
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
@@ -408,6 +419,7 @@ test('cli run with --chart captures an ECharts screenshot by title', async ({ser
   await runMdFile({mdArg: 'index.md', chart: 'Carrier Distance', log})
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     No errors found 💎
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
@@ -448,6 +460,7 @@ test('cli run with --chart captures a chart screenshot by component ID', async (
   await runMdFile({mdArg: 'index.md', chart: 'BarChart (data="chart_data" x="carrier" y="total_distance")', log})
   expect(outputLines()).toEqual(
     trimIndentation(`
+    Page available at http://localhost:<port>/
     No errors found 💎
     Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
   `),
@@ -469,5 +482,10 @@ test('cli run with --chart reports when no chart title matches', async ({server,
   await page.goto(server.url())
   let result = await runMdFile({mdArg: 'index.md', chart: 'Missing Chart', log})
   expect(result).toBe(false)
-  expect(outputLines()).toEqual('Could not find chart "Missing Chart" on index.md')
+  expect(outputLines()).toEqual(
+    trimIndentation(`
+    Page available at http://localhost:<port>/
+    Could not find chart "Missing Chart" on index.md
+  `),
+  )
 })

--- a/ui/tests/install.test.ts
+++ b/ui/tests/install.test.ts
@@ -166,6 +166,7 @@ limit 10
       'Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png',
     )
     expect(runOutput).toContain('No errors found 💎')
+    expect(runOutput).toContain(`Page available at http://localhost:${port}/chart`)
     expect(runOutput).toContain('Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png')
   } finally {
     expectConsoleError(/WebSocket connection to 'ws:\/\/(localhost|127\.0\.0\.1):\d+\/_api\/ws' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED/)


### PR DESCRIPTION
This PR updates the `graphene run page.md` flow to better document the fact that it spawns a persistent serve process. This comprises some commentary in `docs/cli.md` as well as a change to make the run command print "Page available at $URL"