### PR TITLE
rework `check-commit-authors`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,30 +15,87 @@ jobs:
   check-commit-authors:
     if: github.event_name == 'pull_request' && github.repository == 'graphene-data/graphene'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Check commit authors
-        run: |
-          bad_commits=$(git log HEAD^1..HEAD^2 --format='%H%x09%an <%ae>%x09%s' | awk -F '\t' '
-            $2 != "Grant <grant@graphenedata.com>" &&
-            $2 != "Dylan Scott <dylan@graphenedata.com>" &&
-            $2 != "Kevin Marr <kevin@graphenedata.com>" &&
-            $2 != "Demitri Nava <navademitri@gmail.com>" { print }
-          ')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const APPROVED_FILE = '.github/APPROVED_CONTRIBUTORS';
+            const defaultBranch = context.payload.repository.default_branch;
 
-          if [ -n "$bad_commits" ]; then
-            echo "Found commits with unexpected authors:"
-            echo "$bad_commits"
-            echo ""
-            echo "Expected one of:"
-            echo "  Grant <grant@graphenedata.com>"
-            echo "  Dylan Scott <dylan@graphenedata.com>"
-            echo "  Kevin Marr <kevin@graphenedata.com>"
-            echo "  Demitri Nava <navademitri@gmail.com>"
-            exit 1
-          fi
+            async function getTextFile(path) {
+              const { data } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path,
+                ref: defaultBranch,
+              });
+
+              if (!('content' in data) || typeof data.content !== 'string') {
+                throw new Error(`Expected file content for ${path}`);
+              }
+
+              return Buffer.from(data.content, 'base64').toString('utf8');
+            }
+
+            function parseList(content) {
+              return content.split('\n').map(line => line.trim()).filter(line => line && !line.startsWith('#'));
+            }
+
+            function parseApprovedContributors(content) {
+              return new Map(parseList(content).map(line => {
+                const [user, email, extra] = line.split(/\s+/);
+                if (extra) throw new Error(`Expected "username" or "username email" in ${APPROVED_FILE}: ${line}`);
+                return [user.toLowerCase(), email?.toLowerCase() ?? null];
+              }));
+            }
+
+            const approvedContributors = parseApprovedContributors(await getTextFile(APPROVED_FILE));
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const failures = [];
+            for (const commit of commits) {
+              const sha = commit.sha.slice(0, 12);
+              const authorName = commit.commit.author?.name ?? '(unknown)';
+              const authorEmail = commit.commit.author?.email ?? '';
+              const authorLogin = commit.author?.login?.toLowerCase();
+              const authorLabel = authorEmail ? `${authorName} <${authorEmail}>` : authorName;
+
+              if (!authorLogin) {
+                failures.push(`${sha}: ${authorLabel} is not associated with a GitHub user`);
+                continue;
+              }
+
+              if (!approvedContributors.has(authorLogin)) {
+                failures.push(`${sha}: ${authorLabel} is associated with unapproved GitHub user @${authorLogin}`);
+                continue;
+              }
+
+              const requiredEmail = approvedContributors.get(authorLogin);
+              if (requiredEmail && authorEmail.toLowerCase() !== requiredEmail) {
+                failures.push(`${sha}: ${authorLabel} is associated with @${authorLogin}, but must use ${requiredEmail}`);
+              }
+            }
+
+            if (failures.length === 0) {
+              console.log(`All ${commits.length} commit authors are approved`);
+              return;
+            }
+
+            core.setFailed([
+              'Found commits with unexpected authors:',
+              ...failures.map(failure => `  - ${failure}`),
+              '',
+              `Approved GitHub users and any required author emails are listed in ${APPROVED_FILE}.`,
+            ].join('\n'));
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR reworks the `check-commit-authors` CI check to primarily check github usernames using a list in `.github/APPROVED_CONTRIBUTORS`, with an optional whitelisted email (specified for employees) in which case commits by that user must be from that email.