### PR TITLE
make bare `graphene run` consistent with usage/help

### DIFF
--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -21,12 +21,13 @@ process.env.GRAPHENE_PORT = '4163'
 process.env.NODE_ENV = 'test'
 process.env.GRAPHENE_TELEMETRY_DISABLED = '1'
 
-function runCli(args: string[], options: {cwd?: string; env?: NodeJS.ProcessEnv} = {}): Promise<RunResult> {
+function runCli(args: string[], options: {cwd?: string; env?: NodeJS.ProcessEnv; stdin?: string} = {}): Promise<RunResult> {
   return new Promise(resolve => {
     let cliEntry = path.resolve(dir, 'cli.ts')
     let child = spawn('node', [cliEntry, ...args], {cwd: options.cwd, env: {...process.env, ...options.env}})
     let stdout = '',
       stderr = ''
+    if (options.stdin !== undefined) child.stdin.end(options.stdin)
     child.stdout.on('data', d => {
       stdout += d.toString()
     })
@@ -128,6 +129,12 @@ describe('cli run', () => {
     expectCliSuccess(res, 'run help with no input')
     expect(res.stdout).toContain('Usage: graphene run [options] [input]')
     expect(res.stdout).toContain('Path to file, a raw string, or "-" for stdin')
+  })
+
+  it('reads a query from stdin when input is "-"', async () => {
+    let res = await runCli(['run', '-'], {cwd: flightDir, stdin: 'from flights select count() as total'})
+    expectCliSuccess(res, 'run query from stdin')
+    expect(res.stdout.toLowerCase()).toContain('total')
   })
 
   it('runs a query against flights.duckdb (happy path)', async () => {

--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -123,6 +123,13 @@ describe('cli serve (background)', () => {
 })
 
 describe('cli run', () => {
+  it('prints help instead of reading stdin when no input is provided', async () => {
+    let res = await runCli(['run'], {cwd: flightDir})
+    expectCliSuccess(res, 'run help with no input')
+    expect(res.stdout).toContain('Usage: graphene run [options] [input]')
+    expect(res.stdout).toContain('Path to file, a raw string, or "-" for stdin')
+  })
+
   it('runs a query against flights.duckdb (happy path)', async () => {
     let res = await runCli(['run', 'from flights select count() as total'], {cwd: flightDir})
     expectCliSuccess(res, 'run query')

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -70,7 +70,12 @@ program
   .option('-q, --query <queryName>', 'Query or table name to run from a markdown page')
   .option('--input <key=value>', 'Input value to use for parameters; repeat for multiple values', (value, previous: string[]) => previous.concat(value), [])
   .action(
-    withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; headless?: boolean; port?: string; query?: string; input?: string[]}) => {
+    withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; headless?: boolean; port?: string; query?: string; input?: string[]}, command: Command) => {
+      if (!input) {
+        command.outputHelp()
+        return exit(0)
+      }
+
       if (options.port) {
         let port = parsePort(options.port, exit)
         config.port = port


### PR DESCRIPTION
I noticed that running a bare `graphene run` with no `input` argument would wait for input via stdin, which to an unsuspecting user looks like it's hanging. The usage/help says:

```
Usage: graphene run [options] [input]

Run a query or screenshot a Graphene page

Arguments:
  input                                  Path to file, a raw string, or "-" for stdin
```

This PR updates the run command so that it will only read from stdin if the user actually passes `-` for input, and prints the help on an inputless `graphene run`