### PR TITLE
update clickhouse test instance

### DIFF
--- a/examples/clickhouse/package.json
+++ b/examples/clickhouse/package.json
@@ -20,7 +20,7 @@
     "dialect": "clickhouse",
     "defaultNamespace": "default",
     "clickhouse": {
-      "url": "https://kzo1vb16sa.us-east-1.aws.clickhouse.cloud:8443",
+      "url": "https://by0uey760h.us-east-1.aws.clickhouse.cloud:8443",
       "username": "default",
       "requestTimeout": 120000
     },


### PR DESCRIPTION
It looks like the clickhouse test instance used by CI/the clickhouse example got deleted. This PR updates to point to a clickhouse-test instance in the Graphene-staging clickhouse org with the same nyc_taxi dataset.