### PR TITLE
fix noisy CLI error due to exit behavior

### DIFF
--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -143,6 +143,17 @@ describe('cli run', () => {
     expect(res.stdout.toLowerCase()).toContain('total')
   })
 
+  it('prints query diagnostics without a stack trace', async () => {
+    let res = await runCli(['run', 'from flights select carrier order by nope'], {cwd: flightDir})
+    let output = res.stdout + res.stderr
+
+    expect(res.code).toBe(1)
+    expect(output).toContain('Unknown field in ORDER BY: nope')
+    expect(output).not.toContain('TypeError')
+    expect(output).not.toContain('validateInputQuery')
+    expect(output).not.toContain('at file://')
+  })
+
   it('accepts --port on run commands', async () => {
     let res = await runCli(['run', 'from flights select count() as total', '--port', '4164'], {cwd: flightDir})
     expectCliSuccess(res, 'run query with port')

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -348,6 +348,8 @@ function findCaseInsensitive(values: string[], needle: string): string | null {
   return values.find(value => value.toLowerCase() == needle.toLowerCase()) || null
 }
 
+class CliExit {}
+
 function withTelemetry(command: TelemetryCommand, action: (exit: (code?: number) => never, ...args: any[]) => Promise<void>) {
   return async (...args: any[]) => {
     let startedAt = Date.now()
@@ -363,15 +365,17 @@ function withTelemetry(command: TelemetryCommand, action: (exit: (code?: number)
       exitCalled = true
       exitCode = code
       success = exitCode == 0
-      return undefined as never
+      throw new CliExit()
     }
 
     try {
       await action(exit, ...args)
     } catch (err) {
-      exitCode = 1
-      success = false
-      caughtError = err
+      if (!(err instanceof CliExit)) {
+        exitCode = 1
+        success = false
+        caughtError = err
+      }
     } finally {
       if (success) {
         let {shouldSendInstallSeen, fromVersion} = await telemetry.markSuccessfulInvocation()


### PR DESCRIPTION
This PR fixes a noisy error reported by the dogfood workflow:

> **CLI stack-trace on a query error.** A bad `ORDER BY` printed the friendly `Unknown field in ORDER BY` message and then crashed with `TypeError: validateInputQuery is not a function` + a Node stack. The real error was clear; the trace was noise.

The underlying issue was that the `exit` callback in the telemetry wrapping code was typed as returning `never`, and the downstream code took it at its word, when in fact it returned `undefined as never`