### PR TITLE
CLI `--port` arg

### DIFF
--- a/cli/background.ts
+++ b/cli/background.ts
@@ -8,7 +8,7 @@ import {config} from '../lang/config.ts'
 
 const execAsync = promisify(exec)
 
-export async function runServeInBackground(options: {entryPoint?: string; log?: (chunk: string) => void} = {}): Promise<void> {
+export async function runServeInBackground(options: {entryPoint?: string; log?: (chunk: string) => void} = {}): Promise<string> {
   let grapheneCache = getGrapheneCache(config.root)
   let logFile = path.join(grapheneCache, 'serve.log')
   await fs.ensureDir(grapheneCache)
@@ -25,28 +25,34 @@ export async function runServeInBackground(options: {entryPoint?: string; log?: 
 
   if (!child.pid) throw new Error('Failed to start server process')
 
-  await new Promise<void>((resolve, reject) => {
-    let buffer = ''
+  return await new Promise<string>((resolve, reject) => {
+    let emittedLength = 0
     let settled = false
+    let logPoll: NodeJS.Timeout
     let close = () => {
       if (settled) return false
       settled = true
-      fs.unwatchFile(logFile)
+      clearInterval(logPoll)
       fs.closeSync(log)
       return true
     }
 
-    fs.watchFile(logFile, {interval: 200}, (curr, prev) => {
-      if (curr.size > prev.size) {
-        let stream = fs.createReadStream(logFile, {start: prev.size, end: curr.size - 1})
-        stream.on('data', d => {
-          if (options.log) options.log(d.toString())
-          else process.stdout.write(d)
-          buffer = (buffer + d.toString()).slice(-200)
-          if (buffer.includes('Server running at http://localhost:') && close()) resolve()
-        })
+    let readStartupLog = () => {
+      if (settled) return
+      let contents = fs.readFileSync(logFile, 'utf8')
+      if (contents.length > emittedLength) {
+        let chunk = contents.slice(emittedLength)
+        emittedLength = contents.length
+        if (options.log) options.log(chunk)
+        else process.stdout.write(chunk)
       }
-    })
+
+      let url = contents.match(/Server running at (http:\/\/localhost:\d+)/)?.[1]
+      if (url && close()) resolve(url)
+    }
+
+    logPoll = setInterval(readStartupLog, 100)
+    readStartupLog()
 
     child.once('exit', async (code, signal) => {
       if (!close()) return

--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -116,6 +116,12 @@ describe('cli run', () => {
     expect(res.stdout.toLowerCase()).toContain('total')
   })
 
+  it('accepts --port on run commands', async () => {
+    let res = await runCli(['run', 'from flights select count() as total', '--port', '4164'], {cwd: flightDir})
+    expectCliSuccess(res, 'run query with port')
+    expect(res.stdout.toLowerCase()).toContain('total')
+  })
+
   it('runs an inline parameterized query with --input', async () => {
     let res = await runCli(['run', 'from flights where carrier = $carrier select carrier, count() as total group by 1', '--input', 'carrier=AA'], {cwd: flightDir})
     expectCliSuccess(res, 'run parameterized query')
@@ -189,6 +195,12 @@ describe('cli run', () => {
     let res = await runCli(['run', 'from flights select count()', '--input', '=AA'], {cwd: flightDir})
     expect(res.code).toBe(1)
     expect(res.stderr).toContain('Invalid --input "=AA". Expected key=value.')
+  })
+
+  it('rejects invalid --port values', async () => {
+    let res = await runCli(['run', 'from flights select count()', '--port', 'abc'], {cwd: flightDir})
+    expect(res.code).toBe(1)
+    expect(res.stderr).toContain('Invalid --port "abc". Expected an integer from 1 to 65535.')
   })
 
   it('uses a configured duckdb path when present', async () => {

--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -93,7 +93,7 @@ describe('cli serve (background)', () => {
   it('starts the server in the background and restarts cleanly', async () => {
     let first = await runCli(['serve', '--bg'], {cwd: flightDir})
     expectCliSuccess(first, 'serve start')
-    expect(first.stdout).toContain('Server running at')
+    expect(first.stdout).toContain(`Server running at http://localhost:${TEST_PORT}`)
     expect(await isServerRunning(TEST_PORT)).toBe(true)
 
     // running `serve` again should restart it
@@ -106,6 +106,19 @@ describe('cli serve (background)', () => {
     expectCliSuccess(stop, 'serve stop')
     expect(stop.stdout).toContain('Stopping server')
     expect(await isServerRunning(TEST_PORT)).toBe(false)
+  })
+
+  it('prints the configured URL when starting the background server on a custom port', async () => {
+    let port = 4164
+
+    try {
+      let res = await runCli(['serve', '--bg', '--port', String(port)], {cwd: flightDir})
+      expectCliSuccess(res, 'serve start on custom port')
+      expect(res.stdout).toContain(`Server running at http://localhost:${port}`)
+      expect(await isServerRunning(port)).toBe(true)
+    } finally {
+      await runCli(['stop'], {cwd: flightDir, env: {GRAPHENE_PORT: String(port)}})
+    }
   })
 })
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -66,10 +66,17 @@ program
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
   .option('-c, --chart <chartTitleOrComponentId>', 'Title or component ID of a specific chart to capture')
   .option('--headless', 'Run markdown pages in a headless browser instead of opening the system browser')
+  .option('--port <port>', 'Port for the local Graphene server')
   .option('-q, --query <queryName>', 'Query or table name to run from a markdown page')
   .option('--input <key=value>', 'Input value to use for parameters; repeat for multiple values', (value, previous: string[]) => previous.concat(value), [])
   .action(
-    withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; headless?: boolean; query?: string; input?: string[]}) => {
+    withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; headless?: boolean; port?: string; query?: string; input?: string[]}) => {
+      if (options.port) {
+        let port = parseRunPort(options.port, exit)
+        config.port = port
+        process.env.GRAPHENE_PORT = String(port)
+      }
+
       if (options.chart && options.query) {
         console.error('Cannot use --chart and --query together')
         return exit(1)
@@ -303,6 +310,15 @@ function parseRunInputs(values: string[], exit: (code?: number) => never): Recor
     else inputs[key] = [existing, next]
   }
   return inputs
+}
+
+function parseRunPort(value: string, exit: (code?: number) => never): number {
+  let port = Number(value)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    console.error(`Invalid --port "${value}". Expected an integer from 1 to 65535.`)
+    return exit(1)
+  }
+  return port
 }
 
 function renderSql(query: Query, inputs: Record<string, string | string[]>, exit: (code?: number) => never): string {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -72,7 +72,7 @@ program
   .action(
     withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; headless?: boolean; port?: string; query?: string; input?: string[]}) => {
       if (options.port) {
-        let port = parseRunPort(options.port, exit)
+        let port = parsePort(options.port, exit)
         config.port = port
         process.env.GRAPHENE_PORT = String(port)
       }
@@ -197,11 +197,19 @@ program
   .command('serve')
   .description('Run the local server')
   .option('--bg', 'Run the server in the background')
+  .option('--port <port>', 'Port for the local Graphene server')
   .action(
-    withTelemetry('serve', async (exit, options: {bg?: boolean}) => {
+    withTelemetry('serve', async (exit, options: {bg?: boolean; port?: string}) => {
+      if (options.port) {
+        let port = parsePort(options.port, exit)
+        config.port = port
+        process.env.GRAPHENE_PORT = String(port)
+      }
+
       await stopGrapheneIfRunning()
       if (options.bg) {
-        await runServeInBackground()
+        let url = await runServeInBackground({log: () => undefined})
+        console.log(`Server running at ${url}`)
         return exit(0)
       } else {
         let mod = await import('./serve2.ts') // load dynamically, so we're not pulling in a bunch of deps we might not need
@@ -312,7 +320,7 @@ function parseRunInputs(values: string[], exit: (code?: number) => never): Recor
   return inputs
 }
 
-function parseRunPort(value: string, exit: (code?: number) => never): number {
+function parsePort(value: string, exit: (code?: number) => never): number {
   let port = Number(value)
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     console.error(`Invalid --port "${value}". Expected an integer from 1 to 65535.`)

--- a/cli/telemetry.test.ts
+++ b/cli/telemetry.test.ts
@@ -19,10 +19,11 @@ describe('cli telemetry', () => {
   })
 
   it('tracks only safe flag names, not values', () => {
-    expect(getPresentFlags('run', ['run', 'report.md', '--headless', '--query', 'weekly_trends', '--chart', 'Revenue by Region', '--input', 'carrier=AA'])).toEqual([
+    expect(getPresentFlags('run', ['run', 'report.md', '--headless', '--query', 'weekly_trends', '--chart', 'Revenue by Region', '--input', 'carrier=AA', '--port', '4170'])).toEqual([
       'chart',
       'headless',
       'input',
+      'port',
       'query',
     ])
     expect(getPresentFlags('serve', ['serve', '--bg'])).toEqual(['bg'])

--- a/cli/telemetry.test.ts
+++ b/cli/telemetry.test.ts
@@ -26,7 +26,7 @@ describe('cli telemetry', () => {
       'port',
       'query',
     ])
-    expect(getPresentFlags('serve', ['serve', '--bg'])).toEqual(['bg'])
+    expect(getPresentFlags('serve', ['serve', '--bg', '--port', '4170'])).toEqual(['bg', 'port'])
     expect(getPresentFlags('schema', ['schema', 'analytics.orders'])).toEqual([])
   })
 

--- a/cli/telemetry/index.ts
+++ b/cli/telemetry/index.ts
@@ -12,7 +12,7 @@ export type {TelemetryCommand, TelemetryEventName, TelemetryPayloads} from './ty
 
 const DEFAULT_TELEMETRY_ENDPOINT = 'https://app.graphenedata.com/cli-telemetry'
 const SAFE_FLAG_NAMES: Partial<Record<TelemetryCommand, Record<string, string[]>>> = {
-  run: {chart: ['--chart', '-c'], headless: ['--headless'], input: ['--input'], query: ['--query', '-q']},
+  run: {chart: ['--chart', '-c'], headless: ['--headless'], input: ['--input'], port: ['--port'], query: ['--query', '-q']},
   serve: {bg: ['--bg']},
 }
 

--- a/cli/telemetry/index.ts
+++ b/cli/telemetry/index.ts
@@ -13,7 +13,7 @@ export type {TelemetryCommand, TelemetryEventName, TelemetryPayloads} from './ty
 const DEFAULT_TELEMETRY_ENDPOINT = 'https://app.graphenedata.com/cli-telemetry'
 const SAFE_FLAG_NAMES: Partial<Record<TelemetryCommand, Record<string, string[]>>> = {
   run: {chart: ['--chart', '-c'], headless: ['--headless'], input: ['--input'], port: ['--port'], query: ['--query', '-q']},
-  serve: {bg: ['--bg']},
+  serve: {bg: ['--bg'], port: ['--port']},
 }
 
 export class CliTelemetry {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,7 @@ graphene run 'from flights where carrier = $carrier select count() as total' --i
 graphene run - # Read GSQL from stdin and print results
 graphene run path/to/page.md # Open the page in your system browser and save a full-page screenshot
 graphene run path/to/page.md --headless # Run the page in a headless browser and save a full-page screenshot
+graphene run path/to/page.md --port 4170 # Use a specific local dev server port
 graphene install-browser # Install the browser used by `graphene run --headless`
 graphene run path/to/page.md --input carrier=AA # Run the page with input values, overriding page defaults
 
@@ -41,5 +42,6 @@ graphene schema my_dataset.table # Print the GSQL table statement for a database
 
 graphene serve # Start the local dev server (foreground)
 graphene serve --bg # Start the local dev server in the background
+graphene serve --bg --port 4170 # Start the background dev server on a specific port
 graphene stop # Stop the background dev server
 ```


### PR DESCRIPTION
This PR adds a `--port` argument to the `run` and `serve` CLI commands as pretty much every dogfood run in #agent-oops has complained about not having it. I also made it so that in the `--bg` case we print the serve URL in the main CLI command output, as the agent pointed out that otherwise you have to fish it out of `graphene-serve.log` if it's picking the port itself