### PR TITLE
Allow arbitrary metadata

### DIFF
--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -16,7 +16,7 @@ export type Field = {
 }
 
 // Metadata attached to fields.
-// Graphene validates user-authored metadata annotations, while inferred metadata may add internal keys.
+// Graphene allows arbitrary metadata, but for the known fields below it ensures the values are expected.
 // `price: cogs * 1.15 #ratio #currency=USD` -> {ratio: true, currency: 'USD'}
 export type FieldMeta = {
   ratio?: true // 0 to 1 value

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -883,13 +883,17 @@ describe('lang', () => {
     expect(name.metadata).toMatchObject({pii: 'true', unit: 'parsecs', description: 'More comment'})
   })
 
-  it('reports diagnostics for unknown metadata keys', () => {
-    expect(`
+  it('allows unknown metadata keys', () => {
+    analyze(`
       table foo (
         #unknown=value
         name text
       )
-    `).toHaveDiagnostic(/Unknown metadata key "#unknown"/)
+    `)
+    expect(getDiagnostics().filter(d => d.severity === 'error')).toEqual([])
+
+    let table = getTable('foo')!
+    expect(table.columns.find(c => c.name === 'name')!.metadata).toMatchObject({unknown: 'value'})
   })
 
   it('reports diagnostics for invalid metadata enum values', () => {
@@ -919,14 +923,6 @@ describe('lang', () => {
     expect(table.columns.find(c => c.name === 'distance')!.metadata).toMatchObject({unit: 'lightyears'})
   })
 
-  it('reports diagnostics for legacy plural units metadata', () => {
-    expect(`
-      table foo (
-        amount int -- revenue #units=usd
-      )
-    `).toHaveDiagnostic(/Unknown metadata key "#units"/)
-  })
-
   it('reports diagnostics for invalid flag metadata values', () => {
     expect(`
       table foo (
@@ -935,24 +931,6 @@ describe('lang', () => {
       )
     `).toHaveDiagnostic(/Metadata "#ratio" is a flag/)
     expect(getDiagnostics().some(d => /Metadata "#pii" is a flag/.test(d.message))).toBe(true)
-  })
-
-  it('reports diagnostics for unimplemented hide metadata', () => {
-    expect(`
-      table foo (
-        hidden number #hide
-      )
-    `).toHaveDiagnostic(/Unknown metadata key "#hide"/)
-  })
-
-  it('reports diagnostics for user-authored internal metadata keys', () => {
-    expect(`
-      table foo (
-        year_num int #timePart=year
-        month date #defaultName=month
-      )
-    `).toHaveDiagnostic(/Unknown metadata key "#timePart"/)
-    expect(getDiagnostics().some(d => /Unknown metadata key "#defaultName"/.test(d.message))).toBe(true)
   })
 
   it('does not parse legacy dash-hash metadata comments', () => {

--- a/lang/metadata.ts
+++ b/lang/metadata.ts
@@ -35,8 +35,6 @@ let metadataKeyRules = {
   description: {kind: 'string'},
 } as const
 
-let validMetadataKeys = Object.keys(metadataKeyRules)
-
 // Extract metadata from comments that appear directly above a syntax node.
 // Rules:
 // - `#` lines are metadata-only comments and may contain multiple `#key` / `#key=value` entries.
@@ -94,14 +92,7 @@ export function validateMetadataEntries(entries: MetadataEntry[]): MetadataDiagn
   let diagnostics: MetadataDiagnostic[] = []
   for (let entry of entries) {
     let rule = metadataKeyRules[entry.key as keyof typeof metadataKeyRules]
-    if (!rule) {
-      diagnostics.push({
-        message: `Unknown metadata key "#${entry.key}". Expected one of: ${validMetadataKeys.join(', ')}`,
-        from: entry.from,
-        to: entry.to,
-      })
-      continue
-    }
+    if (!rule) continue
 
     if (rule.kind == 'flag') {
       if (!entry.hasValue || entry.rawValue == 'true') continue


### PR DESCRIPTION
Metadata is a flexible feature that can be used to build out custom behavior in the ui. While we validate a few known keys that we use, other keys shouldn't be an error.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>