### PR TITLE
support row prop for `<BigValue/>`

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -93,7 +93,7 @@ You can add YAML frontmatter at the top of a page. The following attributes are 
 - ScatterPlot: title, data, x, y, splitBy, height, width
 - PieChart: title, data, category, value, height, width
 - ECharts: data, height, width, renderer
-- BigValue: title, data, value
+- BigValue: title, data, value, row
 - Table: title, data, rows, sortable, sort, groupBy, groupType, subtotals, totalRow, link, showLinkCol, rowShading, rowLines, rowNumbers, compact, headerColor, headerFontColor, totalRowColor, totalFontColor, backgroundColor, emptyMessage
   - Column (sub-component of Table): id (column name), title, description, align, wrap, wrapTitle, colGroup, contentType, totalAgg, redNegatives
 - Value: data, column, row

--- a/docs/references/big-value.md
+++ b/docs/references/big-value.md
@@ -18,4 +18,3 @@ Here's an example:
 | value | Column or expression to pull the main value from | true | column name, stored expression name, GSQL expression | - |
 | title | Title displayed above the value | false | string | - |
 | row | Row index to pull the main value from | false | number | `0` |
-| subtitle | Subtitle displayed below the title | false | string | - |

--- a/docs/references/big-value.md
+++ b/docs/references/big-value.md
@@ -17,4 +17,5 @@ Here's an example:
 | data | GSQL query or table name | true | query name | - |
 | value | Column or expression to pull the main value from | true | column name, stored expression name, GSQL expression | - |
 | title | Title displayed above the value | false | string | - |
+| row | Row index to pull the main value from | false | number | `0` |
 | subtitle | Subtitle displayed below the title | false | string | - |

--- a/ui/components/BigValue.svelte
+++ b/ui/components/BigValue.svelte
@@ -9,9 +9,10 @@
     data: string | QueryResult
     value?: string
     title?: string
+    row?: number
   }
 
-  let {data, value = undefined, title = undefined}: Props = $props()
+  let {data, value = undefined, title = undefined, row = 0}: Props = $props()
   let logger = untrack(() => componentLogger('BigValue', {data: typeof data == 'string' ? data : undefined, value}))
 
   function formatValue(input: any, loaded: QueryResult) {
@@ -24,7 +25,7 @@
 {#snippet bigValueContent(loaded: QueryResult)}
   <div class="big-value">
     {#if title}<div class="big-value__title">{title}</div>{/if}
-    <div class="big-value__value">{formatValue(loaded?.rows?.[0]?.[value], loaded)}</div>
+    <div class="big-value__value">{formatValue(loaded?.rows?.[row]?.[value], loaded)}</div>
   </div>
 {/snippet}
 

--- a/ui/tests/bigValue.test.ts
+++ b/ui/tests/bigValue.test.ts
@@ -24,6 +24,20 @@ test('big value percent formatting', async ({mount, sharedPage}) => {
   await expect(sharedPage.locator('#component-test')).screenshot('big-value-percent')
 })
 
+test('big value can render a non-default row', async ({mount, sharedPage}) => {
+  await mount('components/BigValue.svelte', {
+    data: rowData(),
+    value: 'value',
+    row: 1,
+    title: 'Selected Row',
+  })
+
+  await expect(sharedPage.getByText('Selected Row')).toBeVisible()
+  await expect(sharedPage.getByText('$200')).toBeVisible()
+  await expect(sharedPage.getByText('$100')).not.toBeVisible()
+  await expect(sharedPage.locator('#component-test')).screenshot('big-value-row')
+})
+
 test('big value null renders em dash', async ({mount, sharedPage}) => {
   await mount('components/BigValue.svelte', {
     data: nullValueData(),
@@ -39,6 +53,12 @@ test('big value null renders em dash', async ({mount, sharedPage}) => {
 function percentData() {
   let rows = [{ratio: 0.314}] as any
   let fields = [{name: 'ratio', type: 'number', metadata: {ratio: true}}] as any
+  return {rows, fields}
+}
+
+function rowData() {
+  let rows = [{value: 100}, {value: 200}] as any
+  let fields = [{name: 'value', type: 'number', metadata: {currency: 'USD'}}] as any
   return {rows, fields}
 }
 

--- a/ui/tests/snapshots/bigValue.test.ts/big-value-row.png
+++ b/ui/tests/snapshots/bigValue.test.ts/big-value-row.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0394cfa2d4e74c49c2b06914d0b8e8500a00072f50b9de22f7baa07ed6f7eda8
+size 2951


### PR DESCRIPTION
Quick one from the [dogfood run](https://graphenedata.slack.com/archives/C09MZ1LKB7T/p1779973598188339) this morning: The agent was confused that `<Value/>` supports a row offset but `<BigValue/>` didn't.