### PR TITLE
tail log on `graphene run` background serve error

### DIFF
--- a/cli/background.test.ts
+++ b/cli/background.test.ts
@@ -1,0 +1,42 @@
+/// <reference types="vitest/globals" />
+import * as fsp from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {expect} from 'vitest'
+
+import {setGlobalConfig} from '../lang/config.ts'
+import {runServeInBackground} from './background.ts'
+
+describe('background server', () => {
+  it('includes the server log when startup exits early', async () => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-bg-fail-'))
+    let entryPoint = path.join(tmpDir, 'fail-server.mjs')
+
+    try {
+      await fsp.mkdir(path.join(tmpDir, 'node_modules'))
+      await fsp.writeFile(
+        entryPoint,
+        [
+          "console.log('Starting Graphene server...')",
+          "console.error('Failed to start Graphene server')",
+          "console.error('listen EPERM: operation not permitted 127.0.0.1:4000')",
+          'process.exit(1)',
+        ].join('\n'),
+      )
+      setGlobalConfig({root: tmpDir, dialect: 'duckdb'})
+
+      let error: unknown
+      try {
+        await runServeInBackground({entryPoint, log: () => undefined})
+      } catch (err) {
+        error = err
+      }
+
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).message).toMatch(/listen EPERM: operation not permitted 127\.0\.0\.1:4000/)
+      expect((error as Error).message).toMatch(/node_modules\/\.graphene\/serve\.log/)
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+})

--- a/cli/background.ts
+++ b/cli/background.ts
@@ -8,13 +8,13 @@ import {config} from '../lang/config.ts'
 
 const execAsync = promisify(exec)
 
-export async function runServeInBackground(): Promise<void> {
+export async function runServeInBackground(options: {entryPoint?: string; log?: (chunk: string) => void} = {}): Promise<void> {
   let grapheneCache = getGrapheneCache(config.root)
   let logFile = path.join(grapheneCache, 'serve.log')
   await fs.ensureDir(grapheneCache)
 
   let log = fs.openSync(logFile, 'w')
-  let entryPoint = process.argv[1] || fileURLToPath(import.meta.url)
+  let entryPoint = options.entryPoint || process.argv[1] || fileURLToPath(import.meta.url)
   let childArgs = [...process.execArgv, entryPoint, 'serve']
   let child = spawn(process.execPath, childArgs, {
     cwd: config.root,
@@ -27,23 +27,48 @@ export async function runServeInBackground(): Promise<void> {
 
   await new Promise<void>((resolve, reject) => {
     let buffer = ''
+    let settled = false
+    let close = () => {
+      if (settled) return false
+      settled = true
+      fs.unwatchFile(logFile)
+      fs.closeSync(log)
+      return true
+    }
+
     fs.watchFile(logFile, {interval: 200}, (curr, prev) => {
       if (curr.size > prev.size) {
-        // File has grown, read the new data
-        let stream = fs.createReadStream(logFile, {start: 0, end: curr.size - 1})
+        let stream = fs.createReadStream(logFile, {start: prev.size, end: curr.size - 1})
         stream.on('data', d => {
-          process.stdout.write(d)
+          if (options.log) options.log(d.toString())
+          else process.stdout.write(d)
           buffer = (buffer + d.toString()).slice(-200)
-          if (buffer.includes('Server running at http://localhost:')) resolve()
+          if (buffer.includes('Server running at http://localhost:') && close()) resolve()
         })
       }
     })
 
-    child.once('exit', () => {
-      reject(new Error('Exited before server started'))
+    child.once('exit', async (code, signal) => {
+      if (!close()) return
+      reject(new Error(await serverStartupErrorMessage({logFile, code, signal})))
     })
-    child.once('error', e => reject(e))
+    child.once('error', async e => {
+      if (!close()) return
+      reject(new Error(await serverStartupErrorMessage({logFile, err: e})))
+    })
   })
+}
+
+async function serverStartupErrorMessage({logFile, code = null, signal = null, err}: {logFile: string; code?: number | null; signal?: NodeJS.Signals | null; err?: Error}): Promise<string> {
+  let status = err ? err.message : `exited before startup finished${code === null ? '' : ` (code ${code})`}${signal ? ` (signal ${signal})` : ''}`
+  let logTail = await readLogTail(logFile)
+  return `Graphene server ${status}.\n\nLast output from ${logFile}:\n${logTail}`
+}
+
+async function readLogTail(logFile: string): Promise<string> {
+  let contents = await fs.readFile(logFile, 'utf8').catch(() => '')
+  let lines = contents.trimEnd().split('\n').slice(-20).join('\n').trim()
+  return lines || '<no output>'
 }
 
 export function getGrapheneCache(root: string): string {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -158,10 +158,7 @@ export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: str
 
 async function sendSocketRequest({pageUrl, action, chart, log}: {pageUrl: string; action: 'check' | 'list'; chart?: string; log: (...args: any[]) => void}) {
   let host = runHost()
-  if (process.env.NODE_ENV !== 'test' && !(await isServerRunning())) {
-    log('Starting Graphene server...')
-    await runServeInBackground()
-  }
+  if (!(await ensureBackgroundServer(log))) return null
 
   let resp = await fetchSocketRequest({host, pageUrl, action, chart})
 
@@ -188,6 +185,20 @@ async function sendSocketRequest({pageUrl, action, chart, log}: {pageUrl: string
   }
 
   return resp
+}
+
+async function ensureBackgroundServer(log: (...args: any[]) => void) {
+  if (process.env.NODE_ENV === 'test' || (await isServerRunning())) return true
+
+  log('Starting Graphene server...')
+  try {
+    await runServeInBackground()
+    return true
+  } catch (err) {
+    log('Failed to start Graphene server')
+    log(err instanceof Error ? err.message : String(err))
+    return false
+  }
 }
 
 function markdownPageUrl(mdFile: string, inputs?: RunInputs) {
@@ -250,10 +261,7 @@ export async function proxyRunRequest(req: IncomingMessage, res: ServerResponse<
 }
 
 async function runHeadlessPageRequest({pageUrl, action, chart, log}: {pageUrl: string; action: 'check' | 'list'; chart?: string; log: (...args: any[]) => void}) {
-  if (process.env.NODE_ENV !== 'test' && !(await isServerRunning())) {
-    log('Starting Graphene server...')
-    await runServeInBackground()
-  }
+  if (!(await ensureBackgroundServer(log))) return null
 
   let host = runHost()
   let browser = await launchHeadlessBrowser(log)


### PR DESCRIPTION
Realized I forgot this change: When `graphene run` failed to start a background server (e.g. due to sandbox permissions) it would give a pretty cryptic error:

```
Starting Graphene server...
file:///Users/dylan/Code/example-nba/node_modules/@graphenedata/cli/dist/cli/chunk-OVWODUTJ.js:12200
      reject(new Error("Exited before server started"));
             ^

Error: Exited before server started
    at ChildProcess.<anonymous> (file:///Users/dylan/Code/example-nba/node_modules/@graphenedata/cli/dist/cli/chunk-OVWODUTJ.js:12200:14)
    at Object.onceWrapper (node:events:623:26)
    at ChildProcess.emit (node:events:508:28)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12)
```

This PR updates the error path to tail the serve log so that you can see the underlying error e.g.

```
Starting Graphene server...
Failed to start Graphene server
listen EPERM: operation not permitted 127.0.0.1:4000
```