### PR TITLE
Add CLA-check workflow

### DIFF
--- a/.github/scripts/cla-check.mjs
+++ b/.github/scripts/cla-check.mjs
@@ -1,0 +1,234 @@
+// CLA-check script. Runs in the cla-check.yml workflow on every PR open /
+// synchronize / reopen and on /recheck comments.
+//
+// Decision flow:
+//   1. Skip bots (`*[bot]`).
+//   2. If the PR author is a member of graphene-data, pass.
+//   3. Otherwise, look up the author in column C of the CLA signatures sheet.
+//      Signed → pass. Unsigned → fail and post (or update) a PR comment.
+//
+// Side effects: GitHub commit status on the PR head SHA, and at most one
+// PR comment identified by the marker below.
+
+import {createSign} from 'node:crypto'
+
+const ORG = 'graphene-data'
+const COMMENT_MARKER = '<!-- cla-check-bot -->'
+const STATUS_CONTEXT = 'CLA'
+
+function need(name) {
+  let v = process.env[name]
+  if (!v) throw new Error(`Missing env: ${name}`)
+  return v
+}
+
+async function ghFetch(token, path, init = {}) {
+  let res = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'graphene-cla-check',
+      ...(init.headers ?? {}),
+    },
+  })
+  return res
+}
+
+export async function isOrgMember(login, {fetchOrgMembership}) {
+  if (!login || login.endsWith('[bot]')) return true
+  return await fetchOrgMembership(login)
+}
+
+export async function isSignedInSheet(login, {fetchSignedUsernames}) {
+  let usernames = await fetchSignedUsernames()
+  let target = login.toLowerCase()
+  return usernames.some(u => u.toLowerCase() === target)
+}
+
+export async function runCheck(deps) {
+  let {author, log = console.log} = deps
+
+  if (!author) {
+    log('No PR author; nothing to check.')
+    return {decision: 'skip'}
+  }
+
+  if (author.endsWith('[bot]')) {
+    log(`Author ${author} is a bot; marking CLA as not required.`)
+    await deps.setStatus('success', 'Bot author — CLA not required')
+    return {decision: 'bot'}
+  }
+
+  if (await isOrgMember(author, deps)) {
+    log(`${author} is a member of ${ORG}; CLA not required.`)
+    await deps.setStatus('success', 'Internal contributor — CLA not required')
+    await deps.dismissCommentIfPresent()
+    return {decision: 'internal'}
+  }
+
+  if (await isSignedInSheet(author, deps)) {
+    log(`${author} is in the signatures sheet.`)
+    await deps.setStatus('success', 'CLA signed')
+    await deps.dismissCommentIfPresent()
+    return {decision: 'signed'}
+  }
+
+  log(`${author} has not signed; posting comment and failing status.`)
+  await deps.upsertComment(buildBlockingComment(author))
+  await deps.setStatus('failure', 'CLA not signed')
+  return {decision: 'unsigned'}
+}
+
+function buildBlockingComment(author) {
+  let url = `https://graphenedata.com/cla?username=${encodeURIComponent(author)}`
+  return [
+    COMMENT_MARKER,
+    `Hi @${author}, thanks for the contribution! Before we can merge, we need you to sign our Contributor License Agreement at ${url}.`,
+    '',
+    "Signing is a one-time thing — once your GitHub username is on file you're covered for any future contributions to this repo. After you submit the form, comment `/recheck` on this PR (or push a new commit) and I'll re-check.",
+  ].join('\n')
+}
+
+function buildClearedComment(author) {
+  return [COMMENT_MARKER, `Thanks for signing the CLA, @${author}! You're cleared to contribute — this check will stay green for any future PRs you open.`].join('\n')
+}
+
+// ----- Google service-account JWT → access token -----
+
+function b64url(input) {
+  return Buffer.from(input).toString('base64').replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '')
+}
+
+export async function getGoogleAccessToken(saKeyJson, scope = 'https://www.googleapis.com/auth/spreadsheets.readonly') {
+  let key = typeof saKeyJson === 'string' ? JSON.parse(saKeyJson) : saKeyJson
+  let now = Math.floor(Date.now() / 1000)
+  let header = b64url(JSON.stringify({alg: 'RS256', typ: 'JWT'}))
+  let claim = b64url(
+    JSON.stringify({
+      iss: key.client_email,
+      scope,
+      aud: 'https://oauth2.googleapis.com/token',
+      iat: now,
+      exp: now + 3600,
+    }),
+  )
+  let signer = createSign('RSA-SHA256')
+  signer.update(`${header}.${claim}`)
+  let sig = b64url(signer.sign(key.private_key))
+  let assertion = `${header}.${claim}.${sig}`
+
+  let res = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    }),
+  })
+  if (!res.ok) throw new Error(`Google token exchange failed: ${res.status} ${await res.text()}`)
+  let json = await res.json()
+  return json.access_token
+}
+
+export async function fetchSheetUsernames({sheetId, accessToken, range = 'Signatures!C:C'}) {
+  let url = `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${encodeURIComponent(range)}`
+  let res = await fetch(url, {headers: {Authorization: `Bearer ${accessToken}`}})
+  if (!res.ok) throw new Error(`Sheets API failed: ${res.status} ${await res.text()}`)
+  let json = await res.json()
+  let rows = json.values ?? []
+  // Drop the header row and any blanks; the first row is the column label.
+  return rows
+    .slice(1)
+    .map(row => (row?.[0] ?? '').toString().trim())
+    .filter(Boolean)
+}
+
+// ----- Real GitHub-flavored implementations of the deps -----
+
+async function buildLiveDeps() {
+  let githubToken = need('GITHUB_TOKEN')
+  let claBotToken = need('CLA_BOT_TOKEN')
+  let repo = need('REPO')
+  let prNumber = Number(need('PR_NUMBER'))
+  let author = need('PR_AUTHOR')
+
+  let pr = await ghFetch(githubToken, `/repos/${repo}/pulls/${prNumber}`).then(r => r.json())
+  let headSha = pr.head?.sha
+  if (!headSha) throw new Error(`Could not resolve head SHA for PR #${prNumber}`)
+
+  return {
+    author,
+    prNumber,
+
+    async fetchOrgMembership(login) {
+      let res = await ghFetch(claBotToken, `/orgs/${ORG}/members/${encodeURIComponent(login)}`)
+      if (res.status === 204) return true
+      if (res.status === 404 || res.status === 302) return false
+      throw new Error(`Org membership lookup failed: ${res.status} ${await res.text()}`)
+    },
+
+    async fetchSignedUsernames() {
+      let accessToken = await getGoogleAccessToken(need('GCP_SA_KEY'))
+      return fetchSheetUsernames({sheetId: need('SHEET_ID'), accessToken})
+    },
+
+    async setStatus(state, description) {
+      let res = await ghFetch(githubToken, `/repos/${repo}/statuses/${headSha}`, {
+        method: 'POST',
+        body: JSON.stringify({
+          state,
+          context: STATUS_CONTEXT,
+          description,
+          target_url: 'https://graphenedata.com/cla',
+        }),
+      })
+      if (!res.ok) throw new Error(`setStatus failed: ${res.status} ${await res.text()}`)
+    },
+
+    async upsertComment(body) {
+      let existing = await findBotComment(githubToken, repo, prNumber)
+      if (existing) {
+        let res = await ghFetch(githubToken, `/repos/${repo}/issues/comments/${existing.id}`, {
+          method: 'PATCH',
+          body: JSON.stringify({body}),
+        })
+        if (!res.ok) throw new Error(`comment update failed: ${res.status} ${await res.text()}`)
+      } else {
+        let res = await ghFetch(githubToken, `/repos/${repo}/issues/${prNumber}/comments`, {
+          method: 'POST',
+          body: JSON.stringify({body}),
+        })
+        if (!res.ok) throw new Error(`comment create failed: ${res.status} ${await res.text()}`)
+      }
+    },
+
+    async dismissCommentIfPresent() {
+      let existing = await findBotComment(githubToken, repo, prNumber)
+      if (!existing) return
+      let res = await ghFetch(githubToken, `/repos/${repo}/issues/comments/${existing.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({body: buildClearedComment(author)}),
+      })
+      if (!res.ok) throw new Error(`comment dismiss failed: ${res.status} ${await res.text()}`)
+    },
+  }
+}
+
+async function findBotComment(token, repo, prNumber) {
+  // PRs rarely have many comments; one page (default 30) is fine for v1.
+  let res = await ghFetch(token, `/repos/${repo}/issues/${prNumber}/comments?per_page=100`)
+  if (!res.ok) throw new Error(`list comments failed: ${res.status} ${await res.text()}`)
+  let comments = await res.json()
+  return comments.find(c => typeof c.body === 'string' && c.body.includes(COMMENT_MARKER))
+}
+
+// ----- CLI entry point -----
+
+const isMain = import.meta.url === `file://${process.argv[1]}`
+if (isMain) {
+  let deps = await buildLiveDeps()
+  let result = await runCheck(deps)
+  console.log('result:', result)
+}

--- a/.github/scripts/cla-check.test.mjs
+++ b/.github/scripts/cla-check.test.mjs
@@ -1,0 +1,106 @@
+import {describe, it, expect, vi} from 'vitest'
+
+import {runCheck, isSignedInSheet, isOrgMember} from './cla-check.mjs'
+
+function makeDeps(overrides = {}) {
+  let calls = {
+    setStatus: [],
+    upsertComment: [],
+    dismissed: 0,
+  }
+  return {
+    calls,
+    deps: {
+      author: 'octocat',
+      prNumber: 1,
+      log: () => {},
+      fetchOrgMembership: vi.fn().mockResolvedValue(false),
+      fetchSignedUsernames: vi.fn().mockResolvedValue([]),
+      setStatus: vi.fn(async (state, desc) => {
+        calls.setStatus.push({state, desc})
+      }),
+      upsertComment: vi.fn(async body => {
+        calls.upsertComment.push(body)
+      }),
+      dismissCommentIfPresent: vi.fn(async () => {
+        calls.dismissed += 1
+      }),
+      ...overrides,
+    },
+  }
+}
+
+describe('runCheck', () => {
+  it('skips bots with success', async () => {
+    let {deps, calls} = makeDeps({author: 'dependabot[bot]'})
+    let r = await runCheck(deps)
+    expect(r.decision).toBe('bot')
+    expect(calls.setStatus).toEqual([{state: 'success', desc: 'Bot author — CLA not required'}])
+    expect(deps.fetchOrgMembership).not.toHaveBeenCalled()
+    expect(deps.fetchSignedUsernames).not.toHaveBeenCalled()
+    expect(calls.upsertComment).toEqual([])
+  })
+
+  it('passes internal org members and dismisses any prior comment', async () => {
+    let {deps, calls} = makeDeps({
+      fetchOrgMembership: vi.fn().mockResolvedValue(true),
+    })
+    let r = await runCheck(deps)
+    expect(r.decision).toBe('internal')
+    expect(calls.setStatus[0].state).toBe('success')
+    expect(calls.dismissed).toBe(1)
+    expect(deps.fetchSignedUsernames).not.toHaveBeenCalled()
+  })
+
+  it('passes external signers (case insensitive match)', async () => {
+    let {deps, calls} = makeDeps({
+      author: 'OctoCat',
+      fetchSignedUsernames: vi.fn().mockResolvedValue(['someone-else', 'octocat']),
+    })
+    let r = await runCheck(deps)
+    expect(r.decision).toBe('signed')
+    expect(calls.setStatus[0].state).toBe('success')
+    expect(calls.dismissed).toBe(1)
+    expect(calls.upsertComment).toEqual([])
+  })
+
+  it('blocks unsigned external contributors with comment + failing status', async () => {
+    let {deps, calls} = makeDeps({
+      fetchSignedUsernames: vi.fn().mockResolvedValue(['someone-else']),
+    })
+    let r = await runCheck(deps)
+    expect(r.decision).toBe('unsigned')
+    expect(calls.setStatus[0].state).toBe('failure')
+    expect(calls.upsertComment).toHaveLength(1)
+    expect(calls.upsertComment[0]).toContain('<!-- cla-check-bot -->')
+    expect(calls.upsertComment[0]).toContain('graphenedata.com/cla?username=octocat')
+    expect(calls.dismissed).toBe(0)
+  })
+})
+
+describe('isSignedInSheet', () => {
+  it('handles empty sheets', async () => {
+    let signed = await isSignedInSheet('anyone', {fetchSignedUsernames: async () => []})
+    expect(signed).toBe(false)
+  })
+
+  it('matches case-insensitively', async () => {
+    let usernames = ['Hubot', 'OctoCat']
+    expect(await isSignedInSheet('octocat', {fetchSignedUsernames: async () => usernames})).toBe(true)
+    expect(await isSignedInSheet('OCTOCAT', {fetchSignedUsernames: async () => usernames})).toBe(true)
+    expect(await isSignedInSheet('someone-else', {fetchSignedUsernames: async () => usernames})).toBe(false)
+  })
+})
+
+describe('isOrgMember', () => {
+  it('short-circuits bots without making a call', async () => {
+    let fetchOrgMembership = vi.fn()
+    expect(await isOrgMember('renovate[bot]', {fetchOrgMembership})).toBe(true)
+    expect(fetchOrgMembership).not.toHaveBeenCalled()
+  })
+
+  it('delegates to fetchOrgMembership for humans', async () => {
+    expect(await isOrgMember('octocat', {fetchOrgMembership: async () => true})).toBe(true)
+    expect(await isOrgMember('octocat', {fetchOrgMembership: async () => false})).toBe(false)
+  })
+})

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,33 @@
+name: CLA Check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  statuses: write
+  contents: read
+
+jobs:
+  cla-check:
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event.issue.pull_request && github.event.comment.body == '/recheck')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: node .github/scripts/cla-check.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLA_BOT_TOKEN: ${{ secrets.CLA_BOT_TOKEN }}
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+          SHEET_ID: ${{ secrets.CLA_SHEET_ID }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to Graphene
+
+Thanks for taking an interest in Graphene! Patches, bug reports, and ideas are all welcome.
+
+## Contributor License Agreement
+
+Before we can merge your first pull request, we need you to sign our Contributor License Agreement at <https://graphenedata.com/cla>. Signing under your GitHub username is a one-time thing — once your username is on file, you're covered for any future contributions to this repo.
+
+If you open a PR before signing, our `CLA` check will fail and our bot will leave a comment with the link. After you sign, comment `/recheck` on the PR (or push another commit) and the check will re-run.
+
+Contributors who are members of the `graphene-data` GitHub organization are exempt.
+
+## Development
+
+See [`AGENTS.md`](./AGENTS.md) for an overview of the repo layout, the CLI commands, our tech stack, and how we run tests.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -110,4 +110,16 @@ export default [
       'no-case-declarations': 'off',
     },
   },
+  {
+    files: ['.github/scripts/**/*.{js,mjs}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {...globals.node},
+    },
+    rules: {
+      'no-console': 'off',
+      'require-await': 'off', // vitest mocks are routinely async-typed without awaiting
+    },
+  },
 ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -64,6 +64,13 @@ export default defineConfig({
           include: ['language-server/**/*.test.ts'],
         },
       },
+      {
+        extends: true,
+        test: {
+          name: 'scripts',
+          include: ['.github/scripts/*.test.mjs'],
+        },
+      },
     ],
   },
 })


### PR DESCRIPTION
Adds a GH automation to automate the CLA signing requirement for all contributors outside the Graphene org.

## How it works
`.github/workflows/cla-check.yml` runs on `pull_request_target` (opened / synchronize / reopened) and on `issue_comment` whose body is exactly `/recheck`. The actual logic lives in `.github/scripts/cla-check.mjs` — plain Node 24, no bundler, no `googleapis` dep. The decision tree:

1. Author ends in `[bot]` → green status, done.
2. `GET /orgs/graphene-data/members/{author}` via `CLA_BOT_TOKEN` (PAT with `read:org`). 204 → internal contributor, green status, any prior bot comment is rewritten to a thank-you.
3. Service-account JWT exchange → access token → `GET /v4/spreadsheets/{SHEET_ID}/values/Signatures!C:C`. Case-insensitive match against the author's login. Signed → green, comment cleared.
4. Otherwise → upsert a single PR comment (identified by a hidden `<!-- cla-check-bot -->` marker) pointing at `https://graphenedata.com/cla?username={author}` and set a failing `CLA` status. Comment again on `synchronize` / `/recheck` is a PATCH on the existing comment, not a new one, so the PR doesn't get spammed.

## Secrets it needs
All already configured on this repo (`gh secret list` shows them):
- `CLA_BOT_TOKEN` — PAT with `Organization → Members: Read-only` on `graphene-data`
- `GCP_SA_KEY` — service-account JSON for `cla-check@cogent-tine-496114-n7.iam.gserviceaccount.com`
- `CLA_SHEET_ID` — `1ly7aRBY0Ozm3oYJixoviZ582efQaQENifxedxseoCBw`

## Testability
The script splits the pure decision logic (`runCheck`) from the I/O (a `buildLiveDeps()` factory) so the unit tests can inject fake `fetchOrgMembership` / `fetchSignedUsernames` / `setStatus` / `upsertComment` deps without ever hitting GitHub or Sheets. Vitest gets a new `scripts` project covering `.github/scripts/*.test.mjs`; the four cases that matter (bot, internal org member, signed external, unsigned external) plus a couple of helper-function tests come out to 8 assertions.

ESLint config gets a small override for `.github/scripts/**/*.{js,mjs}` (Node globals + `require-await` off for vitest mocks) so the script lints under the existing rules.

## CONTRIBUTING.md
New file with a short note pointing external contributors at `/cla` before they open a PR, plus a link to `AGENTS.md` for the rest of the dev story.

## Test plan
- [ ] `pnpm lint` clean
- [ ] `pnpm vitest run --project scripts` — 8 tests green
- [ ] After merge, open a test PR from a non-`graphene-data` account → bot comments + status fails
- [ ] Sign the form at graphenedata.com/cla with that test account's username
- [ ] Comment `/recheck` on the test PR → bot updates comment to "thanks for signing", status flips green

## Known follow-ups
- The `check-commit-authors` job currently allowlists only Grant / Dylan / Kevin. Commits on this branch are authored as `Claude <noreply@anthropic.com>` and will fail that check; the easiest fix is a local rebase + `git commit --amend --author=…` before merging.
- 4 pre-existing `svelte/no-navigation-without-resolve` errors are surfacing on `pnpm lint` for some Node versions (`ui/components/TableRow.svelte:174`, `ui/internal/PageNavGroup.svelte:206/237`, `ui/internal/StyleGallery.svelte:120`). Unrelated to this PR but will block CI; worth fixing separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_011KXMxGCjFmy1eNSYx2JY6L)_