### PR TITLE
don't treat `time` as an alias for `timestamp`

### DIFF
--- a/lang/bigQueryFunctions.ts
+++ b/lang/bigQueryFunctions.ts
@@ -2245,7 +2245,7 @@ export const bigQueryFunctions: FunctionDef[] = [
     `),
     url: `${bq}/time_functions#current_time`,
     args: [{name: 'time_zone', type: 'string?', description: 'The time zone to use. Defaults to UTC.'}],
-    returns: 'timestamp', // Graphene treats TIME as timestamp
+    returns: 'time',
     supportsBareInvocation: true,
   },
   {

--- a/lang/duckDbFunctions.ts
+++ b/lang/duckDbFunctions.ts
@@ -2153,7 +2153,7 @@ export const duckDbFunctions: FunctionDef[] = [
       ['minute', 'number'],
       ['second', 'number'],
     ],
-    returns: 'timestamp',
+    returns: 'time',
   },
   {
     name: 'now',
@@ -2302,7 +2302,7 @@ export const duckDbFunctions: FunctionDef[] = [
     `),
     url: `${duck}/timestamp#current_time`,
     args: [],
-    returns: 'timestamp',
+    returns: 'time',
     supportsBareInvocation: true,
   },
   {
@@ -2340,7 +2340,7 @@ export const duckDbFunctions: FunctionDef[] = [
     `),
     url: `${duck}/timestamp#current_time`,
     args: [],
-    returns: 'timestamp',
+    returns: 'time',
     supportsBareInvocation: true,
   },
 

--- a/lang/functionTypes.ts
+++ b/lang/functionTypes.ts
@@ -3,7 +3,7 @@
 
 import {type Expr, type FieldMeta} from './types.ts'
 
-export type SQLType = 'string' | 'number' | 'boolean' | 'date' | 'timestamp' | 'json' | 'any' | 'bytes'
+export type SQLType = 'string' | 'number' | 'boolean' | 'date' | 'time' | 'timestamp' | 'json' | 'any' | 'bytes'
 
 // Arg definition - can be a simple tuple or an object with description
 // Type patterns:

--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -10,8 +10,10 @@ import {duckDbFunctions} from './duckDbFunctions.ts'
 import {extendFanoutPath, mergeFanoutPaths, mergeSensitiveFanouts, normalizeExprFanout} from './fanout.ts'
 import {postgresFunctions} from './postgresFunctions.ts'
 import {snowflakeFunctions} from './snowflakeFunctions.ts'
-import {arrayOf, scalarType, type Expr, type FieldMeta, type FieldType, isArrayType, isScalarType, type Scope, type TypeKind} from './types.ts'
+import {arrayOf, normalizeScalarType, scalarType, type Expr, type FieldMeta, type FieldType, isArrayType, isScalarType, type Scope, type TypeKind} from './types.ts'
 import {txt} from './util.ts'
+
+const ANY_TYPES: TypeKind[] = ['string', 'number', 'boolean', 'date', 'time', 'timestamp', 'json', 'interval', 'record', 'array']
 
 // The shape that analyzeFunction works with. Converted from FunctionDef at startup.
 interface Overload {
@@ -29,9 +31,9 @@ interface Overload {
 function parseArgType(typeStr: string): {type: TypeKind; rawType?: string}[] {
   let base = typeStr.replace(/[?.]/g, '')
   if (base === 'kw') return [{type: 'sql native', rawType: 'kw'}]
-  if (base === 'T' || base === 'any') return ['string', 'number', 'boolean', 'date', 'timestamp', 'json', 'array'].map(type => ({type: type as TypeKind}))
+  if (base === 'T' || base === 'any') return ANY_TYPES.map(type => ({type}))
   if (base === 'array') return [{type: 'array'}]
-  return [{type: base as TypeKind}]
+  return [{type: normalizeTypeKind(base)}]
 }
 
 function getArgInfo(arg: ArgDef): {name: string; type: string} {
@@ -41,7 +43,7 @@ function getArgInfo(arg: ArgDef): {name: string; type: string} {
 
 function parseArgTypes(arg: ArgDef): {type: TypeKind; rawType?: string}[] {
   let type = Array.isArray(arg) ? arg[1] : arg.type
-  if (Array.isArray(type)) return type.map(t => ({type: t as TypeKind}))
+  if (Array.isArray(type)) return type.map(t => ({type: normalizeTypeKind(t)}))
   return parseArgType(type)
 }
 
@@ -78,7 +80,11 @@ function convertDef(def: FunctionDef): Overload[] {
 function normalizeReturnType(type: string): FieldType | 'array' {
   if (type == 'array') return 'array'
   if (type == 'bytes') return scalarType('string')
-  return scalarType(type as Exclude<TypeKind, 'array'>)
+  return scalarType(normalizeTypeKind(type) as Exclude<TypeKind, 'array'>)
+}
+
+function normalizeTypeKind(type: string): TypeKind {
+  return normalizeScalarType(type) || (type as TypeKind)
 }
 
 // Build a name -> Overload[] map from a FunctionDef array

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -31,7 +31,7 @@ export type FieldMeta = {
 }
 
 export type FieldType = ScalarField | ArrayField
-export type ScalarField = 'string' | 'number' | 'boolean' | 'date' | 'timestamp' | 'json' | 'sql native' | 'error' | 'null' | 'interval' | 'record'
+export type ScalarField = 'string' | 'number' | 'boolean' | 'date' | 'time' | 'timestamp' | 'json' | 'sql native' | 'error' | 'null' | 'interval' | 'record'
 export type ArrayField = {type: 'array'; elementType: FieldType}
 
 export type TimeGrain = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second'

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -1539,6 +1539,10 @@ describe('lang', () => {
     )
   })
 
+  it('type-checks duckdb date_trunc against time values', () => {
+    expect("select date_trunc('day', current_time)").toHaveDiagnostic(/Expected date or timestamp, got time/i)
+  })
+
   it('supports bigquery current datetime functions with optional args', () => {
     setGlobalConfig({root: '', bigquery: {}})
     try {
@@ -1574,6 +1578,27 @@ describe('lang', () => {
       `).toRenderSql(
         'select current_date as current_date, current_datetime as current_datetime, current_time as current_time, current_timestamp as current_timestamp, current_datetime as local_timestamp from `users` as users',
       )
+    } finally {
+      setGlobalConfig({root: ''})
+    }
+  })
+
+  it('infers bigquery time and datetime function types through aliases', () => {
+    setGlobalConfig({root: '', bigquery: {}})
+    try {
+      let [query] = analyze(`
+        from users select
+          current_time() as current_t,
+          time(1, 2, 3) as made_t,
+          time_add(current_time(), 1) as shifted_t,
+          current_datetime() as current_dt
+      `)
+      expect(query.fields.map(field => [field.name, formatType(field.type)])).toEqual([
+        ['current_t', 'time'],
+        ['made_t', 'time'],
+        ['shifted_t', 'time'],
+        ['current_dt', 'timestamp'],
+      ])
     } finally {
       setGlobalConfig({root: ''})
     }
@@ -2020,6 +2045,18 @@ describe('lang', () => {
     expect(formatType(parseWarehouseFieldType('LowCardinality(String)').type)).toBe('string')
     expect(formatType(parseWarehouseFieldType("Enum8('CSH' = 1, 'CRE' = 2)").type)).toBe('string')
     expect(formatType(parseWarehouseFieldType('Array(String)').type)).toBe('array<string>')
+  })
+
+  it('normalizes warehouse scalar aliases without merging time into timestamp', () => {
+    expect(formatType(parseWarehouseFieldType('TIME').type)).toBe('time')
+    expect(formatType(parseWarehouseFieldType('TIME(6)').type)).toBe('time')
+    expect(formatType(parseWarehouseFieldType('TIMETZ').type)).toBe('time')
+    expect(formatType(parseWarehouseFieldType('TIME WITH TIME ZONE').type)).toBe('time')
+    expect(formatType(parseWarehouseFieldType('TIMESTAMP WITH TIME ZONE').type)).toBe('timestamp')
+    expect(formatType(parseWarehouseFieldType('DECIMAL(10, 2)').type)).toBe('number')
+    expect(formatType(parseWarehouseFieldType('VARCHAR(255)').type)).toBe('string')
+    expect(formatType(parseWarehouseFieldType('VARIANT').type)).toBe('string')
+    expect(formatType(parseWarehouseFieldType('STRUCT').type)).toBe('unknown')
   })
 
   it('preserves array element types through computed fields, views, and generic array returns', () => {

--- a/lang/postgresFunctions.ts
+++ b/lang/postgresFunctions.ts
@@ -342,9 +342,9 @@ export const postgresFunctions: FunctionDef[] = [
   extractPart('isodow'),
   extractPart('isoyear'),
   fn({name: 'current_date', args: [], returns: 'date', sqlName: 'CURRENT_DATE', sqlTemplate: 'CURRENT_DATE', supportsBareInvocation: true, url: `${pg}-datetime.html`}),
-  fn({name: 'current_time', args: [], returns: 'timestamp', sqlName: 'CURRENT_TIME', sqlTemplate: 'CURRENT_TIME', supportsBareInvocation: true, url: `${pg}-datetime.html`}),
+  fn({name: 'current_time', args: [], returns: 'time', sqlName: 'CURRENT_TIME', sqlTemplate: 'CURRENT_TIME', supportsBareInvocation: true, url: `${pg}-datetime.html`}),
   fn({name: 'current_timestamp', args: [], returns: 'timestamp', sqlName: 'CURRENT_TIMESTAMP', sqlTemplate: 'CURRENT_TIMESTAMP', supportsBareInvocation: true, url: `${pg}-datetime.html`}),
-  fn({name: 'localtime', args: [], returns: 'timestamp', sqlName: 'LOCALTIME', sqlTemplate: 'LOCALTIME', supportsBareInvocation: true, url: `${pg}-datetime.html`}),
+  fn({name: 'localtime', args: [], returns: 'time', sqlName: 'LOCALTIME', sqlTemplate: 'LOCALTIME', supportsBareInvocation: true, url: `${pg}-datetime.html`}),
   fn({
     name: 'local_timestamp',
     args: [],

--- a/lang/snowflakeFunctions.ts
+++ b/lang/snowflakeFunctions.ts
@@ -1951,7 +1951,7 @@ export const snowflakeFunctions: FunctionDef[] = [
       {name: 'second', type: 'number'},
       {name: 'nanosecond', type: 'number?'},
     ],
-    returns: 'timestamp',
+    returns: 'time',
   },
   {
     name: 'time_slice',
@@ -2404,7 +2404,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     `),
     url: `${sf}/current_time`,
     args: [],
-    returns: 'timestamp',
+    returns: 'time',
     supportsBareInvocation: true,
   },
   {
@@ -2428,7 +2428,7 @@ export const snowflakeFunctions: FunctionDef[] = [
     `),
     url: `${sf}/localtime`,
     args: [],
-    returns: 'timestamp',
+    returns: 'time',
     supportsBareInvocation: true,
   },
   {

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -82,8 +82,14 @@ let SCALAR_TYPE_ALIASES: Record<string, ScalarField> = {
   boolean: 'boolean',
   date: 'date',
   datetime: 'timestamp',
-  time: 'timestamp',
+  time: 'time',
+  timetz: 'time',
+  time_tz: 'time',
+  time_with_time_zone: 'time',
+  time_without_time_zone: 'time',
   timestamp: 'timestamp',
+  timestamp_with_time_zone: 'timestamp',
+  timestamp_without_time_zone: 'timestamp',
   datetime64: 'timestamp',
   timestamp_ntz: 'timestamp',
   timestamp_tz: 'timestamp',
@@ -166,6 +172,8 @@ function parseFieldType(rawType: string, opts: {allowArrayKeyword: boolean; allo
   if (callMatch) {
     let typeName = normalizeTypeName(callMatch[1])
     if ((typeName == 'list' || typeName == 'array') && opts.allowNamedArray) return parseArrayType(callMatch[2], opts)
+    let normalizedScalarType = normalizeScalarType(typeName)
+    if (normalizedScalarType) return {type: normalizedScalarType}
   }
 
   let normalizedScalarType = normalizeScalarType(value)


### PR DESCRIPTION
This PR updates the type system to handle the `time` time. As an example this causes us to give a nice type error diagnostic on the query `select date_trunc('day', current_time)`, which in DuckDB errors at runtime with

```
Binder Error:
No function matches the given name and argument types 'date_trunc(STRING_LITERAL, TIME WITH TIME ZONE)'. You might need to add explicit type casts.
        Candidate functions:
        date_trunc(VARCHAR, DATE) -> TIMESTAMP
        date_trunc(VARCHAR, INTERVAL) -> INTERVAL
        date_trunc(VARCHAR, TIMESTAMP) -> TIMESTAMP
        date_trunc(VARCHAR, TIMESTAMP WITH TIME ZONE) -> TIMESTAMP WITH TIME ZONE


LINE 1: select date_trunc('day', current_time)
```