### PR TITLE
Don't coerce input strings to dates

### DIFF
--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -1376,13 +1376,6 @@ describe('lang', () => {
     expect("from users select created_at + 'many moons'").toHaveDiagnostic(/Invalid date arithmetic/i)
   })
 
-  it('parses temporal parameters at runtime', () => {
-    let queries = analyze(`${testTables}
-      from users select id where created_at >= $start_date
-    `)
-    expect(toSql(queries[0], {start_date: '2024-01-01'})).toMatch(/>=DATE '2024-01-01'/)
-  })
-
   it('diagnoses invalid timestamp literals', () => {
     expect("from users select id where created_at >= 'soonish'").toHaveDiagnostic(/Cannot parse as timestamp/i)
   })

--- a/lang/params.ts
+++ b/lang/params.ts
@@ -1,7 +1,5 @@
 import type {Query} from './types.ts'
 
-import {parseTemporalLiteral} from './temporal.ts'
-
 // Fill in parameter values in a query's SQL strings
 // Params look like $paramName in the SQL
 export function fillInParams(query: Query, params: Record<string, any>) {
@@ -16,15 +14,7 @@ function replaceParams(sql: string, params: Record<string, any>): string {
     let value = params[name]
     if (value === undefined) throw new Error(`Missing param $${name}`)
     if (value === null) return 'NULL'
-    if (typeof value === 'string') {
-      // Check if it looks like a date/timestamp
-      let asDate = parseTemporalLiteral(value, 'date')
-      if (asDate) return `DATE '${asDate.literal}'`
-      let asTimestamp = parseTemporalLiteral(value, 'timestamp')
-      if (asTimestamp) return `TIMESTAMP '${asTimestamp.literal}'`
-      // Regular string
-      return `'${value.replace(/'/g, "''")}'`
-    }
+    if (typeof value === 'string') return `'${value.replace(/'/g, "''")}'`
     if (typeof value === 'number') return value.toString()
     if (typeof value === 'boolean') return value ? 'true' : 'false'
     if (Array.isArray(value)) {


### PR DESCRIPTION
String inputs are always strings. Not sure why we added this, but it feels like the wrong solution.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>