### PR TITLE
warehouse-backed query caching

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -105,7 +105,7 @@ program
       let analysis = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: gsql})}, 'input')
       let [query] = validateInputQuery(analysis, exit)
       let sql = renderSql(query, inputs, exit)
-      let res = await runQuery(sql, {cache: true})
+      let res = await runQuery(sql, {queryCache: 'read-write'})
       printTable(res.rows)
     }),
   )

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -105,7 +105,7 @@ program
       let analysis = analyzeWorkspace({config, files: files.filter(file => file.path != 'input').concat({path: 'input', contents: gsql})}, 'input')
       let [query] = validateInputQuery(analysis, exit)
       let sql = renderSql(query, inputs, exit)
-      let res = await runQuery(sql)
+      let res = await runQuery(sql, {cache: true})
       printTable(res.rows)
     }),
   )

--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -31,7 +31,13 @@ export class BigQueryConnection implements QueryConnection {
     let totalRows = Number(metadata?.statistics?.query?.totalRows ?? rows.length)
     normalizeBigQueryRows(rows)
 
-    return {rows, totalRows, queryCacheRef: {provider: 'bigquery', projectId: this.projectId, jobId: job.id, location: job.location}}
+    return {
+      rows,
+      totalRows,
+      ...(options.queryCache && options.queryCache != 'none'
+        ? {cache: {provider: 'bigquery' as const, ref: {provider: 'bigquery' as const, projectId: this.projectId, jobId: job.id, location: job.location}}}
+        : {}),
+    }
   }
 
   async retrieveCachedQuery(entry: QueryCacheEntry): Promise<QueryResult> {

--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -13,15 +13,12 @@ export class BigQueryConnection implements QueryConnection {
   private readonly client: BigQuery
   private readonly projectId: string
   private readonly defaultNamespace?: string
-  private readonly location?: string
   private readonly clientEmail?: string
 
   constructor(options: BigQueryOptions = {}) {
     options.projectId ||= config.bigquery?.projectId
-    options.location ||= config.bigquery?.location
     if (!options.projectId) throw new Error('projectId must be set in config or provided in service account credentials')
     this.projectId = options.projectId
-    this.location = options.location
     this.clientEmail = (options.credentials as any)?.client_email
     this.client = new BigQuery({...options, userAgent: 'Graphene'})
     this.defaultNamespace = config.defaultNamespace
@@ -29,20 +26,20 @@ export class BigQueryConnection implements QueryConnection {
 
   async runQuery(sql: string, options: QueryOptions = {}): Promise<QueryResult> {
     let {params} = options
-    let [job] = await this.client.createQueryJob({query: sql, useLegacySql: false, params, location: this.location})
+    let [job] = await this.client.createQueryJob({query: sql, useLegacySql: false, params})
     let [rows] = await job.getQueryResults({maxResults: 10000})
     let metadata = job.metadata || (await job.getMetadata())[0]
     let totalRows = Number(metadata?.statistics?.query?.totalRows ?? rows.length)
     normalizeBigQueryRows(rows)
 
-    return {rows, totalRows, queryCacheRef: {provider: 'bigquery', projectId: this.projectId, jobId: job.id, location: job.location || this.location}}
+    return {rows, totalRows, queryCacheRef: {provider: 'bigquery', projectId: this.projectId, jobId: job.id, location: job.location}}
   }
 
   async retrieveCachedQuery(entry: QueryCacheEntry): Promise<QueryResult> {
     let jobId = String(entry.ref.jobId || '')
     if (!jobId) throw new Error('BigQuery cache entry is missing jobId')
 
-    let job = this.client.job(jobId, {location: String(entry.ref.location || this.location || '') || undefined})
+    let job = this.client.job(jobId, {location: String(entry.ref.location || '') || undefined})
     let [rows] = await job.getQueryResults({maxResults: 10000})
     let metadata = job.metadata || (await job.getMetadata())[0]
     let totalRows = Number(metadata?.statistics?.query?.totalRows ?? rows.length)
@@ -51,7 +48,7 @@ export class BigQueryConnection implements QueryConnection {
   }
 
   queryCacheIdentity() {
-    return {projectId: this.projectId, location: this.location || '', clientEmail: this.clientEmail || '', defaultNamespace: this.defaultNamespace || ''}
+    return {projectId: this.projectId, clientEmail: this.clientEmail || '', defaultNamespace: this.defaultNamespace || ''}
   }
 
   async listDatasets(): Promise<string[]> {

--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -1,7 +1,7 @@
 import {BigQuery, BigQueryDate, BigQueryTimestamp, type BigQueryOptions} from '@google-cloud/bigquery'
 
 import {config} from '../../lang/config.ts'
-import {type QueryConnection, type QueryResult, type SchemaColumn, type QueryParams} from './types.ts'
+import {type QueryConnection, type QueryResult, type SchemaColumn, type QueryCacheEntry, type QueryOptions} from './types.ts'
 
 // BigQuery identifiers can contain letters, numbers, underscores, and hyphens
 function validateBigQueryIdent(ident: string) {
@@ -9,32 +9,49 @@ function validateBigQueryIdent(ident: string) {
 }
 
 export class BigQueryConnection implements QueryConnection {
+  queryCacheProvider = 'bigquery' as const
   private readonly client: BigQuery
   private readonly projectId: string
   private readonly defaultNamespace?: string
+  private readonly location?: string
+  private readonly clientEmail?: string
 
   constructor(options: BigQueryOptions = {}) {
     options.projectId ||= config.bigquery?.projectId
+    options.location ||= config.bigquery?.location
     if (!options.projectId) throw new Error('projectId must be set in config or provided in service account credentials')
     this.projectId = options.projectId
+    this.location = options.location
+    this.clientEmail = (options.credentials as any)?.client_email
     this.client = new BigQuery({...options, userAgent: 'Graphene'})
     this.defaultNamespace = config.defaultNamespace
   }
 
-  async runQuery(sql: string, params?: QueryParams): Promise<QueryResult> {
-    let [job] = await this.client.createQueryJob({query: sql, useLegacySql: false, params})
+  async runQuery(sql: string, options: QueryOptions = {}): Promise<QueryResult> {
+    let {params} = options
+    let [job] = await this.client.createQueryJob({query: sql, useLegacySql: false, params, location: this.location})
     let [rows] = await job.getQueryResults({maxResults: 10000})
     let metadata = job.metadata || (await job.getMetadata())[0]
     let totalRows = Number(metadata?.statistics?.query?.totalRows ?? rows.length)
+    normalizeBigQueryRows(rows)
 
-    rows.forEach(r => {
-      Object.entries(r).forEach(([k, v]) => {
-        if (v instanceof BigQueryTimestamp) r[k] = v.value
-        if (v instanceof BigQueryDate) r[k] = v.value
-      })
-    })
+    return {rows, totalRows, queryCacheRef: {provider: 'bigquery', projectId: this.projectId, jobId: job.id, location: job.location || this.location}}
+  }
 
+  async runCachedQuery(entry: QueryCacheEntry): Promise<QueryResult> {
+    let jobId = String(entry.ref.jobId || '')
+    if (!jobId) throw new Error('BigQuery cache entry is missing jobId')
+
+    let job = this.client.job(jobId, {location: String(entry.ref.location || this.location || '') || undefined})
+    let [rows] = await job.getQueryResults({maxResults: 10000})
+    let metadata = job.metadata || (await job.getMetadata())[0]
+    let totalRows = Number(metadata?.statistics?.query?.totalRows ?? rows.length)
+    normalizeBigQueryRows(rows)
     return {rows, totalRows}
+  }
+
+  queryCacheIdentity() {
+    return {projectId: this.projectId, location: this.location || '', clientEmail: this.clientEmail || '', defaultNamespace: this.defaultNamespace || ''}
   }
 
   async listDatasets(): Promise<string[]> {
@@ -67,7 +84,7 @@ export class BigQueryConnection implements QueryConnection {
       where lower(table_name) = lower(@table)
       order by ordinal_position
     `.trim()
-    let res = await this.runQuery(sql, {table})
+    let res = await this.runQuery(sql, {params: {table}})
     return res.rows.map(row => {
       return {name: String(row['column_name']).toLowerCase(), dataType: String(row['data_type'])}
     })
@@ -79,4 +96,13 @@ export class BigQueryConnection implements QueryConnection {
   }
 
   async close(): Promise<void> {}
+}
+
+function normalizeBigQueryRows(rows: any[]) {
+  rows.forEach(r => {
+    Object.entries(r).forEach(([k, v]) => {
+      if (v instanceof BigQueryTimestamp) r[k] = v.value
+      if (v instanceof BigQueryDate) r[k] = v.value
+    })
+  })
 }

--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -38,7 +38,7 @@ export class BigQueryConnection implements QueryConnection {
     return {rows, totalRows, queryCacheRef: {provider: 'bigquery', projectId: this.projectId, jobId: job.id, location: job.location || this.location}}
   }
 
-  async runCachedQuery(entry: QueryCacheEntry): Promise<QueryResult> {
+  async retrieveCachedQuery(entry: QueryCacheEntry): Promise<QueryResult> {
     let jobId = String(entry.ref.jobId || '')
     if (!jobId) throw new Error('BigQuery cache entry is missing jobId')
 

--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -9,7 +9,6 @@ function validateBigQueryIdent(ident: string) {
 }
 
 export class BigQueryConnection implements QueryConnection {
-  queryCacheProvider = 'bigquery' as const
   private readonly client: BigQuery
   private readonly projectId: string
   private readonly defaultNamespace?: string
@@ -48,7 +47,7 @@ export class BigQueryConnection implements QueryConnection {
   }
 
   queryCacheIdentity() {
-    return {projectId: this.projectId, clientEmail: this.clientEmail || '', defaultNamespace: this.defaultNamespace || ''}
+    return {provider: 'bigquery' as const, projectId: this.projectId, clientEmail: this.clientEmail || '', defaultNamespace: this.defaultNamespace || ''}
   }
 
   async listDatasets(): Promise<string[]> {

--- a/cli/connections/clickhouse.ts
+++ b/cli/connections/clickhouse.ts
@@ -1,6 +1,6 @@
 import {createClient, type ClickHouseClient} from '@clickhouse/client'
 
-import {type QueryConnection, type QueryResult, type SchemaColumn, type QueryOptions} from './types.ts'
+import {type QueryConnection, type QueryResult, type SchemaColumn, type QueryOptions, type QueryCacheStatus} from './types.ts'
 
 export interface ClickHouseOptions {
   url: string
@@ -34,7 +34,7 @@ export class ClickHouseConnection implements QueryConnection {
       ...(useQueryCache ? {clickhouse_settings: {use_query_cache: 1, query_cache_ttl: 86400}} : {}),
     })
     let rows = (await result.json()) as Array<Record<string, unknown>>
-    return {rows, totalRows: rows.length, ...(useQueryCache ? {cache: {status: 'delegated' as const, provider: 'clickhouse' as const}} : {})}
+    return {rows, totalRows: rows.length, ...(useQueryCache ? {cache: clickHouseCacheStatus(result.response_headers)} : {})}
   }
 
   queryCacheIdentity() {
@@ -84,4 +84,21 @@ export class ClickHouseConnection implements QueryConnection {
 
 function escapeClickHouseString(value: string) {
   return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
+function clickHouseCacheStatus(headers: Record<string, string | string[] | undefined>): QueryCacheStatus {
+  let cache: QueryCacheStatus = {status: 'delegated', provider: 'clickhouse'}
+  let age = Number(headerValue(headers, 'age'))
+  if (Number.isFinite(age)) {
+    cache.createdAt = Date.now() - age * 1000
+  }
+
+  let expiresAt = Date.parse(headerValue(headers, 'expires') || '')
+  if (Number.isFinite(expiresAt)) cache.expiresAt = expiresAt
+  return cache
+}
+
+function headerValue(headers: Record<string, string | string[] | undefined>, name: string) {
+  let value = headers[name] || headers[name.toLowerCase()] || headers[name.toUpperCase()]
+  return Array.isArray(value) ? value[0] : value
 }

--- a/cli/connections/clickhouse.ts
+++ b/cli/connections/clickhouse.ts
@@ -11,7 +11,6 @@ export interface ClickHouseOptions {
 }
 
 export class ClickHouseConnection implements QueryConnection {
-  queryCacheProvider = 'clickhouse' as const
   private client: ClickHouseClient
   private defaultDatabase: string
 
@@ -36,6 +35,10 @@ export class ClickHouseConnection implements QueryConnection {
     })
     let rows = (await result.json()) as Array<Record<string, unknown>>
     return {rows, totalRows: rows.length, ...(useQueryCache ? {cache: {status: 'delegated' as const, provider: 'clickhouse' as const}} : {})}
+  }
+
+  queryCacheIdentity() {
+    return {provider: 'clickhouse' as const, database: this.defaultDatabase}
   }
 
   async listDatasets(): Promise<string[]> {

--- a/cli/connections/clickhouse.ts
+++ b/cli/connections/clickhouse.ts
@@ -28,14 +28,14 @@ export class ClickHouseConnection implements QueryConnection {
   }
 
   async runQuery(sql: string, options: QueryOptions = {}): Promise<QueryResult> {
-    let {cache} = options
+    let useQueryCache = options.queryCache && options.queryCache != 'none'
     let result = await this.client.query({
       query: sql,
       format: 'JSONEachRow',
-      ...(cache ? {clickhouse_settings: {use_query_cache: 1, query_cache_ttl: 86400}} : {}),
+      ...(useQueryCache ? {clickhouse_settings: {use_query_cache: 1, query_cache_ttl: 86400}} : {}),
     })
     let rows = (await result.json()) as Array<Record<string, unknown>>
-    return {rows, totalRows: rows.length, ...(cache ? {cache: {status: 'delegated' as const, provider: 'clickhouse' as const}} : {})}
+    return {rows, totalRows: rows.length, ...(useQueryCache ? {cache: {status: 'delegated' as const, provider: 'clickhouse' as const}} : {})}
   }
 
   async listDatasets(): Promise<string[]> {

--- a/cli/connections/clickhouse.ts
+++ b/cli/connections/clickhouse.ts
@@ -87,7 +87,7 @@ function escapeClickHouseString(value: string) {
 }
 
 function clickHouseCacheStatus(headers: Record<string, string | string[] | undefined>): QueryCacheStatus {
-  let cache: QueryCacheStatus = {status: 'delegated', provider: 'clickhouse'}
+  let cache: QueryCacheStatus = {provider: 'clickhouse'}
   let age = Number(headerValue(headers, 'age'))
   if (Number.isFinite(age)) {
     cache.createdAt = Date.now() - age * 1000

--- a/cli/connections/clickhouse.ts
+++ b/cli/connections/clickhouse.ts
@@ -1,6 +1,6 @@
 import {createClient, type ClickHouseClient} from '@clickhouse/client'
 
-import {type QueryConnection, type QueryResult, type QueryParams, type SchemaColumn} from './types.ts'
+import {type QueryConnection, type QueryResult, type SchemaColumn, type QueryOptions} from './types.ts'
 
 export interface ClickHouseOptions {
   url: string
@@ -11,6 +11,7 @@ export interface ClickHouseOptions {
 }
 
 export class ClickHouseConnection implements QueryConnection {
+  queryCacheProvider = 'clickhouse' as const
   private client: ClickHouseClient
   private defaultDatabase: string
 
@@ -26,10 +27,15 @@ export class ClickHouseConnection implements QueryConnection {
     })
   }
 
-  async runQuery(sql: string, _params?: QueryParams): Promise<QueryResult> {
-    let result = await this.client.query({query: sql, format: 'JSONEachRow'})
+  async runQuery(sql: string, options: QueryOptions = {}): Promise<QueryResult> {
+    let {cache} = options
+    let result = await this.client.query({
+      query: sql,
+      format: 'JSONEachRow',
+      ...(cache ? {clickhouse_settings: {use_query_cache: 1, query_cache_ttl: 86400}} : {}),
+    })
     let rows = (await result.json()) as Array<Record<string, unknown>>
-    return {rows, totalRows: rows.length}
+    return {rows, totalRows: rows.length, ...(cache ? {cache: {status: 'delegated' as const, provider: 'clickhouse' as const}} : {})}
   }
 
   async listDatasets(): Promise<string[]> {

--- a/cli/connections/duckdb.ts
+++ b/cli/connections/duckdb.ts
@@ -3,7 +3,7 @@ import {promises as fs} from 'fs'
 import path from 'path'
 
 import {config} from '../../lang/config.ts'
-import {type QueryResult, type QueryConnection, type SchemaColumn, type QueryParams} from './types.ts'
+import {type QueryResult, type QueryConnection, type SchemaColumn, type QueryOptions} from './types.ts'
 
 interface DuckDbOptions {
   path?: string
@@ -36,7 +36,8 @@ export class DuckDBConnection implements QueryConnection {
     await this.connection.run('use graphene_cli;')
   }
 
-  async runQuery(sql: string, params?: QueryParams): Promise<QueryResult> {
+  async runQuery(sql: string, options: QueryOptions = {}): Promise<QueryResult> {
+    let {params} = options
     await this.ready
     let reader = params ? await this.connection!.runAndReadAll(sql, params as any) : await this.connection!.runAndReadAll(sql)
     let rows = reader.getRowObjects().map(record => {
@@ -82,7 +83,7 @@ export class DuckDBConnection implements QueryConnection {
       order by ordinal_position
     `.trim()
     let params = schema ? [table, schema] : [table]
-    let res = await this.runQuery(sql, params)
+    let res = await this.runQuery(sql, {params})
     return res.rows.map(row => {
       return {name: String(row['column_name']).toLowerCase(), dataType: String(row['data_type'])}
     })

--- a/cli/connections/index.ts
+++ b/cli/connections/index.ts
@@ -2,7 +2,8 @@ import {readFileSync} from 'fs'
 
 import {config} from '../../lang/config.ts'
 import {authenticatedFetch} from '../auth.ts'
-import {type QueryResult, type QueryConnection, type QueryParams} from './types.ts'
+import {runWithQueryCache} from './queryCache.ts'
+import {type QueryResult, type QueryConnection, type QueryOptions} from './types.ts'
 
 // Reads credentials from environment variables and passes them to the connection constructors.
 // The connection classes themselves have no env-reading logic — this keeps the cloud server
@@ -18,7 +19,7 @@ export async function getConnection(): Promise<QueryConnection> {
     } else if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
       // env var is the path of a json cred file
       let parsed = JSON.parse(readFileSync(process.env.GOOGLE_APPLICATION_CREDENTIALS, {encoding: 'utf-8'}))
-      options = {projectId: parsed.project_id}
+      options = {projectId: parsed.project_id, credentials: parsed}
     }
     return new mod.BigQueryConnection(options)
   } else if (config.dialect === 'duckdb') {
@@ -64,19 +65,20 @@ async function importConnection<T>(load: () => Promise<T>, packageName: string, 
   }
 }
 
-export async function runQuery(sql: string, params?: QueryParams): Promise<QueryResult> {
+export async function runQuery(sql: string, options: QueryOptions = {}): Promise<QueryResult> {
   if (config.host) {
     let resp = await authenticatedFetch('/_api/query', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({sql, params}),
+      body: JSON.stringify({sql, ...options}),
     })
     return await resp.json()
   }
 
   let conn = await getConnection()
   try {
-    return await conn.runQuery(sql, params)
+    if (options.cache) return await runWithQueryCache(conn, sql, options)
+    return await conn.runQuery(sql, options)
   } finally {
     await conn.close()
   }

--- a/cli/connections/index.ts
+++ b/cli/connections/index.ts
@@ -77,7 +77,7 @@ export async function runQuery(sql: string, options: QueryOptions = {}): Promise
 
   let conn = await getConnection()
   try {
-    if (options.cache) return await runWithQueryCache(conn, sql, options)
+    if (options.queryCache && options.queryCache != 'none') return await runWithQueryCache(conn, sql, options)
     return await conn.runQuery(sql, options)
   } finally {
     await conn.close()

--- a/cli/connections/queryCache.ts
+++ b/cli/connections/queryCache.ts
@@ -29,7 +29,7 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
 
   if (!conn.retrieveCachedQuery) {
     let res = await conn.runQuery(sql, {...options, queryCache: options.queryCache || 'read-write'})
-    return withCacheStatus(res, res.cache || {status: 'delegated', provider})
+    return withCacheStatus(res, res.cache || {provider})
   }
 
   let store = new LocalQueryCacheStore(config.root)
@@ -44,13 +44,13 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
       if (entry && entry.expiresAt > now && entry.contextHash == contextHash && entry.provider == provider) {
         try {
           let res = await conn.retrieveCachedQuery(entry)
-          return withCacheStatus(res, {status: 'hit', provider, createdAt: entry.createdAt, expiresAt: entry.expiresAt})
+          return withCacheStatus(res, {provider, createdAt: entry.createdAt, expiresAt: entry.expiresAt})
         } catch (err) {
           await store.delete(key)
           throw err
         }
       }
-      if (entry) return withCacheStatus(await runFreshAndStore(conn, store, key, contextHash, sql, params, provider, now), {status: 'miss', provider})
+      if (entry) return withCacheStatus(await runFreshAndStore(conn, store, key, contextHash, sql, params, provider, now), {provider})
     } catch (err) {
       logCacheFallback(err)
       return await conn.runQuery(sql, {params})
@@ -59,7 +59,7 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
 
   try {
     let res = await runFreshAndStore(conn, store, key, contextHash, sql, params, provider, now)
-    return withCacheStatus(res, {status: 'miss', provider})
+    return withCacheStatus(res, {provider})
   } catch (err) {
     logCacheFallback(err)
     return await conn.runQuery(sql, {params})

--- a/cli/connections/queryCache.ts
+++ b/cli/connections/queryCache.ts
@@ -25,7 +25,7 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
   let provider = conn.queryCacheProvider
   if (!provider || config.queryCache === false) return await conn.runQuery(sql, {params})
 
-  if (!conn.runCachedQuery) {
+  if (!conn.retrieveCachedQuery) {
     let res = await conn.runQuery(sql, {...options, queryCache: options.queryCache || 'read-write'})
     return withCacheStatus(res, res.cache || {status: 'delegated', provider})
   }
@@ -41,7 +41,7 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
       let entry = await store.get(key)
       if (entry && entry.expiresAt > now && entry.contextHash == contextHash && entry.provider == provider) {
         try {
-          let res = await conn.runCachedQuery(entry)
+          let res = await conn.retrieveCachedQuery(entry)
           return withCacheStatus(res, {status: 'hit', provider})
         } catch (err) {
           await store.delete(key)

--- a/cli/connections/queryCache.ts
+++ b/cli/connections/queryCache.ts
@@ -7,6 +7,7 @@ import {type QueryCacheEntry, type QueryConnection, type QueryOptions, type Quer
 
 const CACHE_VERSION = 1
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const fileLocks = new Map<string, Promise<void>>()
 
 interface QueryCacheFile {
   version: number
@@ -118,28 +119,34 @@ export class LocalQueryCacheStore implements QueryCacheStore {
     let filePath = await this.filePath()
     if (!filePath) return
 
-    let state = await this.read()
-    state.entries[entry.key] = entry
-    await this.write(filePath, state)
+    await withFileLock(filePath, async () => {
+      let state = await this.read()
+      state.entries[entry.key] = entry
+      await this.write(filePath, state)
+    })
   }
 
   async delete(key: string): Promise<void> {
     let filePath = await this.filePath()
     if (!filePath) return
 
-    let state = await this.read()
-    delete state.entries[key]
-    await this.write(filePath, state)
+    await withFileLock(filePath, async () => {
+      let state = await this.read()
+      delete state.entries[key]
+      await this.write(filePath, state)
+    })
   }
 
   async prune(now = Date.now()): Promise<void> {
     let filePath = await this.filePath()
     if (!filePath) return
 
-    let state = await this.read()
-    let entries = Object.fromEntries(Object.entries(state.entries).filter(([, entry]) => entry.expiresAt > now))
-    if (Object.keys(entries).length == Object.keys(state.entries).length) return
-    await this.write(filePath, {...state, entries})
+    await withFileLock(filePath, async () => {
+      let state = await this.read()
+      let entries = Object.fromEntries(Object.entries(state.entries).filter(([, entry]) => entry.expiresAt > now))
+      if (Object.keys(entries).length == Object.keys(state.entries).length) return
+      await this.write(filePath, {...state, entries})
+    })
   }
 
   private async read(): Promise<QueryCacheFile> {
@@ -175,6 +182,17 @@ export class LocalQueryCacheStore implements QueryCacheStore {
 
 function defaultState(): QueryCacheFile {
   return {version: CACHE_VERSION, entries: {}}
+}
+
+async function withFileLock(filePath: string, fn: () => Promise<void>) {
+  let previous = fileLocks.get(filePath) || Promise.resolve()
+  let current = previous.catch(() => {}).then(fn)
+  fileLocks.set(filePath, current)
+  try {
+    await current
+  } finally {
+    if (fileLocks.get(filePath) === current) fileLocks.delete(filePath)
+  }
 }
 
 function hashValue(value: unknown) {

--- a/cli/connections/queryCache.ts
+++ b/cli/connections/queryCache.ts
@@ -26,7 +26,7 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
   if (!provider || config.queryCache === false) return await conn.runQuery(sql, {params})
 
   if (!conn.runCachedQuery) {
-    let res = await conn.runQuery(sql, {...options, cache: true})
+    let res = await conn.runQuery(sql, {...options, queryCache: options.queryCache || 'read-write'})
     return withCacheStatus(res, res.cache || {status: 'delegated', provider})
   }
 
@@ -35,7 +35,7 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
   let key = hashValue({version: CACHE_VERSION, dialect: config.dialect, root: config.root, sql, params: params || null, contextHash})
   let now = Date.now()
 
-  if (!options.bypassCache) {
+  if (options.queryCache != 'refresh') {
     try {
       await store.prune(now)
       let entry = await store.get(key)

--- a/cli/connections/queryCache.ts
+++ b/cli/connections/queryCache.ts
@@ -23,7 +23,7 @@ export interface QueryCacheStore {
 export async function runWithQueryCache(conn: QueryConnection, sql: string, options: QueryOptions = {}): Promise<QueryResult> {
   let {params} = options
   let identity = conn.queryCacheIdentity?.()
-  if (!identity || config.queryCache === false) return await conn.runQuery(sql, {params})
+  if (!identity || config.queryCache !== true) return await conn.runQuery(sql, {params})
   let provider = identity.provider
 
   if (!conn.retrieveCachedQuery) {

--- a/cli/connections/queryCache.ts
+++ b/cli/connections/queryCache.ts
@@ -44,13 +44,13 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
       if (entry && entry.expiresAt > now && entry.contextHash == contextHash && entry.provider == provider) {
         try {
           let res = await conn.retrieveCachedQuery(entry)
-          return withCacheStatus(res, {provider, createdAt: entry.createdAt, expiresAt: entry.expiresAt})
+          return withCacheStatus(res, {provider, createdAt: entry.createdAt, expiresAt: entry.expiresAt, ref: entry.ref})
         } catch (err) {
           await store.delete(key)
           throw err
         }
       }
-      if (entry) return withCacheStatus(await runFreshAndStore(conn, store, key, contextHash, sql, params, provider, now), {provider})
+      if (entry) return withCacheStatus(await runFreshAndStore(conn, store, key, contextHash, sql, params, provider, now, options.queryCache || 'read-write'), {provider})
     } catch (err) {
       logCacheFallback(err)
       return await conn.runQuery(sql, {params})
@@ -58,7 +58,7 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
   }
 
   try {
-    let res = await runFreshAndStore(conn, store, key, contextHash, sql, params, provider, now)
+    let res = await runFreshAndStore(conn, store, key, contextHash, sql, params, provider, now, options.queryCache || 'read-write')
     return withCacheStatus(res, {provider})
   } catch (err) {
     logCacheFallback(err)
@@ -75,9 +75,10 @@ async function runFreshAndStore(
   params: QueryParams | undefined,
   provider: QueryCacheEntry['provider'],
   now: number,
+  queryCache: QueryOptions['queryCache'],
 ) {
-  let res = await conn.runQuery(sql, {params})
-  if (!res.queryCacheRef) return res
+  let res = await conn.runQuery(sql, {params, queryCache})
+  if (!res.cache?.ref) return res
 
   try {
     await store.set({
@@ -86,7 +87,7 @@ async function runFreshAndStore(
       contextHash,
       createdAt: now,
       expiresAt: now + CACHE_TTL_MS,
-      ref: res.queryCacheRef,
+      ref: res.cache.ref,
     })
   } catch (err) {
     logCacheFallback(err)
@@ -95,7 +96,7 @@ async function runFreshAndStore(
 }
 
 function withCacheStatus(res: QueryResult, cache: QueryResult['cache']): QueryResult {
-  return {...res, cache}
+  return {...res, cache: {...res.cache, ...cache}}
 }
 
 function logCacheFallback(err: unknown) {

--- a/cli/connections/queryCache.ts
+++ b/cli/connections/queryCache.ts
@@ -22,8 +22,9 @@ export interface QueryCacheStore {
 
 export async function runWithQueryCache(conn: QueryConnection, sql: string, options: QueryOptions = {}): Promise<QueryResult> {
   let {params} = options
-  let provider = conn.queryCacheProvider
-  if (!provider || config.queryCache === false) return await conn.runQuery(sql, {params})
+  let identity = conn.queryCacheIdentity?.()
+  if (!identity || config.queryCache === false) return await conn.runQuery(sql, {params})
+  let provider = identity.provider
 
   if (!conn.retrieveCachedQuery) {
     let res = await conn.runQuery(sql, {...options, queryCache: options.queryCache || 'read-write'})
@@ -31,7 +32,7 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
   }
 
   let store = new LocalQueryCacheStore(config.root)
-  let contextHash = hashValue(conn.queryCacheIdentity?.() || {})
+  let contextHash = hashValue(identity)
   let key = hashValue({version: CACHE_VERSION, dialect: config.dialect, root: config.root, sql, params: params || null, contextHash})
   let now = Date.now()
 

--- a/cli/connections/queryCache.ts
+++ b/cli/connections/queryCache.ts
@@ -43,7 +43,7 @@ export async function runWithQueryCache(conn: QueryConnection, sql: string, opti
       if (entry && entry.expiresAt > now && entry.contextHash == contextHash && entry.provider == provider) {
         try {
           let res = await conn.retrieveCachedQuery(entry)
-          return withCacheStatus(res, {status: 'hit', provider})
+          return withCacheStatus(res, {status: 'hit', provider, createdAt: entry.createdAt, expiresAt: entry.expiresAt})
         } catch (err) {
           await store.delete(key)
           throw err

--- a/cli/connections/queryCache.ts
+++ b/cli/connections/queryCache.ts
@@ -1,0 +1,192 @@
+import {createHash, randomUUID} from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import path from 'node:path'
+
+import {config} from '../../lang/config.ts'
+import {type QueryCacheEntry, type QueryConnection, type QueryOptions, type QueryParams, type QueryResult} from './types.ts'
+
+const CACHE_VERSION = 1
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+interface QueryCacheFile {
+  version: number
+  entries: Record<string, QueryCacheEntry>
+}
+
+export interface QueryCacheStore {
+  get(key: string): Promise<QueryCacheEntry | null>
+  set(entry: QueryCacheEntry): Promise<void>
+  delete(key: string): Promise<void>
+  prune(now?: number): Promise<void>
+}
+
+export async function runWithQueryCache(conn: QueryConnection, sql: string, options: QueryOptions = {}): Promise<QueryResult> {
+  let {params} = options
+  let provider = conn.queryCacheProvider
+  if (!provider || config.queryCache === false) return await conn.runQuery(sql, {params})
+
+  if (!conn.runCachedQuery) {
+    let res = await conn.runQuery(sql, {...options, cache: true})
+    return withCacheStatus(res, res.cache || {status: 'delegated', provider})
+  }
+
+  let store = new LocalQueryCacheStore(config.root)
+  let contextHash = hashValue(conn.queryCacheIdentity?.() || {})
+  let key = hashValue({version: CACHE_VERSION, dialect: config.dialect, root: config.root, sql, params: params || null, contextHash})
+  let now = Date.now()
+
+  if (!options.bypassCache) {
+    try {
+      await store.prune(now)
+      let entry = await store.get(key)
+      if (entry && entry.expiresAt > now && entry.contextHash == contextHash && entry.provider == provider) {
+        try {
+          let res = await conn.runCachedQuery(entry)
+          return withCacheStatus(res, {status: 'hit', provider})
+        } catch (err) {
+          await store.delete(key)
+          throw err
+        }
+      }
+      if (entry) return withCacheStatus(await runFreshAndStore(conn, store, key, contextHash, sql, params, provider, now), {status: 'miss', provider})
+    } catch (err) {
+      logCacheFallback(err)
+      return await conn.runQuery(sql, {params})
+    }
+  }
+
+  try {
+    let res = await runFreshAndStore(conn, store, key, contextHash, sql, params, provider, now)
+    return withCacheStatus(res, {status: 'miss', provider})
+  } catch (err) {
+    logCacheFallback(err)
+    return await conn.runQuery(sql, {params})
+  }
+}
+
+async function runFreshAndStore(
+  conn: QueryConnection,
+  store: QueryCacheStore,
+  key: string,
+  contextHash: string,
+  sql: string,
+  params: QueryParams | undefined,
+  provider: QueryCacheEntry['provider'],
+  now: number,
+) {
+  let res = await conn.runQuery(sql, {params})
+  if (!res.queryCacheRef) return res
+
+  try {
+    await store.set({
+      key,
+      provider,
+      contextHash,
+      createdAt: now,
+      expiresAt: now + CACHE_TTL_MS,
+      ref: res.queryCacheRef,
+    })
+  } catch (err) {
+    logCacheFallback(err)
+  }
+  return res
+}
+
+function withCacheStatus(res: QueryResult, cache: QueryResult['cache']): QueryResult {
+  return {...res, cache}
+}
+
+function logCacheFallback(err: unknown) {
+  let message = err instanceof Error ? err.message : String(err)
+  console.warn(`[graphene] Query cache failed; running query directly. ${message}`)
+}
+
+export class LocalQueryCacheStore implements QueryCacheStore {
+  private projectRoot: string
+
+  constructor(projectRoot: string) {
+    this.projectRoot = projectRoot
+  }
+
+  async get(key: string): Promise<QueryCacheEntry | null> {
+    let state = await this.read()
+    return state.entries[key] || null
+  }
+
+  async set(entry: QueryCacheEntry): Promise<void> {
+    let filePath = await this.filePath()
+    if (!filePath) return
+
+    let state = await this.read()
+    state.entries[entry.key] = entry
+    await this.write(filePath, state)
+  }
+
+  async delete(key: string): Promise<void> {
+    let filePath = await this.filePath()
+    if (!filePath) return
+
+    let state = await this.read()
+    delete state.entries[key]
+    await this.write(filePath, state)
+  }
+
+  async prune(now = Date.now()): Promise<void> {
+    let filePath = await this.filePath()
+    if (!filePath) return
+
+    let state = await this.read()
+    let entries = Object.fromEntries(Object.entries(state.entries).filter(([, entry]) => entry.expiresAt > now))
+    if (Object.keys(entries).length == Object.keys(state.entries).length) return
+    await this.write(filePath, {...state, entries})
+  }
+
+  private async read(): Promise<QueryCacheFile> {
+    let filePath = await this.filePath()
+    if (!filePath) return defaultState()
+
+    try {
+      let parsed = JSON.parse(await fs.readFile(filePath, 'utf-8'))
+      if (parsed?.version !== CACHE_VERSION || typeof parsed.entries != 'object' || Array.isArray(parsed.entries)) return defaultState()
+      return {version: CACHE_VERSION, entries: parsed.entries}
+    } catch {
+      return defaultState()
+    }
+  }
+
+  private async write(filePath: string, state: QueryCacheFile) {
+    let tmpPath = `${filePath}.tmp-${randomUUID()}`
+    await fs.mkdir(path.dirname(filePath), {recursive: true})
+    await fs.writeFile(tmpPath, JSON.stringify(state, null, 2) + '\n')
+    await fs.rename(tmpPath, filePath)
+  }
+
+  private async filePath() {
+    let nodeModules = path.join(this.projectRoot, 'node_modules')
+    try {
+      if (!(await fs.stat(nodeModules)).isDirectory()) return null
+    } catch {
+      return null
+    }
+    return path.join(nodeModules, '.graphene', 'query-cache.json')
+  }
+}
+
+function defaultState(): QueryCacheFile {
+  return {version: CACHE_VERSION, entries: {}}
+}
+
+function hashValue(value: unknown) {
+  return createHash('sha256').update(stableStringify(value)).digest('hex')
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  if (value && typeof value == 'object') {
+    return `{${Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}

--- a/cli/connections/snowflake.ts
+++ b/cli/connections/snowflake.ts
@@ -82,7 +82,11 @@ export class SnowflakeConnection implements QueryConnection {
           })
           stream.on('end', () => {
             let totalRows = Number(statement.getNumRows())
-            resolve({rows, totalRows, queryCacheRef: {provider: 'snowflake', queryId: statement.getQueryId()}})
+            resolve({
+              rows,
+              totalRows,
+              ...(options.queryCache && options.queryCache != 'none' ? {cache: {provider: 'snowflake' as const, ref: {provider: 'snowflake' as const, queryId: statement.getQueryId()}}} : {}),
+            })
           })
         },
       })

--- a/cli/connections/snowflake.ts
+++ b/cli/connections/snowflake.ts
@@ -2,7 +2,7 @@ import {createPrivateKey} from 'node:crypto'
 import snowflake from 'snowflake-sdk'
 
 import {config} from '../../lang/config.ts'
-import {type QueryConnection, type QueryResult, type SchemaColumn, type QueryParams} from './types.ts'
+import {type QueryConnection, type QueryResult, type SchemaColumn, type QueryCacheEntry, type QueryOptions} from './types.ts'
 
 interface SnowflakeOptions {
   username?: string
@@ -22,10 +22,13 @@ interface SnowflakeOptions {
 // Instructions for generating private/public keys: https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-keys
 
 export class SnowflakeConnection implements QueryConnection {
+  queryCacheProvider = 'snowflake' as const
   private ready: Promise<void>
   private connection!: snowflake.Connection
+  private opts: SnowflakeOptions
 
   constructor(opts: SnowflakeOptions) {
+    this.opts = opts || {}
     this.ready = this.initialize(opts || {})
   }
 
@@ -56,7 +59,8 @@ export class SnowflakeConnection implements QueryConnection {
     })
   }
 
-  async runQuery(sql: string, params?: QueryParams): Promise<QueryResult> {
+  async runQuery(sql: string, options: QueryOptions = {}): Promise<QueryResult> {
+    let {params} = options
     await this.ready
     return await new Promise<QueryResult>((resolve, reject) => {
       let rows: any[] = []
@@ -79,11 +83,29 @@ export class SnowflakeConnection implements QueryConnection {
           })
           stream.on('end', () => {
             let totalRows = Number(statement.getNumRows())
-            resolve({rows, totalRows})
+            resolve({rows, totalRows, queryCacheRef: {provider: 'snowflake', queryId: statement.getQueryId()}})
           })
         },
       })
     })
+  }
+
+  async runCachedQuery(entry: QueryCacheEntry): Promise<QueryResult> {
+    let queryId = String(entry.ref.queryId || '')
+    if (!queryId) throw new Error('Snowflake cache entry is missing queryId')
+    return await this.runQuery(`select * from table(result_scan('${queryId.replace(/'/g, "''")}'))`)
+  }
+
+  queryCacheIdentity() {
+    let cfg = config.snowflake || ({} as any)
+    return {
+      account: this.opts.account || cfg.account || '',
+      username: this.opts.username || cfg.username || '',
+      role: cfg.role || '',
+      warehouse: cfg.warehouse || '',
+      database: cfg.database || '',
+      schema: cfg.schema || '',
+    }
   }
 
   async listDatasets(): Promise<string[]> {
@@ -114,7 +136,7 @@ export class SnowflakeConnection implements QueryConnection {
       where table_type in ('BASE TABLE', 'VIEW') and upper(table_schema) = upper(?)
       order by table_name
     `,
-      [schema],
+      {params: [schema]},
     )
     return res.rows.map(row => `${String(row['table_schema']).toLowerCase()}.${String(row['table_name']).toLowerCase()}`)
   }
@@ -132,7 +154,7 @@ export class SnowflakeConnection implements QueryConnection {
       where upper(table_schema) = upper(?) and upper(table_name) = upper(?)
       order by ordinal_position
     `,
-      [schema, table],
+      {params: [schema, table]},
     )
     return res.rows.map(row => {
       return {name: String(row['column_name']).toLowerCase(), dataType: String(row['data_type'])}

--- a/cli/connections/snowflake.ts
+++ b/cli/connections/snowflake.ts
@@ -22,7 +22,6 @@ interface SnowflakeOptions {
 // Instructions for generating private/public keys: https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-keys
 
 export class SnowflakeConnection implements QueryConnection {
-  queryCacheProvider = 'snowflake' as const
   private ready: Promise<void>
   private connection!: snowflake.Connection
   private opts: SnowflakeOptions
@@ -99,6 +98,7 @@ export class SnowflakeConnection implements QueryConnection {
   queryCacheIdentity() {
     let cfg = config.snowflake || ({} as any)
     return {
+      provider: 'snowflake' as const,
       account: this.opts.account || cfg.account || '',
       username: this.opts.username || cfg.username || '',
       role: cfg.role || '',

--- a/cli/connections/snowflake.ts
+++ b/cli/connections/snowflake.ts
@@ -90,7 +90,7 @@ export class SnowflakeConnection implements QueryConnection {
     })
   }
 
-  async runCachedQuery(entry: QueryCacheEntry): Promise<QueryResult> {
+  async retrieveCachedQuery(entry: QueryCacheEntry): Promise<QueryResult> {
     let queryId = String(entry.ref.queryId || '')
     if (!queryId) throw new Error('Snowflake cache entry is missing queryId')
     return await this.runQuery(`select * from table(result_scan('${queryId.replace(/'/g, "''")}'))`)

--- a/cli/connections/types.ts
+++ b/cli/connections/types.ts
@@ -13,7 +13,7 @@ export interface SchemaColumn {
 export type QueryParams = unknown[] | Record<string, unknown>
 
 export type QueryCacheProvider = 'snowflake' | 'bigquery' | 'clickhouse'
-export type QueryCacheStatus = {status: 'hit' | 'miss' | 'delegated'; provider?: QueryCacheProvider; createdAt?: number; expiresAt?: number}
+export type QueryCacheStatus = {provider?: QueryCacheProvider; createdAt?: number; expiresAt?: number}
 export type QueryCacheRef = {provider: QueryCacheProvider; [key: string]: unknown}
 export type QueryCacheIdentity = QueryCacheRef
 export type QueryCacheMode = 'read-write' | 'refresh' | 'none'

--- a/cli/connections/types.ts
+++ b/cli/connections/types.ts
@@ -1,6 +1,8 @@
 export interface QueryResult {
   rows: Array<Record<string, unknown>>
   totalRows?: number
+  queryCacheRef?: QueryCacheRef
+  cache?: QueryCacheStatus
 }
 
 export interface SchemaColumn {
@@ -10,8 +12,30 @@ export interface SchemaColumn {
 
 export type QueryParams = unknown[] | Record<string, unknown>
 
+export type QueryCacheProvider = 'snowflake' | 'bigquery' | 'clickhouse'
+export type QueryCacheStatus = {status: 'hit' | 'miss' | 'delegated'; provider?: QueryCacheProvider}
+export type QueryCacheRef = {provider: QueryCacheProvider; [key: string]: unknown}
+
+export interface QueryCacheEntry {
+  key: string
+  provider: QueryCacheProvider
+  contextHash: string
+  createdAt: number
+  expiresAt: number
+  ref: QueryCacheRef
+}
+
+export interface QueryOptions {
+  params?: QueryParams
+  cache?: boolean
+  bypassCache?: boolean
+}
+
 export interface QueryConnection {
-  runQuery(sql: string, params?: QueryParams): Promise<QueryResult>
+  runQuery(sql: string, options?: QueryOptions): Promise<QueryResult>
+  queryCacheProvider?: QueryCacheProvider
+  queryCacheIdentity?(): unknown
+  runCachedQuery?(entry: QueryCacheEntry): Promise<QueryResult>
   listDatasets(): Promise<string[]>
   listSchemas?(dataset: string): Promise<string[]>
   listTables(dataset?: string): Promise<string[]>

--- a/cli/connections/types.ts
+++ b/cli/connections/types.ts
@@ -1,7 +1,6 @@
 export interface QueryResult {
   rows: Array<Record<string, unknown>>
   totalRows?: number
-  queryCacheRef?: QueryCacheRef
   cache?: QueryCacheStatus
 }
 
@@ -13,8 +12,8 @@ export interface SchemaColumn {
 export type QueryParams = unknown[] | Record<string, unknown>
 
 export type QueryCacheProvider = 'snowflake' | 'bigquery' | 'clickhouse'
-export type QueryCacheStatus = {provider?: QueryCacheProvider; createdAt?: number; expiresAt?: number}
 export type QueryCacheRef = {provider: QueryCacheProvider; [key: string]: unknown}
+export type QueryCacheStatus = {provider?: QueryCacheProvider; createdAt?: number; expiresAt?: number; ref?: QueryCacheRef}
 export type QueryCacheIdentity = QueryCacheRef
 export type QueryCacheMode = 'read-write' | 'refresh' | 'none'
 

--- a/cli/connections/types.ts
+++ b/cli/connections/types.ts
@@ -35,7 +35,7 @@ export interface QueryConnection {
   runQuery(sql: string, options?: QueryOptions): Promise<QueryResult>
   queryCacheProvider?: QueryCacheProvider
   queryCacheIdentity?(): unknown
-  runCachedQuery?(entry: QueryCacheEntry): Promise<QueryResult>
+  retrieveCachedQuery?(entry: QueryCacheEntry): Promise<QueryResult>
   listDatasets(): Promise<string[]>
   listSchemas?(dataset: string): Promise<string[]>
   listTables(dataset?: string): Promise<string[]>

--- a/cli/connections/types.ts
+++ b/cli/connections/types.ts
@@ -15,6 +15,7 @@ export type QueryParams = unknown[] | Record<string, unknown>
 export type QueryCacheProvider = 'snowflake' | 'bigquery' | 'clickhouse'
 export type QueryCacheStatus = {status: 'hit' | 'miss' | 'delegated'; provider?: QueryCacheProvider}
 export type QueryCacheRef = {provider: QueryCacheProvider; [key: string]: unknown}
+export type QueryCacheMode = 'read-write' | 'refresh' | 'none'
 
 export interface QueryCacheEntry {
   key: string
@@ -27,8 +28,7 @@ export interface QueryCacheEntry {
 
 export interface QueryOptions {
   params?: QueryParams
-  cache?: boolean
-  bypassCache?: boolean
+  queryCache?: QueryCacheMode
 }
 
 export interface QueryConnection {

--- a/cli/connections/types.ts
+++ b/cli/connections/types.ts
@@ -13,7 +13,7 @@ export interface SchemaColumn {
 export type QueryParams = unknown[] | Record<string, unknown>
 
 export type QueryCacheProvider = 'snowflake' | 'bigquery' | 'clickhouse'
-export type QueryCacheStatus = {status: 'hit' | 'miss' | 'delegated'; provider?: QueryCacheProvider}
+export type QueryCacheStatus = {status: 'hit' | 'miss' | 'delegated'; provider?: QueryCacheProvider; createdAt?: number; expiresAt?: number}
 export type QueryCacheRef = {provider: QueryCacheProvider; [key: string]: unknown}
 export type QueryCacheIdentity = QueryCacheRef
 export type QueryCacheMode = 'read-write' | 'refresh' | 'none'
@@ -34,8 +34,8 @@ export interface QueryOptions {
 
 export interface QueryConnection {
   runQuery(sql: string, options?: QueryOptions): Promise<QueryResult>
-  queryCacheIdentity?(): QueryCacheIdentity
   retrieveCachedQuery?(entry: QueryCacheEntry): Promise<QueryResult>
+  queryCacheIdentity?(): QueryCacheIdentity
   listDatasets(): Promise<string[]>
   listSchemas?(dataset: string): Promise<string[]>
   listTables(dataset?: string): Promise<string[]>

--- a/cli/connections/types.ts
+++ b/cli/connections/types.ts
@@ -15,6 +15,7 @@ export type QueryParams = unknown[] | Record<string, unknown>
 export type QueryCacheProvider = 'snowflake' | 'bigquery' | 'clickhouse'
 export type QueryCacheStatus = {status: 'hit' | 'miss' | 'delegated'; provider?: QueryCacheProvider}
 export type QueryCacheRef = {provider: QueryCacheProvider; [key: string]: unknown}
+export type QueryCacheIdentity = QueryCacheRef
 export type QueryCacheMode = 'read-write' | 'refresh' | 'none'
 
 export interface QueryCacheEntry {
@@ -33,8 +34,7 @@ export interface QueryOptions {
 
 export interface QueryConnection {
   runQuery(sql: string, options?: QueryOptions): Promise<QueryResult>
-  queryCacheProvider?: QueryCacheProvider
-  queryCacheIdentity?(): unknown
+  queryCacheIdentity?(): QueryCacheIdentity
   retrieveCachedQuery?(entry: QueryCacheEntry): Promise<QueryResult>
   listDatasets(): Promise<string[]>
   listSchemas?(dataset: string): Promise<string[]>

--- a/cli/queryCache.test.ts
+++ b/cli/queryCache.test.ts
@@ -48,7 +48,7 @@ class DelegatedCacheConnection implements QueryConnection {
   runQuery(sql: string, options: QueryOptions = {}): Promise<QueryResult> {
     this.lastOptions = options
     this.lastSql = sql
-    return Promise.resolve({rows: [{source: 'fresh'}], totalRows: 1, cache: {status: 'delegated', provider: 'clickhouse'}})
+    return Promise.resolve({rows: [{source: 'fresh'}], totalRows: 1, cache: {provider: 'clickhouse'}})
   }
 
   lastSql?: string
@@ -138,8 +138,8 @@ describe('runWithQueryCache', () => {
     let first = await runWithQueryCache(conn, 'select 1')
     let second = await runWithQueryCache(conn, 'select 1')
 
-    expect(first.cache).toEqual({status: 'miss', provider: 'snowflake'})
-    expect(second.cache).toEqual(expect.objectContaining({status: 'hit', provider: 'snowflake', createdAt: expect.any(Number), expiresAt: expect.any(Number)}))
+    expect(first.cache).toEqual({provider: 'snowflake'})
+    expect(second.cache).toEqual(expect.objectContaining({provider: 'snowflake', createdAt: expect.any(Number), expiresAt: expect.any(Number)}))
     expect(second.rows).toEqual([{source: 'cache'}])
     expect(conn.freshRuns).toBe(1)
     expect(conn.cachedRuns).toBe(1)
@@ -183,7 +183,7 @@ describe('runWithQueryCache', () => {
     let refreshed = await runWithQueryCache(conn, 'select 1', {queryCache: 'refresh'})
     let cached = await runWithQueryCache(conn, 'select 1')
 
-    expect(refreshed.cache).toEqual({status: 'miss', provider: 'snowflake'})
+    expect(refreshed.cache).toEqual({provider: 'snowflake'})
     expect(cached.rows).toEqual([{source: 'cache'}])
     expect(conn.freshRuns).toBe(2)
     expect(conn.cachedRuns).toBe(1)
@@ -198,6 +198,6 @@ describe('runWithQueryCache', () => {
 
     expect(conn.lastSql).toBe('select 1')
     expect(conn.lastOptions).toEqual({queryCache: 'read-write'})
-    expect(res.cache).toEqual({status: 'delegated', provider: 'clickhouse'})
+    expect(res.cache).toEqual({provider: 'clickhouse'})
   })
 })

--- a/cli/queryCache.test.ts
+++ b/cli/queryCache.test.ts
@@ -108,6 +108,25 @@ describe('query cache store', () => {
     await fs.writeFile(file, '{not json')
     expect(await store.get('old')).toBeNull()
   })
+
+  it('preserves concurrent in-process metadata writes', async () => {
+    let root = await cacheProject()
+    let entries = Array.from({length: 20}, (_, i) => ({
+      key: `key-${i}`,
+      provider: 'snowflake' as const,
+      contextHash: 'ctx',
+      createdAt: i,
+      expiresAt: Date.now() + 1000,
+      ref: {provider: 'snowflake' as const, queryId: `query-${i}`},
+    }))
+
+    await Promise.all(entries.map(entry => new LocalQueryCacheStore(root).set(entry)))
+
+    let store = new LocalQueryCacheStore(root)
+    for (let entry of entries) {
+      expect(await store.get(entry.key)).toMatchObject({ref: {queryId: entry.ref.queryId}})
+    }
+  })
 })
 
 describe('runWithQueryCache', () => {

--- a/cli/queryCache.test.ts
+++ b/cli/queryCache.test.ts
@@ -9,7 +9,6 @@ import {LocalQueryCacheStore, runWithQueryCache} from './connections/queryCache.
 import {type QueryCacheEntry, type QueryConnection, type QueryOptions, type QueryResult} from './connections/types.ts'
 
 class StoredCacheConnection implements QueryConnection {
-  queryCacheProvider = 'snowflake' as const
   freshRuns = 0
   cachedRuns = 0
   failCached = false
@@ -26,7 +25,7 @@ class StoredCacheConnection implements QueryConnection {
   }
 
   queryCacheIdentity() {
-    return {account: 'acct', username: 'user', role: 'role'}
+    return {provider: 'snowflake' as const, account: 'acct', username: 'user', role: 'role'}
   }
 
   listDatasets() {
@@ -44,7 +43,6 @@ class StoredCacheConnection implements QueryConnection {
 }
 
 class DelegatedCacheConnection implements QueryConnection {
-  queryCacheProvider = 'clickhouse' as const
   lastOptions?: QueryOptions
 
   runQuery(sql: string, options: QueryOptions = {}): Promise<QueryResult> {
@@ -54,6 +52,10 @@ class DelegatedCacheConnection implements QueryConnection {
   }
 
   lastSql?: string
+
+  queryCacheIdentity() {
+    return {provider: 'clickhouse' as const, database: 'default'}
+  }
 
   listDatasets() {
     return Promise.resolve([])

--- a/cli/queryCache.test.ts
+++ b/cli/queryCache.test.ts
@@ -1,0 +1,167 @@
+/// <reference types="vitest/globals" />
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import path from 'node:path'
+import {vi} from 'vitest'
+
+import {setGlobalConfig} from '../lang/config.ts'
+import {LocalQueryCacheStore, runWithQueryCache} from './connections/queryCache.ts'
+import {type QueryCacheEntry, type QueryConnection, type QueryOptions, type QueryResult} from './connections/types.ts'
+
+class StoredCacheConnection implements QueryConnection {
+  queryCacheProvider = 'snowflake' as const
+  freshRuns = 0
+  cachedRuns = 0
+  failCached = false
+
+  runQuery(_sql: string, _options?: QueryOptions): Promise<QueryResult> {
+    this.freshRuns += 1
+    return Promise.resolve({rows: [{source: 'fresh', n: this.freshRuns}], totalRows: 1, queryCacheRef: {provider: 'snowflake', queryId: `query-${this.freshRuns}`}})
+  }
+
+  runCachedQuery(_entry: QueryCacheEntry): Promise<QueryResult> {
+    this.cachedRuns += 1
+    if (this.failCached) throw new Error('cached result expired')
+    return Promise.resolve({rows: [{source: 'cache'}], totalRows: 1})
+  }
+
+  queryCacheIdentity() {
+    return {account: 'acct', username: 'user', role: 'role'}
+  }
+
+  listDatasets() {
+    return Promise.resolve([])
+  }
+  listTables() {
+    return Promise.resolve([])
+  }
+  describeTable() {
+    return Promise.resolve([])
+  }
+  close() {
+    return Promise.resolve()
+  }
+}
+
+class DelegatedCacheConnection implements QueryConnection {
+  queryCacheProvider = 'clickhouse' as const
+  lastOptions?: QueryOptions
+
+  runQuery(sql: string, options: QueryOptions = {}): Promise<QueryResult> {
+    this.lastOptions = options
+    this.lastSql = sql
+    return Promise.resolve({rows: [{source: 'fresh'}], totalRows: 1, cache: {status: 'delegated', provider: 'clickhouse'}})
+  }
+
+  lastSql?: string
+
+  listDatasets() {
+    return Promise.resolve([])
+  }
+  listTables() {
+    return Promise.resolve([])
+  }
+  describeTable() {
+    return Promise.resolve([])
+  }
+  close() {
+    return Promise.resolve()
+  }
+}
+
+async function cacheProject() {
+  let root = await fs.mkdtemp(path.join(os.tmpdir(), 'graphene-query-cache-'))
+  await fs.mkdir(path.join(root, 'node_modules'))
+  return root
+}
+
+describe('query cache store', () => {
+  it('stores metadata without query text or row data', async () => {
+    let root = await cacheProject()
+    let store = new LocalQueryCacheStore(root)
+    await store.set({
+      key: 'abc',
+      provider: 'snowflake',
+      contextHash: 'ctx',
+      createdAt: 1,
+      expiresAt: Date.now() + 1000,
+      ref: {provider: 'snowflake', queryId: 'query-1'},
+    })
+
+    let raw = await fs.readFile(path.join(root, 'node_modules/.graphene/query-cache.json'), 'utf-8')
+    expect(raw).toContain('query-1')
+    expect(raw).not.toContain('select * from private_table')
+    expect(raw).not.toContain('source')
+    expect(await store.get('abc')).toMatchObject({provider: 'snowflake', ref: {queryId: 'query-1'}})
+  })
+
+  it('prunes expired entries and treats corrupt files as empty', async () => {
+    let root = await cacheProject()
+    let file = path.join(root, 'node_modules/.graphene/query-cache.json')
+    let store = new LocalQueryCacheStore(root)
+    await store.set({key: 'old', provider: 'bigquery', contextHash: 'ctx', createdAt: 1, expiresAt: 2, ref: {provider: 'bigquery', jobId: 'job'}})
+    await store.prune(3)
+    expect(await store.get('old')).toBeNull()
+
+    await fs.writeFile(file, '{not json')
+    expect(await store.get('old')).toBeNull()
+  })
+})
+
+describe('runWithQueryCache', () => {
+  it('stores a fresh provider reference and replays it on the next matching query', async () => {
+    let root = await cacheProject()
+    setGlobalConfig({root, dialect: 'snowflake', snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
+    let conn = new StoredCacheConnection()
+
+    let first = await runWithQueryCache(conn, 'select 1')
+    let second = await runWithQueryCache(conn, 'select 1')
+
+    expect(first.cache).toEqual({status: 'miss', provider: 'snowflake'})
+    expect(second.cache).toEqual({status: 'hit', provider: 'snowflake'})
+    expect(second.rows).toEqual([{source: 'cache'}])
+    expect(conn.freshRuns).toBe(1)
+    expect(conn.cachedRuns).toBe(1)
+  })
+
+  it('opts out when queryCache is false', async () => {
+    let root = await cacheProject()
+    setGlobalConfig({root, dialect: 'snowflake', queryCache: false, snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
+    let conn = new StoredCacheConnection()
+
+    let res = await runWithQueryCache(conn, 'select 1')
+    await runWithQueryCache(conn, 'select 1')
+
+    expect(res.cache).toBeUndefined()
+    expect(conn.freshRuns).toBe(2)
+    expect(conn.cachedRuns).toBe(0)
+  })
+
+  it('logs and falls back to a direct query when replay fails', async () => {
+    let root = await cacheProject()
+    setGlobalConfig({root, dialect: 'snowflake', snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
+    let warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let conn = new StoredCacheConnection()
+
+    await runWithQueryCache(conn, 'select 1')
+    conn.failCached = true
+    let fallback = await runWithQueryCache(conn, 'select 1')
+
+    expect(fallback.rows).toEqual([{source: 'fresh', n: 2}])
+    expect(conn.freshRuns).toBe(2)
+    expect(warn.mock.calls[0][0]).toContain('Query cache failed')
+    warn.mockRestore()
+  })
+
+  it('delegates cache settings for providers without stored references', async () => {
+    let root = await cacheProject()
+    setGlobalConfig({root, dialect: 'clickhouse', clickhouse: {url: 'https://example.com', username: 'default'}})
+    let conn = new DelegatedCacheConnection()
+
+    let res = await runWithQueryCache(conn, 'select 1')
+
+    expect(conn.lastSql).toBe('select 1')
+    expect(conn.lastOptions).toEqual({cache: true})
+    expect(res.cache).toEqual({status: 'delegated', provider: 'clickhouse'})
+  })
+})

--- a/cli/queryCache.test.ts
+++ b/cli/queryCache.test.ts
@@ -19,7 +19,7 @@ class StoredCacheConnection implements QueryConnection {
     return Promise.resolve({rows: [{source: 'fresh', n: this.freshRuns}], totalRows: 1, queryCacheRef: {provider: 'snowflake', queryId: `query-${this.freshRuns}`}})
   }
 
-  runCachedQuery(_entry: QueryCacheEntry): Promise<QueryResult> {
+  retrieveCachedQuery(_entry: QueryCacheEntry): Promise<QueryResult> {
     this.cachedRuns += 1
     if (this.failCached) throw new Error('cached result expired')
     return Promise.resolve({rows: [{source: 'cache'}], totalRows: 1})

--- a/cli/queryCache.test.ts
+++ b/cli/queryCache.test.ts
@@ -153,6 +153,21 @@ describe('runWithQueryCache', () => {
     warn.mockRestore()
   })
 
+  it('refreshes stored metadata without reading an existing cache entry', async () => {
+    let root = await cacheProject()
+    setGlobalConfig({root, dialect: 'snowflake', snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
+    let conn = new StoredCacheConnection()
+
+    await runWithQueryCache(conn, 'select 1')
+    let refreshed = await runWithQueryCache(conn, 'select 1', {queryCache: 'refresh'})
+    let cached = await runWithQueryCache(conn, 'select 1')
+
+    expect(refreshed.cache).toEqual({status: 'miss', provider: 'snowflake'})
+    expect(cached.rows).toEqual([{source: 'cache'}])
+    expect(conn.freshRuns).toBe(2)
+    expect(conn.cachedRuns).toBe(1)
+  })
+
   it('delegates cache settings for providers without stored references', async () => {
     let root = await cacheProject()
     setGlobalConfig({root, dialect: 'clickhouse', clickhouse: {url: 'https://example.com', username: 'default'}})
@@ -161,7 +176,7 @@ describe('runWithQueryCache', () => {
     let res = await runWithQueryCache(conn, 'select 1')
 
     expect(conn.lastSql).toBe('select 1')
-    expect(conn.lastOptions).toEqual({cache: true})
+    expect(conn.lastOptions).toEqual({queryCache: 'read-write'})
     expect(res.cache).toEqual({status: 'delegated', provider: 'clickhouse'})
   })
 })

--- a/cli/queryCache.test.ts
+++ b/cli/queryCache.test.ts
@@ -113,7 +113,7 @@ describe('query cache store', () => {
 describe('runWithQueryCache', () => {
   it('stores a fresh provider reference and replays it on the next matching query', async () => {
     let root = await cacheProject()
-    setGlobalConfig({root, dialect: 'snowflake', snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
+    setGlobalConfig({root, dialect: 'snowflake', queryCache: true, snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
     let conn = new StoredCacheConnection()
 
     let first = await runWithQueryCache(conn, 'select 1')
@@ -126,9 +126,9 @@ describe('runWithQueryCache', () => {
     expect(conn.cachedRuns).toBe(1)
   })
 
-  it('opts out when queryCache is false', async () => {
+  it('does not cache unless queryCache is true', async () => {
     let root = await cacheProject()
-    setGlobalConfig({root, dialect: 'snowflake', queryCache: false, snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
+    setGlobalConfig({root, dialect: 'snowflake', snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
     let conn = new StoredCacheConnection()
 
     let res = await runWithQueryCache(conn, 'select 1')
@@ -141,7 +141,7 @@ describe('runWithQueryCache', () => {
 
   it('logs and falls back to a direct query when replay fails', async () => {
     let root = await cacheProject()
-    setGlobalConfig({root, dialect: 'snowflake', snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
+    setGlobalConfig({root, dialect: 'snowflake', queryCache: true, snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
     let warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     let conn = new StoredCacheConnection()
 
@@ -157,7 +157,7 @@ describe('runWithQueryCache', () => {
 
   it('refreshes stored metadata without reading an existing cache entry', async () => {
     let root = await cacheProject()
-    setGlobalConfig({root, dialect: 'snowflake', snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
+    setGlobalConfig({root, dialect: 'snowflake', queryCache: true, snowflake: {account: 'acct', username: 'user', privateKeyPath: 'key'}})
     let conn = new StoredCacheConnection()
 
     await runWithQueryCache(conn, 'select 1')
@@ -172,7 +172,7 @@ describe('runWithQueryCache', () => {
 
   it('delegates cache settings for providers without stored references', async () => {
     let root = await cacheProject()
-    setGlobalConfig({root, dialect: 'clickhouse', clickhouse: {url: 'https://example.com', username: 'default'}})
+    setGlobalConfig({root, dialect: 'clickhouse', queryCache: true, clickhouse: {url: 'https://example.com', username: 'default'}})
     let conn = new DelegatedCacheConnection()
 
     let res = await runWithQueryCache(conn, 'select 1')

--- a/cli/queryCache.test.ts
+++ b/cli/queryCache.test.ts
@@ -15,7 +15,11 @@ class StoredCacheConnection implements QueryConnection {
 
   runQuery(_sql: string, _options?: QueryOptions): Promise<QueryResult> {
     this.freshRuns += 1
-    return Promise.resolve({rows: [{source: 'fresh', n: this.freshRuns}], totalRows: 1, queryCacheRef: {provider: 'snowflake', queryId: `query-${this.freshRuns}`}})
+    return Promise.resolve({
+      rows: [{source: 'fresh', n: this.freshRuns}],
+      totalRows: 1,
+      ...(_options?.queryCache && _options.queryCache != 'none' ? {cache: {provider: 'snowflake' as const, ref: {provider: 'snowflake' as const, queryId: `query-${this.freshRuns}`}}} : {}),
+    })
   }
 
   retrieveCachedQuery(_entry: QueryCacheEntry): Promise<QueryResult> {
@@ -138,7 +142,7 @@ describe('runWithQueryCache', () => {
     let first = await runWithQueryCache(conn, 'select 1')
     let second = await runWithQueryCache(conn, 'select 1')
 
-    expect(first.cache).toEqual({provider: 'snowflake'})
+    expect(first.cache).toEqual({provider: 'snowflake', ref: {provider: 'snowflake', queryId: 'query-1'}})
     expect(second.cache).toEqual(expect.objectContaining({provider: 'snowflake', createdAt: expect.any(Number), expiresAt: expect.any(Number)}))
     expect(second.rows).toEqual([{source: 'cache'}])
     expect(conn.freshRuns).toBe(1)
@@ -183,7 +187,7 @@ describe('runWithQueryCache', () => {
     let refreshed = await runWithQueryCache(conn, 'select 1', {queryCache: 'refresh'})
     let cached = await runWithQueryCache(conn, 'select 1')
 
-    expect(refreshed.cache).toEqual({provider: 'snowflake'})
+    expect(refreshed.cache).toEqual({provider: 'snowflake', ref: {provider: 'snowflake', queryId: 'query-2'}})
     expect(cached.rows).toEqual([{source: 'cache'}])
     expect(conn.freshRuns).toBe(2)
     expect(conn.cachedRuns).toBe(1)

--- a/cli/queryCache.test.ts
+++ b/cli/queryCache.test.ts
@@ -120,7 +120,7 @@ describe('runWithQueryCache', () => {
     let second = await runWithQueryCache(conn, 'select 1')
 
     expect(first.cache).toEqual({status: 'miss', provider: 'snowflake'})
-    expect(second.cache).toEqual({status: 'hit', provider: 'snowflake'})
+    expect(second.cache).toEqual(expect.objectContaining({status: 'hit', provider: 'snowflake', createdAt: expect.any(Number), expiresAt: expect.any(Number)}))
     expect(second.rows).toEqual([{source: 'cache'}])
     expect(conn.freshRuns).toBe(1)
     expect(conn.cachedRuns).toBe(1)

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -151,7 +151,7 @@ export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: str
     console.error(err instanceof Error ? err.message : String(err))
     return false
   }
-  let res = await runQuery(sql)
+  let res = await runQuery(sql, {cache: true})
   printTable(res.rows)
   return true
 }

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -151,7 +151,7 @@ export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: str
     console.error(err instanceof Error ? err.message : String(err))
     return false
   }
-  let res = await runQuery(sql, {cache: true})
+  let res = await runQuery(sql, {queryCache: 'read-write'})
   printTable(res.rows)
   return true
 }

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -151,7 +151,7 @@ async function createConfig(telemetry?: CliTelemetry): Promise<InlineConfig> {
 async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMessage>) {
   let chunks = [] as any[]
   for await (let chunk of req) chunks.push(chunk)
-  let {gsql, params, hashes} = JSON.parse(Buffer.concat(chunks).toString())
+  let {gsql, params, hashes = []} = JSON.parse(Buffer.concat(chunks).toString())
   res.setHeader('Content-Type', 'application/json')
 
   await workspaceLoadPromise
@@ -180,11 +180,11 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
     return res.end()
   }
 
-  let queryResults = await runQuery(sql)
+  let queryResults = await runQuery(sql, {cache: true, bypassCache: req.headers['cache-control'] == 'no-cache'})
   let totalRows = queryResults.totalRows ?? queryResults.rows.length
   if (totalRows > queryResults.rows.length) throw new Error('Query returns too many rows')
   let fields = queries[0].fields.map(field => ({name: field.name, type: field.type, metadata: field.metadata || {}}))
-  res.end(JSON.stringify({rows: queryResults.rows, hash, fields, sql}))
+  res.end(JSON.stringify({rows: queryResults.rows, hash, fields, sql, cache: queryResults.cache}))
 }
 
 async function handlePage(server: ViteDevServer, res: ServerResponse<IncomingMessage>) {

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -182,7 +182,7 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
   }
 
   let queryCache: QueryCacheMode = req.headers['cache-control'] == 'no-cache' ? 'refresh' : 'read-write'
-  let queryResults = await runQuery(sql, {params, queryCache})
+  let queryResults = await runQuery(sql, {queryCache})
   let totalRows = queryResults.totalRows ?? queryResults.rows.length
   if (totalRows > queryResults.rows.length) throw new Error('Query returns too many rows')
   let fields = queries[0].fields.map(field => ({name: field.name, type: field.type, metadata: field.metadata || {}}))

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -14,6 +14,7 @@ import type {AnalysisResult, WorkspaceFileInput} from '../lang/types.ts'
 import {config} from '../lang/config.ts'
 import {analyzeWorkspace, loadWorkspace, toSql} from '../lang/core.ts'
 import {runQuery} from './connections/index.ts'
+import {type QueryCacheMode} from './connections/types.ts'
 import {extractFrontmatter, injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 import {mockFileMap} from './mockFiles.ts'
 import {runVitePlugin} from './run.ts'
@@ -180,7 +181,8 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
     return res.end()
   }
 
-  let queryResults = await runQuery(sql, {cache: true, bypassCache: req.headers['cache-control'] == 'no-cache'})
+  let queryCache: QueryCacheMode = req.headers['cache-control'] == 'no-cache' ? 'refresh' : 'read-write'
+  let queryResults = await runQuery(sql, {params, queryCache})
   let totalRows = queryResults.totalRows ?? queryResults.rows.length
   if (totalRows > queryResults.rows.length) throw new Error('Query returns too many rows')
   let fields = queries[0].fields.map(field => ({name: field.name, type: field.type, metadata: field.metadata || {}}))

--- a/docs/config.md
+++ b/docs/config.md
@@ -9,6 +9,7 @@ Graphene reads its configuration from the `graphene` object in your project's `p
     "defaultNamespace": "main",
     "ignoredFiles": ["**/readme.md", "**/agents.md", "**/claude.md"],
     "envFile": [".env", "../../.env"],
+    "queryCache": false,
     "updateNotifier": false
   }
 }
@@ -56,6 +57,12 @@ Set to `false` to opt out of anonymous usage telemetry.
 
 Set to `false` to opt out of CLI update notices. You can also set `GRAPHENE_NO_UPDATE_NOTIFIER=1` in the environment.
 
+## `queryCache`
+
+Set to `false` to opt out of warehouse query result caching. Query caching is enabled by default for supported warehouse connections.
+
+Graphene stores only small metadata references in `node_modules/.graphene/query-cache.json`; query result rows stay in the warehouse result cache. Snowflake and BigQuery reuse recent result references for up to 24 hours. ClickHouse uses its warehouse query cache settings with a 24 hour TTL. If the cache path fails for any reason, Graphene logs a warning and runs the query normally.
+
 # Database connections
 
 Exactly one of the following blocks should be present. The dialect is inferred from whichever one you set.
@@ -92,11 +99,13 @@ The matching passphrase env var is `SNOWFLAKE_PRI_PASSPHRASE`.
 ```json
 "bigquery": {
   "projectId": "my-project-123",
+  "location": "US",
   "keyPath": "/Users/me/.ssh/graphene-bq-key.json"
 }
 ```
 
 - `projectId` — Google Cloud project ID for billing/jobs.
+- `location` — optional geographic location for BigQuery jobs.
 - `keyPath` — absolute path to the service account JSON key. Usually set via the `GOOGLE_APPLICATION_CREDENTIALS` env var instead.
 
 ## `clickhouse`

--- a/docs/config.md
+++ b/docs/config.md
@@ -9,7 +9,7 @@ Graphene reads its configuration from the `graphene` object in your project's `p
     "defaultNamespace": "main",
     "ignoredFiles": ["**/readme.md", "**/agents.md", "**/claude.md"],
     "envFile": [".env", "../../.env"],
-    "queryCache": false,
+    "queryCache": true,
     "updateNotifier": false
   }
 }
@@ -59,7 +59,7 @@ Set to `false` to opt out of CLI update notices. You can also set `GRAPHENE_NO_U
 
 ## `queryCache`
 
-Set to `false` to opt out of warehouse query result caching. Query caching is enabled by default for supported warehouse connections.
+Set to `true` to opt in to warehouse query result caching. Query caching is disabled by default.
 
 Graphene stores only small metadata references in `node_modules/.graphene/query-cache.json`; query result rows stay in the warehouse result cache. Snowflake and BigQuery reuse recent result references for up to 24 hours. ClickHouse uses its warehouse query cache settings with a 24 hour TTL. If the cache path fails for any reason, Graphene logs a warning and runs the query normally.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -99,13 +99,11 @@ The matching passphrase env var is `SNOWFLAKE_PRI_PASSPHRASE`.
 ```json
 "bigquery": {
   "projectId": "my-project-123",
-  "location": "US",
   "keyPath": "/Users/me/.ssh/graphene-bq-key.json"
 }
 ```
 
 - `projectId` — Google Cloud project ID for billing/jobs.
-- `location` — optional geographic location for BigQuery jobs.
 - `keyPath` — absolute path to the service account JSON key. Usually set via the `GOOGLE_APPLICATION_CREDENTIALS` env var instead.
 
 ## `clickhouse`

--- a/docs/config.md
+++ b/docs/config.md
@@ -61,7 +61,7 @@ Set to `false` to opt out of CLI update notices. You can also set `GRAPHENE_NO_U
 
 Set to `true` to opt in to warehouse query result caching. Query caching is disabled by default.
 
-Graphene stores only small metadata references in `node_modules/.graphene/query-cache.json`; query result rows stay in the warehouse result cache. Snowflake and BigQuery reuse recent result references for up to 24 hours. ClickHouse uses its warehouse query cache settings with a 24 hour TTL. If the cache path fails for any reason, Graphene logs a warning and runs the query normally.
+Graphene stores only small metadata references in `node_modules/.graphene/query-cache.json`; query result rows stay in the warehouse result cache. If enabled, results are eligible to be reused for 24 hours.
 
 # Database connections
 

--- a/examples/clickhouse/package.json
+++ b/examples/clickhouse/package.json
@@ -28,6 +28,7 @@
       ".env",
       "../../.env",
       "../../../.env"
-    ]
+    ],
+    "queryCache": true
   }
 }

--- a/examples/ecomm/package.json
+++ b/examples/ecomm/package.json
@@ -26,6 +26,7 @@
       ".env",
       "../../.env",
       "../../../.env"
-    ]
+    ],
+    "queryCache": true
   }
 }

--- a/examples/snowflake/package.json
+++ b/examples/snowflake/package.json
@@ -27,6 +27,7 @@
       ".env",
       "../../.env",
       "../../../.env"
-    ]
+    ],
+    "queryCache": true
   }
 }

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -17,7 +17,6 @@ export interface Config {
   bigquery?: {
     projectId?: string
     keyPath?: string
-    location?: string
   }
 
   snowflake?: {

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -9,6 +9,7 @@ export interface Config {
   ignoredFiles: string[]
   telemetry?: boolean
   updateNotifier?: boolean
+  queryCache?: boolean
   port?: number
   host?: string
   envFile: string[] // array of paths where we can look for the env file
@@ -16,6 +17,7 @@ export interface Config {
   bigquery?: {
     projectId?: string
     keyPath?: string
+    location?: string
   }
 
   snowflake?: {

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -9,7 +9,7 @@ export interface QueryResult {
   cache?: QueryCacheStatus
 }
 
-export type QueryCacheStatus = {status: 'hit' | 'miss' | 'delegated'; provider?: 'snowflake' | 'bigquery' | 'clickhouse'; createdAt?: number; expiresAt?: number}
+export type QueryCacheStatus = {provider?: 'snowflake' | 'bigquery' | 'clickhouse'; createdAt?: number; expiresAt?: number}
 
 // A single output column in a query result.
 export type Field = {

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -9,7 +9,7 @@ export interface QueryResult {
   cache?: QueryCacheStatus
 }
 
-export type QueryCacheStatus = {status: 'hit' | 'miss' | 'delegated'; provider?: 'snowflake' | 'bigquery' | 'clickhouse'}
+export type QueryCacheStatus = {status: 'hit' | 'miss' | 'delegated'; provider?: 'snowflake' | 'bigquery' | 'clickhouse'; createdAt?: number; expiresAt?: number}
 
 // A single output column in a query result.
 export type Field = {

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -6,7 +6,10 @@ export interface QueryResult {
   error?: GrapheneError
   hash?: string // hash of the compiled sql for caching
   sql?: string
+  cache?: QueryCacheStatus
 }
+
+export type QueryCacheStatus = {status: 'hit' | 'miss' | 'delegated'; provider?: 'snowflake' | 'bigquery' | 'clickhouse'}
 
 // A single output column in a query result.
 export type Field = {

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -9,7 +9,9 @@ export interface QueryResult {
   cache?: QueryCacheStatus
 }
 
-export type QueryCacheStatus = {provider?: 'snowflake' | 'bigquery' | 'clickhouse'; createdAt?: number; expiresAt?: number}
+export type QueryCacheProvider = 'snowflake' | 'bigquery' | 'clickhouse'
+export type QueryCacheRef = {provider: QueryCacheProvider; [key: string]: unknown}
+export type QueryCacheStatus = {provider?: QueryCacheProvider; createdAt?: number; expiresAt?: number; ref?: QueryCacheRef}
 
 // A single output column in a query result.
 export type Field = {

--- a/ui/internal/LocalApp.svelte
+++ b/ui/internal/LocalApp.svelte
@@ -9,17 +9,18 @@
   import ErrorDisplay from './ErrorDisplay.svelte'
   import ChartGallery from './ChartGallery.svelte'
   import StyleGallery from './StyleGallery.svelte'
+  import {pageCacheState, refreshQueries} from './queryEngine.ts'
   import {type GrapheneError} from '../../lang/index.js'
 
   let pageInputs = activatePageInputs(new PageInputs())
   setPageInputsContext(pageInputs)
-  onDestroy(() => releasePageInputs(pageInputs))
 
   // Nav sidebar with HMR support for the virtual file list
   let navData = $state(navFiles)
   import.meta.hot?.accept('virtual:nav', mod => navData = mod.default)
 
   let pathName = window.location.pathname.replace(/^\//, '') || 'index'
+  let ageTimer: number | undefined
 
   // Track compile errors from both initial load and subsequent HMR failures.
   let compileError = $state<GrapheneError | null>(null)
@@ -43,8 +44,12 @@
   // The md file is dynamically imported, so even if there's a compile error, we'll still load LocalApp and can show the user the issue
   let Page = $state<any>(null)
   let pageMeta = $state<any>({})
+  let now = $state(Date.now())
+  let cacheAge = $derived(formatCacheAge($pageCacheState.oldestCreatedAt, now))
 
   onMount(async () => {
+    ageTimer = window.setInterval(() => now = Date.now(), 60_000)
+
     try {
       // force fonts to load before we mount the component.
       // This is important for echarts, as it measures text and if done with the wrong font, then
@@ -70,12 +75,38 @@
       window.$GRAPHENE.appLoading = false
     }
   })
+
+  onDestroy(() => {
+    releasePageInputs(pageInputs)
+    if (ageTimer) window.clearInterval(ageTimer)
+  })
+
+  function formatCacheAge(createdAt: number | undefined, timestamp: number) {
+    if (!createdAt) return ''
+
+    let ageMs = Math.max(0, timestamp - createdAt)
+    let minutes = Math.floor(ageMs / 60_000)
+    if (minutes < 1) return 'under 1m old'
+    if (minutes < 60) return `${minutes}m old`
+
+    let hours = Math.floor(minutes / 60)
+    if (hours < 24) return `${hours}h old`
+
+    return `${Math.floor(hours / 24)}d old`
+  }
 </script>
 
 <SidebarToggle style='position:fixed;top:2rem;left:2rem;opacity:0.3;' />
 <Sidebar>
   <PageNavGroup files={navData} />
 </Sidebar>
+
+{#if cacheAge}
+  <div class="query-cache-status" aria-live="polite">
+    <span>Oldest cached result {cacheAge}</span>
+    <button type="button" onclick={() => refreshQueries()} disabled={$pageCacheState.loading}>Refresh</button>
+  </div>
+{/if}
 
 <main id="content" class={{pageContent: compileError || !!Page, dashboardLayout: pageMeta.layout == 'dashboard'}}>
   {#if compileError}
@@ -102,6 +133,55 @@
   }
 
   .page-error-heading { margin-top: 0; }
+
+  .query-cache-status {
+    position: fixed;
+    top: 2rem;
+    right: 2rem;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    max-width: calc(100vw - 4rem);
+    padding: 6px 8px 6px 10px;
+    border: 1px solid #d9dee7;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+    color: #475569;
+    font-size: 12px;
+    line-height: 1.2;
+  }
+
+  .query-cache-status button {
+    flex: 0 0 auto;
+    min-height: 26px;
+    padding: 4px 8px;
+    border: 1px solid #cbd5e1;
+    border-radius: 5px;
+    background: #fff;
+    color: #1f2937;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .query-cache-status button:hover:not(:disabled) {
+    border-color: #94a3b8;
+    background: #f8fafc;
+  }
+
+  .query-cache-status button:disabled {
+    cursor: default;
+    opacity: 0.55;
+  }
+
+  @media (max-width: 720px) {
+    .query-cache-status {
+      top: 1.25rem;
+      right: 1rem;
+      max-width: calc(100vw - 5rem);
+    }
+  }
 
   /* want to control this margin so it lines up with the SidebarToggle */
   main h1:first-child {

--- a/ui/internal/clientCache.ts
+++ b/ui/internal/clientCache.ts
@@ -4,6 +4,23 @@
 
 const TTL_MS = 1000 * 60 * 60 * 2
 
+export interface BrowserCachedResult<T> {
+  result: T
+  cache: BrowserCacheMetadata
+}
+
+export interface BrowserCacheMetadata {
+  createdAt: number
+  expiresAt: number
+}
+
+interface QueryResultCacheMetadata {
+  cache?: {
+    createdAt?: number
+    expiresAt?: number
+  }
+}
+
 let cache: Cache | null = null
 async function getCache() {
   cache ||= await caches.open('graphene-data')
@@ -15,21 +32,25 @@ export async function getHashes(): Promise<string[]> {
   let keys = await store.keys()
   return keys
     .map(k => {
-      let url = new URL(k.url)
-      let expires = Number(url.searchParams.get('expires') || 0)
-      if (expires < Date.now()) {
+      let entry = parseCacheKey(k)
+      if (!entry || entry.expiresAt < Date.now()) {
         store.delete(k)
         return null
       }
-      return url.pathname.replace(/^\//, '')
+      return entry.hash
     })
     .filter(Boolean) as string[]
 }
 
-export async function cacheRead(hash: string): Promise<any | null> {
+export async function cacheRead<T>(hash: string): Promise<BrowserCachedResult<T> | null> {
   let store = await getCache()
-  let resp = await store.match(`https://graphene-cache/${hash}`, {ignoreSearch: true})
-  return await resp?.clone().json()
+  let entry = await findCacheEntry(store, hash)
+  if (!entry) return null
+
+  let resp = await store.match(entry.request)
+  let result = (await resp?.clone().json()) as T | undefined
+  if (!result) return null
+  return {result, cache: {createdAt: entry.createdAt, expiresAt: entry.expiresAt}}
 }
 
 export async function cacheWrite(hash: string, response: Response) {
@@ -40,6 +61,40 @@ export async function cacheWrite(hash: string, response: Response) {
   let existing = await store.keys(`https://graphene-cache/${hash}`, {ignoreSearch: true})
   existing.forEach(key => store.delete(key))
 
-  let expiresAt = Date.now() + TTL_MS
-  await store.put(`https://graphene-cache/${hash}?expires=${expiresAt}`, response)
+  let now = Date.now()
+  let body: QueryResultCacheMetadata = await response
+    .clone()
+    .json()
+    .catch(() => ({}))
+  let createdAt = Number(body?.cache?.createdAt || now)
+  let browserExpiresAt = now + TTL_MS
+  let serverExpiresAt = Number(body?.cache?.expiresAt || browserExpiresAt)
+  let expiresAt = Math.min(browserExpiresAt, serverExpiresAt)
+  await store.put(cacheUrl(hash, createdAt, expiresAt), response)
+}
+
+async function findCacheEntry(store: Cache, hash: string) {
+  let keys = await store.keys(`https://graphene-cache/${hash}`, {ignoreSearch: true})
+  let now = Date.now()
+  for (let request of keys) {
+    let entry = parseCacheKey(request)
+    if (!entry) continue
+    if (entry.expiresAt >= now) return {...entry, request}
+    store.delete(request)
+  }
+  return null
+}
+
+function parseCacheKey(request: Request) {
+  let url = new URL(request.url)
+  let hash = url.pathname.replace(/^\//, '')
+  let expiresAt = Number(url.searchParams.get('expires') || 0)
+  if (!hash || !expiresAt) return null
+
+  let createdAt = Number(url.searchParams.get('createdAt') || 0) || expiresAt - TTL_MS
+  return {hash, createdAt, expiresAt}
+}
+
+function cacheUrl(hash: string, createdAt: number, expiresAt: number) {
+  return `https://graphene-cache/${hash}?createdAt=${createdAt}&expires=${expiresAt}`
 }

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -6,7 +6,7 @@ import {writable} from 'svelte/store'
 import type {GrapheneError} from '../../lang/index.d.ts'
 
 import {type QueryResult, type Field} from '../component-utilities/types.ts'
-import {cacheRead, cacheWrite, getHashes} from './clientCache.ts'
+import {type BrowserCacheMetadata, cacheRead, cacheWrite, getHashes} from './clientCache.ts'
 import {getActivePageInputs, type ParamSnapshot} from './pageInputs.svelte.ts'
 
 type ResultHandler = (res: QueryResult | void) => void
@@ -34,7 +34,12 @@ export interface PageCacheState {
   loading: boolean
 }
 
-export type QueryFetcher = (req: QueryRequest, options?: {refresh?: boolean}) => Promise<QueryResult>
+interface QueryFetchResult {
+  result: QueryResult
+  browserCache?: BrowserCacheMetadata
+}
+
+export type QueryFetcher = (req: QueryRequest, options?: {refresh?: boolean}) => Promise<QueryFetchResult>
 
 let runPending: Promise<void> | null = null
 let refreshNextRun = false
@@ -103,7 +108,7 @@ async function runNode(n: QueryNode, refresh = false) {
   try {
     let res = await queryFetcher({params, gsql, hashes, repoId: window.$GRAPHENE?.repoId}, {refresh})
     updateQueryCacheTimestamp(n, res)
-    let result = translateData(res, n)
+    let result = translateData(res.result, n)
     if (n.source) queryResults[n.source] = result // TODO do we still need queryResults? Seems like a hack
     n.callback(result)
   } catch (e) {
@@ -118,7 +123,7 @@ async function runNode(n: QueryNode, refresh = false) {
   }
 }
 
-async function fetchWithCache(req: QueryRequest, options: {refresh?: boolean} = {}): Promise<QueryResult> {
+async function fetchWithCache(req: QueryRequest, options: {refresh?: boolean} = {}): Promise<QueryFetchResult> {
   let response = await fetch('/_api/query', {
     method: 'POST',
     headers: {'Content-Type': 'application/json', ...(options.refresh ? {'Cache-Control': 'no-cache'} : {})},
@@ -128,7 +133,9 @@ async function fetchWithCache(req: QueryRequest, options: {refresh?: boolean} = 
 
   // cache hit. Read data out of the browser cache and return it
   if (response.status == 304) {
-    return await cacheRead(hash)
+    let cached = await cacheRead<QueryResult>(hash)
+    if (cached) return {result: cached.result, browserCache: cached.cache}
+    throw new Error('Browser cache entry was missing for query result')
   }
 
   if (!response.ok) {
@@ -139,7 +146,7 @@ async function fetchWithCache(req: QueryRequest, options: {refresh?: boolean} = 
   }
 
   cacheWrite(hash, response.clone())
-  return await response.json()
+  return {result: await response.json()}
 }
 
 function runAll() {
@@ -202,8 +209,8 @@ export function translateData(data: any, node: QueryNode): QueryResult {
 
 const isQueryLoading = () => !!queries.find(q => q.loading)
 
-function updateQueryCacheTimestamp(n: QueryNode, res: QueryResult) {
-  let createdAt = res.cache?.createdAt
+function updateQueryCacheTimestamp(n: QueryNode, res: QueryFetchResult) {
+  let createdAt = res.result.cache?.createdAt || res.browserCache?.createdAt
   if (createdAt) {
     cachedQueryTimestamps.set(n, createdAt)
   } else {

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -1,6 +1,8 @@
 // The query engine gathers query requests and inputs from components, and issues requests to the server.
 // When inputs change, it takes care of notifying affected components and requesting new data.
 
+import {writable} from 'svelte/store'
+
 import type {GrapheneError} from '../../lang/index.d.ts'
 
 import {type QueryResult, type Field} from '../component-utilities/types.ts'
@@ -27,14 +29,22 @@ export interface QueryRequest {
   repoId: string
 }
 
-export type QueryFetcher = (req: QueryRequest) => Promise<QueryResult>
+export interface PageCacheState {
+  oldestCreatedAt?: number
+  loading: boolean
+}
+
+export type QueryFetcher = (req: QueryRequest, options?: {refresh?: boolean}) => Promise<QueryResult>
 
 let runPending: Promise<void> | null = null
+let refreshNextRun = false
 let queries = [] as QueryNode[]
 let queryResults = {} as Record<string, {rows: any[]; fields?: Field[]}>
+let cachedQueryTimestamps = new Map<QueryNode, number>()
 
 let queryFetcher: QueryFetcher = fetchWithCache
 export const setQueryFetcher = f => (queryFetcher = f)
+export const pageCacheState = writable<PageCacheState>({loading: false})
 
 // Called by GrapheneQuery tags to register a named query on the page
 function registerQuery(name: string, contents: string) {
@@ -60,23 +70,28 @@ function query(source: string, fields: Record<string, string | string[]>, callba
 }
 
 function unsubscribe(callback: ResultHandler) {
+  queries.filter(q => q.callback === callback).forEach(q => cachedQueryTimestamps.delete(q))
   queries = queries.filter(q => q.callback !== callback)
+  updatePageCacheState()
 }
 
 function resetQueryEngine() {
   queries = []
   Object.keys(queryResults).forEach(key => delete queryResults[key])
+  cachedQueryTimestamps.clear()
+  updatePageCacheState()
   getActivePageInputs().reset()
 }
 
 // Actually runs a given query that some frontend component is listening to.
 // This is pretty dumb at the moment, it simply concats all code fenced queries as table statements, then appends the actual query at the end.
-async function runNode(n: QueryNode) {
+async function runNode(n: QueryNode, refresh = false) {
   if (!n.callback) throw new Error('running node nobody is listening to')
 
   n.callback() // notifies listeners we're back in the loading state
   n.loading = true
   n.error = undefined
+  updatePageCacheState()
 
   // build up the request body. Hashes is the list of ETag hashes currently in our browser cache. We send all of them,
   // letting the server determine the hash of this particular query, and whether data we already have is acceptable.
@@ -86,24 +101,27 @@ async function runNode(n: QueryNode) {
   let params = getActivePageInputs().getParams()
 
   try {
-    let res = await queryFetcher({params, gsql, hashes, repoId: window.$GRAPHENE?.repoId})
+    let res = await queryFetcher({params, gsql, hashes, repoId: window.$GRAPHENE?.repoId}, {refresh})
+    updateQueryCacheTimestamp(n, res)
     let result = translateData(res, n)
     if (n.source) queryResults[n.source] = result // TODO do we still need queryResults? Seems like a hack
     n.callback(result)
   } catch (e) {
+    cachedQueryTimestamps.delete(n)
     let err = typeof e == 'string' ? new Error(e) : (e as Error)
     let grapheneError = err as GrapheneError
     n.error = {...grapheneError, componentId: n.componentId || grapheneError.componentId, message: err.message, stack: err.stack}
     n.callback({rows: [], fields: [], error: n.error, sql: ''})
   } finally {
     n.loading = false
+    updatePageCacheState()
   }
 }
 
-async function fetchWithCache(req: QueryRequest): Promise<QueryResult> {
+async function fetchWithCache(req: QueryRequest, options: {refresh?: boolean} = {}): Promise<QueryResult> {
   let response = await fetch('/_api/query', {
     method: 'POST',
-    headers: {'Content-Type': 'application/json'},
+    headers: {'Content-Type': 'application/json', ...(options.refresh ? {'Cache-Control': 'no-cache'} : {})},
     body: JSON.stringify(req),
   })
   let hash = response.headers.get('ETag') || ''
@@ -129,13 +147,23 @@ function runAll() {
   runPending = Promise.resolve()
     .then(_runAll)
     .finally(() => (runPending = null))
+  return runPending
+}
+
+export async function refreshQueries() {
+  refreshNextRun = true
+  if (runPending) await runPending
+  return runAll()
 }
 
 async function _runAll() {
+  let refresh = refreshNextRun
+  refreshNextRun = false
+
   await Promise.all(
     queries.map(async n => {
       if (!n.callback) return
-      await runNode(n)
+      await runNode(n, refresh)
     }),
   )
 }
@@ -174,6 +202,24 @@ export function translateData(data: any, node: QueryNode): QueryResult {
 
 const isQueryLoading = () => !!queries.find(q => q.loading)
 
+function updateQueryCacheTimestamp(n: QueryNode, res: QueryResult) {
+  let createdAt = res.cache?.createdAt
+  if (createdAt) {
+    cachedQueryTimestamps.set(n, createdAt)
+  } else {
+    cachedQueryTimestamps.delete(n)
+  }
+  updatePageCacheState()
+}
+
+function updatePageCacheState() {
+  let timestamps = [...cachedQueryTimestamps.values()]
+  pageCacheState.set({
+    oldestCreatedAt: timestamps.length ? Math.min(...timestamps) : undefined,
+    loading: isQueryLoading(),
+  })
+}
+
 if (typeof window !== 'undefined') {
   Object.assign(window.$GRAPHENE, {
     getParam: (name: string) => getActivePageInputs().getParam(name),
@@ -186,6 +232,7 @@ if (typeof window !== 'undefined') {
     unsubscribe,
     resetQueryEngine,
     rerunQueries: runAll,
+    refreshQueries,
     isQueryLoading,
     queryResults,
   })

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -109,8 +109,9 @@ test('remaps Snowflake-style uppercase query result keys to requested field casi
   await expect(page).screenshot('markdown-snowflake-uppercase-result-keys')
 })
 
-test('shows page cache age and refreshes queries without cache', async ({server, page}) => {
+test('shows browser cache age and refreshes queries without cache', async ({server, page}) => {
   let cacheControlHeaders: string[] = []
+  let requestCount = 0
   server.mockFile(
     '/index.md',
     `
@@ -125,15 +126,66 @@ test('shows page cache age and refreshes queries without cache', async ({server,
   await page.route('**/_api/query', async route => {
     let cacheControl = route.request().headers()['cache-control'] || ''
     cacheControlHeaders.push(cacheControl)
+    requestCount += 1
+    if (requestCount == 2) {
+      await route.fulfill({status: 304, headers: {ETag: 'browser-cache-status'}})
+      return
+    }
+
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      headers: {ETag: `cache-status-${cacheControlHeaders.length}`},
+      headers: {ETag: 'browser-cache-status'},
       body: JSON.stringify({
         rows: [{num: 3}],
         fields: [{name: 'num', type: scalarType('number')}],
         sql: '',
-        cache: cacheControl == 'no-cache' ? undefined : {status: 'hit', provider: 'snowflake', createdAt: Date.now() - 125 * 60 * 1000},
+      }),
+    })
+  })
+
+  await page.goto(server.url() + '/')
+  await waitForGrapheneLoad(page)
+  await expect(page.getByText('Oldest cached result')).not.toBeVisible()
+
+  await page.evaluate(() => window.$GRAPHENE.rerunQueries())
+  await expect(page.getByText('Oldest cached result under 1m old')).toBeVisible()
+  await expect(page).screenshot('markdown-query-cache-status')
+
+  await page.getByRole('button', {name: 'Refresh'}).click()
+  await expect.poll(() => cacheControlHeaders.at(-1)).toBe('no-cache')
+  await expect(page.getByText('Oldest cached result')).not.toBeVisible()
+})
+
+test('uses warehouse cache age when browser-cached warehouse results are reused', async ({server, page}) => {
+  let requestCount = 0
+  server.mockFile(
+    '/index.md',
+    `
+    \`\`\`gsql cached_count
+    select 3 as num
+    \`\`\`
+
+    <Value data="cached_count" column="num" />
+  `,
+  )
+
+  await page.route('**/_api/query', async route => {
+    requestCount += 1
+    if (requestCount == 2) {
+      await route.fulfill({status: 304, headers: {ETag: 'warehouse-cache-status'}})
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: {ETag: 'warehouse-cache-status'},
+      body: JSON.stringify({
+        rows: [{num: 3}],
+        fields: [{name: 'num', type: scalarType('number')}],
+        sql: '',
+        cache: {status: 'hit', provider: 'snowflake', createdAt: Date.now() - 125 * 60 * 1000},
       }),
     })
   })
@@ -141,11 +193,44 @@ test('shows page cache age and refreshes queries without cache', async ({server,
   await page.goto(server.url() + '/')
   await waitForGrapheneLoad(page)
   await expect(page.getByText('Oldest cached result 2h old')).toBeVisible()
-  await expect(page).screenshot('markdown-query-cache-status')
 
-  await page.getByRole('button', {name: 'Refresh'}).click()
-  await expect.poll(() => cacheControlHeaders.at(-1)).toBe('no-cache')
-  await expect(page.getByText('Oldest cached result')).not.toBeVisible()
+  await page.evaluate(() => window.$GRAPHENE.rerunQueries())
+  await expect(page.getByText('Oldest cached result 2h old')).toBeVisible()
+})
+
+test('expires browser cache entries no later than warehouse cache expiration', async ({server, page}) => {
+  let requestBodies: any[] = []
+  server.mockFile(
+    '/index.md',
+    `
+    \`\`\`gsql cached_count
+    select 3 as num
+    \`\`\`
+
+    <Value data="cached_count" column="num" />
+  `,
+  )
+
+  await page.route('**/_api/query', async route => {
+    requestBodies.push(route.request().postDataJSON())
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: {ETag: 'expired-warehouse-cache-status'},
+      body: JSON.stringify({
+        rows: [{num: 3}],
+        fields: [{name: 'num', type: scalarType('number')}],
+        sql: '',
+        cache: {status: 'hit', provider: 'snowflake', createdAt: Date.now() - 125 * 60 * 1000, expiresAt: Date.now() - 1},
+      }),
+    })
+  })
+
+  await page.goto(server.url() + '/')
+  await waitForGrapheneLoad(page)
+  await page.evaluate(() => window.$GRAPHENE.rerunQueries())
+
+  await expect.poll(() => requestBodies[1]?.hashes).toEqual([])
 })
 
 test('deduplicates chart query fields already used for sort', async ({server, page}) => {

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -185,7 +185,7 @@ test('uses warehouse cache age when browser-cached warehouse results are reused'
         rows: [{num: 3}],
         fields: [{name: 'num', type: scalarType('number')}],
         sql: '',
-        cache: {status: 'hit', provider: 'snowflake', createdAt: Date.now() - 125 * 60 * 1000},
+        cache: {provider: 'snowflake', createdAt: Date.now() - 125 * 60 * 1000},
       }),
     })
   })
@@ -221,7 +221,7 @@ test('expires browser cache entries no later than warehouse cache expiration', a
         rows: [{num: 3}],
         fields: [{name: 'num', type: scalarType('number')}],
         sql: '',
-        cache: {status: 'hit', provider: 'snowflake', createdAt: Date.now() - 125 * 60 * 1000, expiresAt: Date.now() - 1},
+        cache: {provider: 'snowflake', createdAt: Date.now() - 125 * 60 * 1000, expiresAt: Date.now() - 1},
       }),
     })
   })

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -109,6 +109,45 @@ test('remaps Snowflake-style uppercase query result keys to requested field casi
   await expect(page).screenshot('markdown-snowflake-uppercase-result-keys')
 })
 
+test('shows page cache age and refreshes queries without cache', async ({server, page}) => {
+  let cacheControlHeaders: string[] = []
+  server.mockFile(
+    '/index.md',
+    `
+    \`\`\`gsql cached_count
+    select 3 as num
+    \`\`\`
+
+    <Value data="cached_count" column="num" />
+  `,
+  )
+
+  await page.route('**/_api/query', async route => {
+    let cacheControl = route.request().headers()['cache-control'] || ''
+    cacheControlHeaders.push(cacheControl)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: {ETag: `cache-status-${cacheControlHeaders.length}`},
+      body: JSON.stringify({
+        rows: [{num: 3}],
+        fields: [{name: 'num', type: scalarType('number')}],
+        sql: '',
+        cache: cacheControl == 'no-cache' ? undefined : {status: 'hit', provider: 'snowflake', createdAt: Date.now() - 125 * 60 * 1000},
+      }),
+    })
+  })
+
+  await page.goto(server.url() + '/')
+  await waitForGrapheneLoad(page)
+  await expect(page.getByText('Oldest cached result 2h old')).toBeVisible()
+  await expect(page).screenshot('markdown-query-cache-status')
+
+  await page.getByRole('button', {name: 'Refresh'}).click()
+  await expect.poll(() => cacheControlHeaders.at(-1)).toBe('no-cache')
+  await expect(page.getByText('Oldest cached result')).not.toBeVisible()
+})
+
 test('deduplicates chart query fields already used for sort', async ({server, page}) => {
   server.mockFile(
     '/index.md',

--- a/ui/tests/snapshots/markdown.test.ts/markdown-query-cache-status.png
+++ b/ui/tests/snapshots/markdown.test.ts/markdown-query-cache-status.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7df059ab894dbaea7c84865f3920e8e73829d44e04f5f949aef75a13aa598f2d
+size 9297

--- a/ui/tests/snapshots/markdown.test.ts/markdown-query-cache-status.png
+++ b/ui/tests/snapshots/markdown.test.ts/markdown-query-cache-status.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7df059ab894dbaea7c84865f3920e8e73829d44e04f5f949aef75a13aa598f2d
-size 9297
+oid sha256:28dc713a16e482724a54e8de86dc51cde4d4321d834d7a82d65847f4a482bcd5
+size 9412


### PR DESCRIPTION
This PR adds a first pass at query caching on the backend, backed by supporting warehouses. This scheme does not store any query result data at all, just a metadata mapping used to utilize the warehouse's own result cache:

- Snowflake and BigQuery each supporting pulling the results of any queries in the last 24 hours, with different APIs
  - Snowflake exposes a queryId and allows that query's results to be queried with SQL
  - BigQuery allows previous jobs' results to be pulled via the API
- ClickHouse exposes a managed version of this, where we opt-in to using the query cache (and potentially stale results), and we configure a 24hr TTL, but ClickHouse handles pulling from the cache for us when we run the query. Cache metadata is returned in headers

I wired the cache metadata up to a placeholder-level UI, which looks like this:

<img width="250" height="73" alt="Screenshot 2026-05-20 at 10 40 50 AM" src="https://github.com/user-attachments/assets/4a205fa0-9dd3-46a6-91fd-7422b52704da" />

We may want to do a pass on making this look nicer before merging. Additionally, this change interacts with the existing browser cache layer. I opted to make the UI treat results from browser vs backend/warehouse cache the same. Whether served from the browser cache or backend cache we will show the age of the results with the option to refresh.