### PR TITLE
list approved contributors by github username

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -1,0 +1,6 @@
+# One GitHub username per line. Matching is case-insensitive.
+kevinmarr
+rogueg
+dylanscott
+
+demitrin

--- a/.github/EMAIL_BLACKLIST
+++ b/.github/EMAIL_BLACKLIST
@@ -1,0 +1,9 @@
+# One email pattern per line. Matching is case-insensitive and supports * and ? wildcards.
+caseymarr@gmail.com
+me@grantmarvin.com
+dylan.scott@gmail.com
+
+noreply@anthropic.com
+cursoragent@cursor.com
+pi-agent@*
+pi-bot@*


### PR DESCRIPTION
This PR is a pre-requisite to #423, since the CI check in that PR pulls these lists from main, so that contributors can't add themselves in their own PR.