### PR TITLE
Axis defaults should respect the type

### DIFF
--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -272,18 +272,14 @@ function inferAxesFromEncodedFields(config: NormalConfig, fields: Field[], rows:
     if (!axis) continue
     let seriesOnAxis = config.series.filter(entry => Number(entry?.xAxisIndex ?? 0) === axisIndex)
     let field = seriesOnAxis.map(entry => getEncodeField(entry, fields, 'x')).find(Boolean)
-    let inferred = inferAxisFromField(field, rows)
-
-    config.xAxis[axisIndex] = {...inferred, ...axis, axisLabel: {...inferred.axisLabel, ...axis.axisLabel}, axisPointer: {...inferred.axisPointer, ...axis.axisPointer}}
+    config.xAxis[axisIndex] = inferAxisFromField(field, rows, axis)
   }
 
   for (let [axisIndex, axis] of config.yAxis.entries()) {
     if (!axis) continue
     let seriesOnAxis = config.series.filter(entry => Number(entry?.yAxisIndex ?? 0) === axisIndex)
     let field = seriesOnAxis.map(entry => getSeriesValueField(entry, fields)).find(Boolean)
-    let inferred = inferAxisFromField(field, rows)
-
-    config.yAxis[axisIndex] = {...inferred, ...axis, axisLabel: {...inferred.axisLabel, ...axis.axisLabel}, axisPointer: {...inferred.axisPointer, ...axis.axisPointer}}
+    config.yAxis[axisIndex] = inferAxisFromField(field, rows, axis)
   }
 }
 
@@ -678,20 +674,25 @@ function horizontalBarGuard(config: NormalConfig, fields: Field[]) {
 }
 
 // Build axis defaults from field metadata, including temporal domains and formatters.
-function inferAxisFromField(field: Field | undefined, rows: Record<string, any>[]) {
-  if (!field) return {type: 'category'}
+function inferAxisFromField(field: Field | undefined, rows: Record<string, any>[], axis: Record<string, any> = {}) {
+  if (!field) {
+    axis.type ||= 'category'
+    return axis
+  }
   if (typeof field.type !== 'string') throw new Error(`Field ${field.name} has unsupported non-scalar type: array`)
 
-  let type: 'time' | 'value' | 'category' = 'category'
-  if (field.type === 'date' || field.type === 'timestamp') type = 'time'
-  if (field.type === 'number') type = 'value'
-  let axis: Record<string, any> = {field, type}
+  let inferredType: 'time' | 'value' | 'category' = 'category'
+  if (field.type === 'date' || field.type === 'timestamp') inferredType = 'time'
+  if (field.type === 'number') inferredType = 'value'
 
-  if (type === 'value') {
+  axis.field = field
+  axis.type ||= inferredType
+
+  if (axis.type === 'value') {
     let domain = temporalValueDomain(field, rows)
     if (domain) {
-      axis.min = domain[0]
-      axis.max = domain[1]
+      axis.min ??= domain[0]
+      axis.max ??= domain[1]
     }
 
     if (field.metadata?.timeGrain === 'year') {
@@ -699,9 +700,13 @@ function inferAxisFromField(field: Field | undefined, rows: Record<string, any>[
       // doesn't end up with the 2000/2002/2004/2005 stub-label pattern.
       let ticks = domain ? niceIntegerTicks(domain[0], domain[1]) : []
       let formatter = (value: unknown) => axisFormatter(value, field)
-      axis.axisLabel = {customValues: ticks, formatter}
-      axis.axisTick = {customValues: ticks}
-      axis.axisPointer = {label: {formatter}}
+      axis.axisLabel = {...axis.axisLabel}
+      axis.axisLabel.customValues ??= ticks
+      axis.axisLabel.formatter ??= formatter
+      axis.axisTick = {...axis.axisTick}
+      axis.axisTick.customValues ??= ticks
+      axis.axisPointer = {...axis.axisPointer, label: {...axis.axisPointer?.label}}
+      axis.axisPointer.label.formatter ??= formatter
       return axis
     }
 
@@ -710,13 +715,14 @@ function inferAxisFromField(field: Field | undefined, rows: Record<string, any>[
       // visually they are discrete buckets. Pin tick positions to evenly-spaced
       // integers so we never get a stub boundary label (e.g. weeks 1, 14, 27, 40, 53).
       let ticks = domain ? niceIntegerTicks(domain[0], domain[1]) : []
-      axis.axisLabel = {
-        hideOverlap: true,
-        customValues: ticks,
-        formatter: (value: unknown) => (domain && (Number(value) < domain[0] || Number(value) > domain[1]) ? '' : formatTimeOrdinal(field, value)),
-      }
-      axis.axisTick = {customValues: ticks}
-      axis.axisPointer = {label: {formatter: (value: unknown) => formatTimeOrdinal(field, value)}}
+      axis.axisLabel = {...axis.axisLabel}
+      axis.axisLabel.hideOverlap ??= true
+      axis.axisLabel.customValues ??= ticks
+      axis.axisLabel.formatter ??= (value: unknown) => (domain && (Number(value) < domain[0] || Number(value) > domain[1]) ? '' : formatTimeOrdinal(field, value))
+      axis.axisTick = {...axis.axisTick}
+      axis.axisTick.customValues ??= ticks
+      axis.axisPointer = {...axis.axisPointer, label: {...axis.axisPointer?.label}}
+      axis.axisPointer.label.formatter ??= (value: unknown) => formatTimeOrdinal(field, value)
       return axis
     }
   }

--- a/ui/tests/snapshots/viz.test.ts/echarts-heatmap-numeric-category-axis.png
+++ b/ui/tests/snapshots/viz.test.ts/echarts-heatmap-numeric-category-axis.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4d81063afc6312d177c21666fbe625399e4bf78d62ffc875cec3a75e2091c05
+size 6940

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -114,6 +114,36 @@ test('echarts supports splitBy=[group,stack] for grouped+stacked bars', async ({
   await expect(chart.el).screenshot('echarts-splitby-group-stack')
 })
 
+test('echarts heatmap supports numeric values on explicit category axis', async ({mount, chart}) => {
+  let rows = [
+    {season: 2021, team: 'Aces', win_pct: 71},
+    {season: 2022, team: 'Aces', win_pct: 65},
+    {season: 2023, team: 'Aces', win_pct: 82},
+    {season: 2021, team: 'Bears', win_pct: 48},
+    {season: 2022, team: 'Bears', win_pct: 55},
+    {season: 2023, team: 'Bears', win_pct: 43},
+  ]
+  let fields = [
+    {name: 'season', type: scalarType('number'), metadata: {timeGrain: 'year'}},
+    {name: 'team', type: scalarType('string')},
+    {name: 'win_pct', type: scalarType('number'), metadata: {pct: true}},
+  ]
+
+  await mount('components/ECharts.svelte', {
+    data: {rows, fields},
+    height: '320px',
+    config: {
+      title: {text: 'Win Percentage by Season'},
+      tooltip: {trigger: 'item'},
+      visualMap: {min: 0, max: 100, dimension: 'win_pct', show: false, inRange: {color: ['#b4464b', '#f3efe7', '#2f7f6f']}},
+      xAxis: {type: 'category', position: 'top', axisLabel: {interval: 0}},
+      yAxis: {type: 'category', inverse: true},
+      series: [{type: 'heatmap', encode: {x: 'season', y: 'team', value: 'win_pct', sort: 'season asc'}}],
+    },
+  })
+  await expect(chart.el).screenshot('echarts-heatmap-numeric-category-axis')
+})
+
 test('bar chart', async ({mount, chart}) => {
   await mount('components/BarChart.svelte', {data: timeseries(), x: 'month', y: 'sales_usd0k', title: 'Monthly Sales'})
   await expect(chart.el).screenshot('bar-chart')
@@ -189,7 +219,7 @@ test('bar chart bounds numeric year x axis from metadata', async ({mount, chart}
 
   await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'year', y: 'flights', splitBy: 'status', arrange: 'stack', title: 'Flight Status by Year'})
   await chart.chartDispatchAction({type: 'showTip', seriesIndex: 0, dataIndex: 2})
-  await expect(chart.el).screenshot('bar-chart-numeric-year-domain-tooltip')
+  await expect(chart.el).screenshot('bar-chart-numeric-year-domain')
 })
 
 test('horizontal bar chart', async ({mount, chart}) => {


### PR DESCRIPTION
When we're inferring axis defaults, we need to respect any explicit axis `type` set in an ECharts component. In this added test, the field on the x axis is numeric and would be a value axis, so we set a min/max. But the EChart config sets it back to `category`, in which case the min/max breaks the chart.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>