### PR TITLE
hide value-axis chrome on numeric x-axes with line/bar series

### DIFF
--- a/examples/flights/numeric_x_axis_styling.md
+++ b/examples/flights/numeric_x_axis_styling.md
@@ -1,0 +1,47 @@
+---
+title: Numeric X-Axis Styling
+layout: dashboard
+---
+
+Regression coverage for the "vertical y-axis line + vertical gridlines on line /
+area / bar charts" bug. The fix in #392 handled `extract(year)` and the
+`timeOrdinal` family by reading column metadata, but the same chrome leaks back
+in whenever a numeric x-axis lacks that metadata: window functions, integer
+casts, math expressions, raw integer columns. None of the four charts below
+should show a vertical y-axis line, vertical splitLines, or x-axis tick marks.
+
+```gsql carrier_totals
+from flights
+select carrier, count() as flight_count
+order by flight_count desc
+```
+
+```gsql carrier_rank
+from carrier_totals
+select row_number() over (order by flight_count desc) as rank, carrier, flight_count
+order by rank
+```
+
+```gsql flights_per_dep_hour
+from flights
+where not is_cancelled
+select extract(hour from dep_time)::integer as dep_hour, count() as flight_count
+order by dep_hour
+```
+
+```gsql flights_per_distance_bucket
+from flights
+where not is_cancelled
+select (floor(distance / 250) * 250)::integer as distance_bucket, count() as flight_count
+order by distance_bucket
+```
+
+<Row>
+  <LineChart title="Carriers ranked (row_number)" data=carrier_rank x=rank y=flight_count />
+  <BarChart title="Carriers ranked (row_number)" data=carrier_rank x=rank y=flight_count />
+</Row>
+
+<Row>
+  <LineChart title="Flights by hour-of-day (cast int)" data=flights_per_dep_hour x=dep_hour y=flight_count />
+  <AreaChart title="Flights by 250-mi bucket" data=flights_per_distance_bucket x=distance_bucket y=flight_count />
+</Row>

--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -22,6 +22,7 @@ export function enrich(config: EChartsConfig, rows: Record<string, any>[], field
 
   // Resolve axis metadata up front so row shaping (like explicit sorting) can use it.
   inferAxesFromEncodedFields(normalized, fields, rows)
+  hideValueAxisChromeForLineAndBar(normalized)
   extendValueAxisDomainsForBars(normalized)
 
   // Mutate row/field data before dataset creation so synthesized fields are reflected in dataset dimensions.
@@ -292,6 +293,32 @@ function inferAxesFromEncodedFields(config: NormalConfig, fields: Field[], rows:
     if (!axis?.field?.metadata?.timeOrdinal && axis?.field?.metadata?.timeGrain !== 'year') continue
 
     let yAxisIndexes = config.series.filter(entry => Number(entry?.xAxisIndex ?? 0) === axisIndex).map(entry => Number(entry?.yAxisIndex ?? 0))
+    for (let yAxisIndex of yAxisIndexes) {
+      let yAxis = config.yAxis[yAxisIndex]
+      if (!yAxis || yAxis.axisLine?.show != null) continue
+      yAxis.axisLine = {...yAxis.axisLine, show: false}
+    }
+  }
+}
+
+// Numeric x-axes that drive line/bar series read like discrete dimensions, so the
+// value-axis chrome (vertical splitLines, x-axis line, ticks, paired y-axis line)
+// looks noisy. Hide it whenever the caller hasn't set it explicitly. Horizontal
+// bars are excluded by the value-typed y-axis check.
+function hideValueAxisChromeForLineAndBar(config: NormalConfig) {
+  for (let [axisIndex, xAxis] of config.xAxis.entries()) {
+    if (xAxis?.type !== 'value') continue
+    let seriesOnAxis = config.series.filter(entry => Number(entry?.xAxisIndex ?? 0) === axisIndex && (entry?.type === 'line' || entry?.type === 'bar'))
+    if (seriesOnAxis.length === 0) continue
+
+    let yAxisIndexes = seriesOnAxis.map(entry => Number(entry?.yAxisIndex ?? 0))
+    let pairedAreAllValue = yAxisIndexes.every(idx => config.yAxis[idx]?.type === 'value')
+    if (!pairedAreAllValue) continue
+
+    if (xAxis.splitLine?.show == null) xAxis.splitLine = {...xAxis.splitLine, show: false}
+    if (xAxis.axisLine?.show == null) xAxis.axisLine = {...xAxis.axisLine, show: false}
+    if (xAxis.axisTick?.show == null) xAxis.axisTick = {...xAxis.axisTick, show: false}
+
     for (let yAxisIndex of yAxisIndexes) {
       let yAxis = config.yAxis[yAxisIndex]
       if (!yAxis || yAxis.axisLine?.show != null) continue


### PR DESCRIPTION
Closes #404.

## Summary

#392 hid the y-axis line and value-axis splitLines only for x-axes tagged with `year` or `timeOrdinal` metadata. The same chrome leaks back in for any other numeric x-axis — `row_number()`, `extract(year)::integer`, `floor(distance/250)*250`, raw integer columns, etc.

This generalizes the cleanup. After `inferAxesFromEncodedFields`, a new enrichment runs against any value-typed x-axis with at least one line or bar series and a value-typed y-axis, hiding:

- `xAxis.splitLine`, `xAxis.axisLine`, `xAxis.axisTick`
- the paired `yAxis.axisLine`

The value-typed y-axis check naturally excludes horizontal bars (which have a category y-axis and want their value x-axis chrome). All four hides respect explicit caller config (`show != null` skip), matching the existing pattern at `enrich.ts:297`.

The year/timeOrdinal blocks in `inferAxisFromField` stay as-is — they keep the chrome hidden even on scatter (no line/bar), which the new general rule wouldn't cover. Slight redundancy for line/bar on year/ordinal, but both produce the same result.

## Repro / regression coverage

`examples/flights/numeric_x_axis_styling.md` exercises the four classes of expression that hit this bug: window functions, integer casts, math/bucketing, plus a side-by-side line + bar.

## Test plan

- [x] `pnpm lint` clean
- [x] Visual check on `examples/flights/numeric_x_axis_styling.md` — none of the four charts should show a vertical y-axis line, vertical splitLines, or x-axis tick marks
- [x] Visual check on `examples/flights/year_extraction.md` — should look identical to before (existing year-metadata path still applies)
- [x] Spot-check other line/bar dashboards in `examples/` for regressions, especially horizontal bar charts (should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)