### PR TITLE
Fix rows=all, DATE CLI formatting, folder URL redirect

### DIFF
--- a/cli/printer.ts
+++ b/cli/printer.ts
@@ -26,6 +26,19 @@ export function printDiagnostics(diags: GrapheneError[], log?: any) {
   if (parts.length) log(parts.join('\n\n'))
 }
 
+function formatValue(v: unknown): string {
+  if (v instanceof Date) {
+    if (v.getUTCHours() === 0 && v.getUTCMinutes() === 0 && v.getUTCSeconds() === 0 && v.getUTCMilliseconds() === 0) {
+      let y = v.getUTCFullYear()
+      let m = String(v.getUTCMonth() + 1).padStart(2, '0')
+      let d = String(v.getUTCDate()).padStart(2, '0')
+      return `${y}-${m}-${d}`
+    }
+    return v.toUTCString()
+  }
+  return v?.toString() ?? ''
+}
+
 export function printTable(rows: any[]) {
   if (!rows || rows.length === 0) {
     console.log(chalk.yellow('No results returned'))
@@ -36,7 +49,7 @@ export function printTable(rows: any[]) {
   let table = new Table({head: headers.map(h => chalk.blue(h))})
   let MAX_DISPLAY_ROWS = 200
   let displayRows = rows.slice(0, MAX_DISPLAY_ROWS)
-  displayRows.forEach(row => table.push(headers.map(h => row[h]?.toString() || '')))
+  displayRows.forEach(row => table.push(headers.map(h => formatValue(row[h]))))
   console.log(table.toString())
   if (rows.length > MAX_DISPLAY_ROWS) {
     console.log(chalk.yellow(`Displayed first ${MAX_DISPLAY_ROWS} rows (of ${rows.length} total).`))

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -343,6 +343,10 @@ const handleRequestPlugin = {
         if (!pathName || pathName == '/') pathName = 'index'
         let relativeMdPath = pathName.replace(/^\//, '') + '.md'
         let mdPath = path.join(config.root, relativeMdPath)
+        if (!mockFileMap[relativeMdPath] && !(await fs.exists(mdPath))) {
+          relativeMdPath = pathName.replace(/^\//, '') + '/index.md'
+          mdPath = path.join(config.root, relativeMdPath)
+        }
 
         if (mockFileMap[relativeMdPath] || (await fs.exists(mdPath))) {
           await handlePage(s, res)

--- a/ui/components/_Table.svelte
+++ b/ui/components/_Table.svelte
@@ -41,6 +41,7 @@
   }: Props = $props()
 
   let rowsNum = $derived.by(() => {
+    if (String(rows).toLowerCase() === 'all') return Infinity
     let parsed = Number.parseInt(String(rows), 10)
     return (!Number.isFinite(parsed) || parsed <= 0) ? 10 : parsed
   })

--- a/ui/components/_Table.svelte
+++ b/ui/components/_Table.svelte
@@ -270,6 +270,7 @@
   let displayedPageLength = $derived(paginated
     ? Math.min(rowsNum, (dataForDisplay?.length ?? 0) - rowsNum * (currentPage - 1))
     : dataForDisplay?.length ?? 0)
+  let rowNumberOffset = $derived(paginated ? rowsNum * (currentPage - 1) : 0)
 
   const goToPage = (page: number) => {
     if (!paginated) return
@@ -458,7 +459,7 @@
             groupNamePosition={groupNamePosition}
             orderedColumns={orderedColumns}
             columnLookup={columnLookup}
-            index={rowsNum * (currentPage - 1)}
+            index={rowNumberOffset}
           />
         {/if}
 

--- a/ui/internal/LocalApp.svelte
+++ b/ui/internal/LocalApp.svelte
@@ -19,7 +19,11 @@
   let navData = $state(navFiles)
   import.meta.hot?.accept('virtual:nav', mod => navData = mod.default)
 
-  let pathName = window.location.pathname.replace(/^\//, '') || 'index'
+  let pathName = window.location.pathname.replace(/^\//, '').replace(/\/$/, '') || 'index'
+  // Mirror the server-side folder redirect: if /foo.md doesn't exist but /foo/index.md does, load that.
+  if (pathName != 'index' && !navFiles.some(f => f.path == pathName + '.md') && navFiles.some(f => f.path == pathName + '/index.md')) {
+    pathName += '/index'
+  }
 
   // Track compile errors from both initial load and subsequent HMR failures.
   let compileError = $state<GrapheneError | null>(null)

--- a/ui/tests/table.test.ts
+++ b/ui/tests/table.test.ts
@@ -366,6 +366,7 @@ test('total row renders for ungrouped tables', async ({mount, sharedPage}) => {
   let table = component.locator('table')
   let totalRow = table.locator('tr.total-row')
   await expect(totalRow).toBeVisible()
+  await expect(table.locator('tr.table-row').first().locator('td.index')).toHaveText('1')
   await expect(totalRow).toContainText('10')
   await expect(component.locator('.table-container')).screenshot('total-row-basic')
 })
@@ -386,6 +387,7 @@ test('row-level link behavior opens external destinations and hides link column'
 
   let table = component.locator('table')
   await expect(table).toBeVisible()
+  await expect(table.locator('tr.table-row').first().locator('td.index')).toHaveText('1')
   await expect(table.getByRole('columnheader', {name: 'Url'})).toHaveCount(0)
 
   let noPopupPromise = sharedPage


### PR DESCRIPTION
## Summary

- **#57** — `rows=all` in Table now disables pagination by returning `Infinity` for `rowsNum`, making the `paginated` derived false
- **#164** — DATE values from Snowflake (raw JS `Date` objects at UTC midnight) now display as `YYYY-MM-DD` in CLI output instead of the verbose `toString()` form; other Date objects fall back to `toUTCString()`
- **#387** — Server middleware now falls back to `folder/index.md` when `folder.md` doesn't exist, enabling clean folder-path URLs; the client-side router mirrors the same fallback so the page actually renders

## Test plan

- [x] \`rows=all\` — visually verify a table renders all rows with no pagination controls; \`rows=5\` and default still paginate
- [x] DATE formatting — run a query returning a DATE column on Snowflake and confirm clean \`YYYY-MM-DD\` output
- [x] Folder URL redirect — add an \`index.md\` inside a subfolder of any example and confirm visiting the folder URL (without trailing slash) loads the page

Closes #57
Closes #164
Closes #387

https://claude.ai/code/session_01YUEwYq4Rxtmjd24pSAoXYt