### PR TITLE
fix query wrapping interaction with comments/annotations

### DIFF
--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -95,7 +95,7 @@ async function runNode(n: QueryNode, refresh = false) {
   // letting the server determine the hash of this particular query, and whether data we already have is acceptable.
   let hashes = await getHashes()
   let tables = queries.filter(q => q.name)
-  let gsql = [...tables.map(q => `table ${q.name} as (${q.contents})`), n.contents].join('\n')
+  let gsql = [...tables.map(q => `table ${q.name} as (\n${q.contents}\n)`), n.contents].join('\n')
   let params = getActivePageInputs().getParams()
 
   try {

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -239,7 +239,7 @@ test('cli run with md file reports runtime query errors', async ({server, page})
   )
 })
 
-test('cli run with --headless handles page query column annotations', async ({server}) => {
+test('cli run handles page query with trailing column annotation', async ({server}) => {
   server.mockFile(
     '/index.md',
     `

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -239,6 +239,32 @@ test('cli run with md file reports runtime query errors', async ({server, page})
   )
 })
 
+test('cli run with --headless handles page query column annotations', async ({server}) => {
+  server.mockFile(
+    '/index.md',
+    `
+    # Page Query Column Annotations
+    \`\`\`sql annotated
+    from flights select carrier,
+      extract(month from dep_time) as month_num, #timeOrdinal=month_of_year
+      dep_delay / 100 as delay_drop_pct #ratio
+    \`\`\`
+    <BigValue data="annotated" value="delay_drop_pct" title="Delay Drop" />
+  `,
+  )
+
+  server.url()
+  let result = await runMdFile({mdArg: 'index.md', headless: true, log})
+  expect(result).toBe(true)
+  expect(outputLines()).toEqual(
+    trimIndentation(`
+    Page available at http://localhost:<port>/
+    No errors found 💎
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
+  `),
+  )
+})
+
 test('cli run with md file reports runtime chart configuration errors', async ({server, page}) => {
   expectConsoleError('Chart failed to render')
   server.mockFile(

--- a/ui/tests/snapshots/markdown.test.ts/reports-analysis-query-errors.png
+++ b/ui/tests/snapshots/markdown.test.ts/reports-analysis-query-errors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c3257f992183537737f302e321b536ad81c66c6d89d64cee404ab4c60137ad0f
-size 30611
+oid sha256:9a99101acce60abe51b4f365d0b3555e547e181cd2a7621d4cfb883ff7efa4c8
+size 29312


### PR DESCRIPTION
While testing the dogfooding workflow the agent hit this case where the last line of a query ended with a comment/annotation, which broke the `table as ($contents)` wrapping.