### PR TITLE
add extra prop check to input, value components

### DIFF
--- a/examples/clickhouse/flows.md
+++ b/examples/clickhouse/flows.md
@@ -27,10 +27,10 @@ from flow_sample
 ```
 
 <Row>
-  <BigValue data=flow_summary value=trips title="Sample Trips" fmt=num0 />
-  <BigValue data=flow_summary value=routes title="Sample Routes" fmt=num0 />
-  <BigValue data=flow_summary value=pickup_neighborhoods title="Pickup Areas" fmt=num0 />
-  <BigValue data=flow_summary value=dropoff_neighborhoods title="Dropoff Areas" fmt=num0 />
+  <BigValue data=flow_summary value=trips title="Sample Trips" />
+  <BigValue data=flow_summary value=routes title="Sample Routes" />
+  <BigValue data=flow_summary value=pickup_neighborhoods title="Pickup Areas" />
+  <BigValue data=flow_summary value=dropoff_neighborhoods title="Dropoff Areas" />
 </Row>
 
 ```sql flow_edges
@@ -126,8 +126,8 @@ limit 25
 <Table data=top_routes title="Top Origin-Destination Routes" rows=25 compact=true search=true totalRow=true>
   <Column id=pickup title="Pickup" />
   <Column id=dropoff title="Dropoff" />
-  <Column id=trips title="Trips" fmt=num0 />
-  <Column id=avg_distance title="Avg Distance" fmt=num1 />
-  <Column id=avg_minutes title="Avg Minutes" fmt=num1 />
-  <Column id=avg_total_amount title="Avg Fare" fmt=usd2 />
+  <Column id=trips title="Trips" />
+  <Column id=avg_distance title="Avg Distance" />
+  <Column id=avg_minutes title="Avg Minutes" />
+  <Column id=avg_total_amount title="Avg Fare" />
 </Table>

--- a/examples/clickhouse/index.md
+++ b/examples/clickhouse/index.md
@@ -6,9 +6,9 @@ layout: dashboard
 ClickHouse sample dashboard over `default.nyc_taxi`.
 
 <Row>
-  <BigValue data=nyc_taxi value=count(*) title="Trips" fmt=num0 />
-  <BigValue data=nyc_taxi value=avg(total_amount) title="Avg Fare" fmt=usd2 />
-  <BigValue data=nyc_taxi value=p50(total_amount) title="Median Fare" fmt=usd2 />
+  <BigValue data=nyc_taxi value=count(*) title="Trips" />
+  <BigValue data=nyc_taxi value=avg(total_amount) title="Avg Fare" />
+  <BigValue data=nyc_taxi value=p50(total_amount) title="Median Fare" />
 </Row>
 
 ```sql weekly_trips

--- a/examples/ecomm/product-explorer.md
+++ b/examples/ecomm/product-explorer.md
@@ -6,8 +6,8 @@ layout: dashboard
 Select filters to explore product performance by category, brand, and time.
 
 <Row>
-  <Dropdown name="category" title="Category" data="category_options" allowDeselect="true"/>
-  <Dropdown name="brand" title="Brand" data="brand_options" allowDeselect="true"/>
+  <Dropdown name="category" title="Category" data="category_options"/>
+  <Dropdown name="brand" title="Brand" data="brand_options"/>
   <DateRange name="daterange" label="Date Range"/>
 </Row>
 

--- a/examples/flights/carrier_detail.md
+++ b/examples/flights/carrier_detail.md
@@ -49,7 +49,7 @@ select
 
 **<Value data=carrier_info column=nickname /> (<Value data=carrier_info column=code />)**
 has been operating since <Value data=kpis column=operating_since />,
-with <Value data=kpis column=total_flights fmt=num0 />
+with <Value data=kpis column=total_flights />
 flights to <Value data=kpis column=destinations /> destinations.
 
 <Row>
@@ -168,6 +168,6 @@ limit 100
   <Column id=manufacturer />
   <Column id=model />
   <Column id=year_built title="Year Built" />
-  <Column id=flights_flown title="Flights" fmt=num0 />
+  <Column id=flights_flown title="Flights" />
   <Column id=miles_flown />
 </Table>

--- a/examples/flights/index.md
+++ b/examples/flights/index.md
@@ -136,11 +136,11 @@ order by flights desc
 
 <Table data=top_carriers title="Top Carriers" link=link showLinkCol=false rows=100>
   <Column id=carrier />
-  <Column id=flights fmt=num0 />
-  <Column id=on_time_arrival_rate title="On-Time Arr %" fmt=pct1 contentType=colorscale colorScale=positive />
-  <Column id=cancellation_rate title="Cancel %" fmt=pct2 contentType=colorscale colorScale=negative />
-  <Column id=avg_dep_delay title="Avg Delay (min)" fmt="0.0" />
-  <Column id=destinations title="Destinations" fmt=num0 />
-  <Column id=avg_aircraft_age title="Avg Aircraft Age (y)" fmt="0.0" />
-  <Column id=avg_distance title="Avg Distance (mi)" fmt=num0 />
+  <Column id=flights />
+  <Column id=on_time_arrival_rate title="On-Time Arr %" contentType=colorscale colorScale=positive />
+  <Column id=cancellation_rate title="Cancel %" contentType=colorscale colorScale=negative />
+  <Column id=avg_dep_delay title="Avg Delay (min)" />
+  <Column id=destinations title="Destinations" />
+  <Column id=avg_aircraft_age title="Avg Aircraft Age (y)" />
+  <Column id=avg_distance title="Avg Distance (mi)" />
 </Table>

--- a/examples/postgres/index.md
+++ b/examples/postgres/index.md
@@ -6,9 +6,9 @@ layout: dashboard
 Postgres sample dashboard over `public.customers`, `public.orders`, and `public.order_items`.
 
 <Row>
-  <BigValue data=orders value=count(*) title="Orders" fmt=num0 />
-  <BigValue data=orders value=sum(total) title="Revenue" fmt=usd2 />
-  <BigValue data=orders value=p50(total) title="Median Order" fmt=usd2 />
+  <BigValue data=orders value=count(*) title="Orders" />
+  <BigValue data=orders value=sum(total) title="Revenue" />
+  <BigValue data=orders value=p50(total) title="Median Order" />
 </Row>
 
 ```gsql revenue_by_week

--- a/examples/snowflake/index.md
+++ b/examples/snowflake/index.md
@@ -18,7 +18,7 @@ from contacts select count() as total_contacts
 <Row>
   <BigValue data=summary value=total_establishments title="Establishments" />
   <BigValue data=contact_count value=total_contacts title="Contacts" />
-  <BigValue data=summary value=avg_score title="Avg Rating" fmt="0.00" />
+  <BigValue data=summary value=avg_score title="Avg Rating" />
 </Row>
 
 ## Establishments by State

--- a/ui/components/BigValue.svelte
+++ b/ui/components/BigValue.svelte
@@ -3,7 +3,7 @@
   import QueryLoad from './QueryLoad.svelte'
   import {formatFromField} from '../component-utilities/format.ts'
   import type {QueryResult} from '../component-utilities/types.ts'
-  import {componentLogger} from '../internal/telemetry.ts'
+  import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
 
   interface Props {
     data: string | QueryResult
@@ -12,8 +12,9 @@
     row?: number
   }
 
-  let {data, value = undefined, title = undefined, row = 0}: Props = $props()
+  let {data, value = undefined, title = undefined, row = 0, ...extraProps}: Props & Record<string, unknown> = $props()
   let logger = untrack(() => componentLogger('BigValue', {data: typeof data == 'string' ? data : undefined, value}))
+  untrack(() => logExtraProps(logger, 'BigValue', extraProps))
 
   function formatValue(input: any, loaded: QueryResult) {
     if (input === null || input === undefined) return '—'

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import {onMount} from 'svelte'
+  import {onMount, untrack} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
   import {captureInitial, getPageInputs} from '../internal/pageInputs.svelte.ts'
+  import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
 
   interface Props {
     name: string
@@ -21,7 +22,11 @@
     name, label = undefined, title = undefined, description = undefined, start = undefined,
     end = undefined, defaultValue = undefined, presetRanges = undefined, data = undefined,
     dates = undefined, hideDuringPrint = true,
-  }: Props = $props()
+    ...extraProps
+  }: Props & Record<string, unknown> = $props()
+
+  let logger = untrack(() => componentLogger('DateRange', {name}))
+  untrack(() => logExtraProps(logger, 'DateRange', extraProps))
 
   const DEFAULT_PRESETS = ['Last 7 Days', 'Last 30 Days', 'Last 90 Days', 'Last 365 Days', 'Last Month', 'Last Year', 'Month to Date', 'Month to Today', 'Year to Date', 'Year to Today', 'All Time']
 

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import {onMount, setContext, tick, type Snippet} from 'svelte'
+  import {onMount, setContext, tick, untrack, type Snippet} from 'svelte'
   import {ensureArray, toBoolean} from '../component-utilities/inputUtils'
   import {captureInitial, getPageInputs} from '../internal/pageInputs.svelte.ts'
+  import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
 
   interface Option {
     value: any
@@ -33,7 +34,11 @@
     labelField = undefined, title = undefined, placeholder = 'Select option', multiple = false,
     defaultValue = undefined, selectAllByDefault = false, noDefault = false, disableSelectAll = false,
     hideDuringPrint = true, description = undefined, disabled = false, children = undefined,
-  }: Props = $props()
+    ...extraProps
+  }: Props & Record<string, unknown> = $props()
+
+  let logger = untrack(() => componentLogger('Dropdown', {name}))
+  untrack(() => logExtraProps(logger, 'Dropdown', extraProps))
 
   let mounted = false
   let queryOptions: Option[] = $state([])

--- a/ui/components/DropdownOption.svelte
+++ b/ui/components/DropdownOption.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-  import {getContext, onMount} from 'svelte'
+  import {getContext, onMount, untrack} from 'svelte'
+  import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
 
   interface Props {
     value: any
     valueLabel?: string
   }
 
-  let {value, valueLabel = undefined}: Props = $props()
+  let {value, valueLabel = undefined, ...extraProps}: Props & Record<string, unknown> = $props()
+  let logger = untrack(() => componentLogger('DropdownOption', {value}))
+  untrack(() => logExtraProps(logger, 'DropdownOption', extraProps))
 
   type RegisterFn = ((option: {value: any; label: string}) => (() => void) | void) | undefined
   const register = getContext<RegisterFn>('dropdown')

--- a/ui/components/ScatterPlot.svelte
+++ b/ui/components/ScatterPlot.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import {untrack} from 'svelte'
   import ECharts from './ECharts.svelte'
   import {formatTitle} from '../component-utilities/format.ts'
   import {parseCommaList} from '../component-utilities/inputUtils.ts'
   import type {EChartsConfig, QueryResult, SeriesWithGroupingHint} from '../component-utilities/types.ts'
+  import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
 
   interface Props {
     data: string | QueryResult
@@ -22,7 +24,11 @@
     title = undefined,
     height = undefined,
     width = undefined,
-  }: Props = $props()
+    ...extraProps
+  }: Props & Record<string, unknown> = $props()
+
+  let logger = untrack(() => componentLogger('ScatterPlot', {data: typeof data == 'string' ? data : undefined, x, y}))
+  untrack(() => logExtraProps(logger, 'ScatterPlot', extraProps))
 
   function buildConfig(): EChartsConfig {
     let yFields = parseCommaList(y)
@@ -50,4 +56,4 @@
   }
 </script>
 
-<ECharts data={data} config={buildConfig()} {height} {width} />
+<ECharts data={data} config={buildConfig()} {height} {width} componentId={logger.id} />

--- a/ui/components/TextInput.svelte
+++ b/ui/components/TextInput.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import {onMount} from 'svelte'
+  import {onMount, untrack} from 'svelte'
   import {toBoolean} from '../component-utilities/inputUtils'
   import {captureInitial, getPageInputs} from '../internal/pageInputs.svelte.ts'
+  import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
 
   interface Props {
     name: string
@@ -17,7 +18,11 @@
   let {
     name, title = undefined, label = undefined, description = undefined,
     placeholder = 'Type to search', defaultValue = undefined, hideDuringPrint = true, unsafe = false,
-  }: Props = $props()
+    ...extraProps
+  }: Props & Record<string, unknown> = $props()
+
+  let logger = untrack(() => componentLogger('TextInput', {name}))
+  untrack(() => logExtraProps(logger, 'TextInput', extraProps))
 
   let pageInputs = getPageInputs()
   let field = captureInitial(() => pageInputs.text(name))

--- a/ui/components/Value.svelte
+++ b/ui/components/Value.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+    import {untrack} from 'svelte'
     import QueryLoad from './QueryLoad.svelte'
     import {formatFromField} from '../component-utilities/format.ts'
     import type {QueryResult} from '../component-utilities/types.ts'
+    import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
 
     interface Props {
       data: string | QueryResult
@@ -9,7 +11,9 @@
       row?: number
     }
 
-    let {data, column, row = 0}: Props = $props()
+    let {data, column, row = 0, ...extraProps}: Props & Record<string, unknown> = $props()
+    let logger = untrack(() => componentLogger('Value', {data: typeof data == 'string' ? data : undefined, column}))
+    untrack(() => logExtraProps(logger, 'Value', extraProps))
 
     function formatValue(input: any, loaded: QueryResult) {
       if (input === null || input === undefined) return '—'
@@ -22,4 +26,4 @@
   <span>{formatValue(loaded?.rows?.[row]?.[column], loaded)}</span>
 {/snippet}
 
-<QueryLoad {data} fields={{column}} inline children={valueContent} />
+<QueryLoad {data} fields={{column}} inline children={valueContent} componentId={logger.id} />

--- a/ui/tests/extraProps.test.ts
+++ b/ui/tests/extraProps.test.ts
@@ -1,0 +1,36 @@
+import {expect, test} from './fixtures.ts'
+import {singleDim} from './testData.ts'
+
+test.beforeEach(async ({sharedPage}) => {
+  await sharedPage.setViewportSize({width: 1280, height: 720})
+})
+
+test('display components report unsupported props', async ({mount, sharedPage}) => {
+  await mount('components/Value.svelte', {data: singleDim(), column: 'value', fmt: 'usd'})
+  await expectUnsupportedProp(sharedPage, 'Unsupported prop "fmt" on Value.')
+
+  await mount('components/BigValue.svelte', {data: singleDim(), value: 'value', subtitle: 'Ignored'})
+  await expectUnsupportedProp(sharedPage, 'Unsupported prop "subtitle" on BigValue.')
+
+  await mount('components/ScatterPlot.svelte', {data: singleDim(), x: 'category', y: 'value', subtitle: 'Ignored'})
+  await expectUnsupportedProp(sharedPage, 'Unsupported prop "subtitle" on ScatterPlot.')
+})
+
+test('input components report unsupported props', async ({mount, sharedPage}) => {
+  await mount('components/TextInput.svelte', {name: 'search', title: 'Search', helperText: 'Ignored'})
+  await expectUnsupportedProp(sharedPage, 'Unsupported prop "helperText" on TextInput.')
+
+  await mount('components/Dropdown.svelte', {name: 'carrier', allowDeselect: true})
+  await expectUnsupportedProp(sharedPage, 'Unsupported prop "allowDeselect" on Dropdown.')
+
+  await mount('components/DateRange.svelte', {name: 'window', calendar: true})
+  await expectUnsupportedProp(sharedPage, 'Unsupported prop "calendar" on DateRange.')
+
+  await mount('components/DropdownOption.svelte', {value: 'AA', label: 'American'})
+  await expectUnsupportedProp(sharedPage, 'Unsupported prop "label" on DropdownOption.')
+})
+
+async function expectUnsupportedProp(sharedPage: any, message: string) {
+  let messages = await sharedPage.evaluate(() => (window as any).$GRAPHENE.getErrors().map((error: any) => error.message))
+  expect(messages).toContain(message)
+}


### PR DESCRIPTION
The dogfood run also pointed out that there was no warning when it attempted to use a non-existent prop with `<BigValue/>`. We already added a pattern for erroring on extra/unknown props for the chart wrapper components. This PR adds the same checks to the Value and BigValue components, as well as the input components (and ScatterPlot). This turned up a number of usages of unsupported props still in our examples (`fmt` and `allowDeselect`)