### PR TITLE
CSV export

### DIFF
--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -154,6 +154,12 @@ describe('cli run', () => {
     expect(output).not.toContain('at file://')
   })
 
+  it('prints csv for an inline query with --format csv', async () => {
+    let res = await runCli(['run', "select 'a,b' as name, 2 as total", '--format', 'csv'], {cwd: flightDir})
+    expectCliSuccess(res, 'run query as csv')
+    expect(res.stdout).toBe('name,total\n"a,b",2\n')
+  })
+
   it('accepts --port on run commands', async () => {
     let res = await runCli(['run', 'from flights select count() as total', '--port', '4164'], {cwd: flightDir})
     expectCliSuccess(res, 'run query with port')
@@ -191,6 +197,13 @@ describe('cli run', () => {
     let res = await runCli(['run', 'index.md', '--query', 'performance_by_year'], {cwd: flightDir})
     expectCliSuccess(res, 'run markdown query')
     expect(res.stdout.toLowerCase()).toContain('flight_count')
+  })
+
+  it('prints csv for a named query from a markdown file with --format csv', async () => {
+    let res = await runCli(['run', 'index.md', '--query', 'performance_by_year', '--format', 'csv'], {cwd: flightDir})
+    expectCliSuccess(res, 'run markdown query as csv')
+    expect(res.stdout.startsWith('year,status,flight_count\n')).toBe(true)
+    expect(res.stdout).not.toContain('┌')
   })
 
   it('runs a parameterized named query from a markdown file with --input', async () => {
@@ -239,6 +252,18 @@ describe('cli run', () => {
     let res = await runCli(['run', 'from flights select count()', '--port', 'abc'], {cwd: flightDir})
     expect(res.code).toBe(1)
     expect(res.stderr).toContain('Invalid --port "abc". Expected an integer from 1 to 65535.')
+  })
+
+  it('rejects invalid --format values', async () => {
+    let res = await runCli(['run', 'from flights select count()', '--format', 'json'], {cwd: flightDir})
+    expect(res.code).toBe(1)
+    expect(res.stderr).toContain('Invalid --format "json". Expected table or csv.')
+  })
+
+  it('rejects markdown csv export without --query or --chart', async () => {
+    let res = await runCli(['run', 'index.md', '--format', 'csv'], {cwd: flightDir})
+    expect(res.code).toBe(1)
+    expect(res.stderr).toContain('--format csv for markdown files requires --query or --chart')
   })
 
   it('uses a configured duckdb path when present', async () => {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -8,6 +8,7 @@ import {fileURLToPath} from 'url'
 
 import {config, loadConfig, setGlobalConfig} from '../lang/config.ts'
 import {analyzeWorkspace, getFile, loadWorkspace, toSql, type Query} from '../lang/core.ts'
+import {rowsToCsv} from '../lang/csv.ts'
 import {parseWarehouseFieldType, type AnalysisResult} from '../lang/types.ts'
 import {loginPkce} from './auth.ts'
 import {runServeInBackground, stopGrapheneIfRunning} from './background.ts'
@@ -65,16 +66,19 @@ program
   .description('Run a query or screenshot a Graphene page')
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
   .option('-c, --chart <chartTitleOrComponentId>', 'Title or component ID of a specific chart to capture')
+  .option('--format <format>', 'Output format for query or chart data: table or csv', 'table')
   .option('--headless', 'Run markdown pages in a headless browser instead of opening the system browser')
   .option('--port <port>', 'Port for the local Graphene server')
   .option('-q, --query <queryName>', 'Query or table name to run from a markdown page')
   .option('--input <key=value>', 'Input value to use for parameters; repeat for multiple values', (value, previous: string[]) => previous.concat(value), [])
   .action(
-    withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; headless?: boolean; port?: string; query?: string; input?: string[]}, command: Command) => {
+    withTelemetry('run', async (exit, input: string | undefined, options: {chart?: string; format?: string; headless?: boolean; port?: string; query?: string; input?: string[]}, command: Command) => {
       if (!input) {
         command.outputHelp()
         return exit(0)
       }
+
+      let format = parseRunFormat(options.format || 'table', exit)
 
       if (options.port) {
         let port = parsePort(options.port, exit)
@@ -92,12 +96,17 @@ program
         return exit(1)
       }
 
+      if (format == 'csv' && !options.chart && !options.query && getExistingPath(input)?.endsWith('.md')) {
+        console.error('--format csv for markdown files requires --query or --chart')
+        return exit(1)
+      }
+
       let inputs = parseRunInputs(options.input || [], exit)
       let inputPath = getExistingPath(input)
       if (inputPath && inputPath.endsWith('.md')) {
         let res = options.query
-          ? await runNamedQueryFromMd(inputPath, options.query, {inputs, telemetry})
-          : await runMdFile({mdArg: inputPath, chart: options.chart, headless: options.headless, inputs, telemetry})
+          ? await runNamedQueryFromMd(inputPath, options.query, {format, inputs, telemetry})
+          : await runMdFile({mdArg: inputPath, chart: options.chart, format, headless: options.headless, inputs, log: format == 'csv' ? console.error : console.log, telemetry})
         return exit(res ? 0 : 1)
       }
 
@@ -118,7 +127,8 @@ program
       let [query] = validateInputQuery(analysis, exit)
       let sql = renderSql(query, inputs, exit)
       let res = await runQuery(sql)
-      printTable(res.rows)
+      if (format == 'csv') console.log(rowsToCsv(res.rows, query.fields))
+      else printTable(res.rows)
     }),
   )
 
@@ -340,6 +350,12 @@ function parsePort(value: string, exit: (code?: number) => never): number {
     return exit(1)
   }
   return port
+}
+
+function parseRunFormat(value: string, exit: (code?: number) => never): 'table' | 'csv' {
+  if (value == 'table' || value == 'csv') return value
+  console.error(`Invalid --format "${value}". Expected table or csv.`)
+  return exit(1)
 }
 
 function renderSql(query: Query, inputs: Record<string, string | string[]>, exit: (code?: number) => never): string {

--- a/cli/esbuild.mjs
+++ b/cli/esbuild.mjs
@@ -66,6 +66,7 @@ await cp(path.resolve(__dirname, '../ui'), path.resolve(__dirname, 'dist/ui'), {
 await mkdir(path.resolve(__dirname, 'dist/lang'), {recursive: true})
 await cp(path.resolve(__dirname, '../lang/index.d.ts'), path.resolve(__dirname, 'dist/index.d.ts'))
 await cp(path.resolve(__dirname, '../lang/index.d.ts'), path.resolve(__dirname, 'dist/lang/index.d.ts'))
+await cp(path.resolve(__dirname, '../lang/csv.ts'), path.resolve(__dirname, 'dist/lang/csv.ts'))
 await transpileSvelteModules(path.resolve(__dirname, 'dist/ui'))
 await rm(path.resolve(__dirname, 'dist/ui/node_modules'), {recursive: true, force: true})
 await rm(path.resolve(__dirname, 'dist/ui/package.json'))

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -40,35 +40,22 @@ let pendingRequests: Record<string, {response: ServerResponse<IncomingMessage>}>
 
 export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
   let log = options.log || console.log
-  let mdFile = normalizeFile(options.mdArg)
-  if (!mdFile) {
-    log(`Couldn't find ${options.mdArg}`)
+  let md = await analyzeMdFile(options.mdArg, log)
+  if (!md) return false
+  options.telemetry?.event('workspace_scanned', {command: 'run', ...md.scanCounts})
+  if (md.analysis.diagnostics.length > 0) {
+    printDiagnostics(md.analysis.diagnostics, log)
     return false
   }
 
-  let files = await loadWorkspace(config.root, false, config.ignoredFiles)
-  options.telemetry?.event('workspace_scanned', {command: 'run', ...getWorkspaceScanCounts(files)})
-  let mdContents: string
-  if (process.env.NODE_ENV == 'test' && mockFileMap[mdFile]) {
-    mdContents = mockFileMap[mdFile]
-  } else {
-    mdContents = readFileSync(path.resolve(config.root, mdFile), 'utf-8')
-  }
-
-  let result = analyzeWorkspace({config, files: files.filter(file => file.path != mdFile).concat({path: mdFile, contents: mdContents, kind: 'md'})}, mdFile)
-  if (result.diagnostics.length > 0) {
-    printDiagnostics(result.diagnostics, log)
-    return false
-  }
-
-  let pageUrl = markdownPageUrl(mdFile, options.inputs)
+  let pageUrl = markdownPageUrl(md.path, options.inputs)
   let request = {pageUrl, action: 'check' as const, chart: options.chart, format: options.format || 'table', log}
   let resp = options.headless ? await runHeadlessPageRequest(request) : await sendSocketRequest(request)
   if (!resp) return false
 
   if (options.format == 'csv') {
     if (resp.csv === undefined) {
-      log(`Could not find chart "${options.chart}" on ${mdFile}`)
+      log(`Could not find chart "${options.chart}" on ${md.path}`)
       return false
     }
     console.log(resp.csv)
@@ -79,10 +66,10 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
 
   let errors = Array.from(resp.errors || []) as GrapheneError[]
   let chartNotFound = !!options.chart && !resp.screenshot
-  if (chartNotFound) log(`Could not find chart "${options.chart}" on ${mdFile}`)
+  if (chartNotFound) log(`Could not find chart "${options.chart}" on ${md.path}`)
 
   if (errors.length) {
-    log(styleText('red', 'Runtime errors') + ` in ${mdFile}:`)
+    log(styleText('red', 'Runtime errors') + ` in ${md.path}:`)
   } else if (!chartNotFound) {
     log('No errors found 💎')
   }
@@ -110,23 +97,15 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
 }
 
 export async function listMdFileQueries(mdArg: string, telemetry?: CliTelemetry, log: (...args: any[]) => void = console.log): Promise<boolean> {
-  let mdFile = normalizeFile(mdArg)
-  if (!mdFile) {
-    log(`Couldn't find ${mdArg}`)
+  let md = await analyzeMdFile(mdArg, log)
+  if (!md) return false
+  telemetry?.event('workspace_scanned', {command: 'list', ...md.scanCounts})
+  if (md.analysis.diagnostics.length > 0) {
+    printDiagnostics(md.analysis.diagnostics, log)
     return false
   }
 
-  let files = await loadWorkspace(config.root, false, config.ignoredFiles)
-  telemetry?.event('workspace_scanned', {command: 'list', ...getWorkspaceScanCounts(files)})
-  let mdContents = process.env.NODE_ENV == 'test' && mockFileMap[mdFile] ? mockFileMap[mdFile] : readFileSync(path.resolve(config.root, mdFile), 'utf-8')
-
-  let result = analyzeWorkspace({config, files: files.filter(file => file.path != mdFile).concat({path: mdFile, contents: mdContents, kind: 'md'})}, mdFile)
-  if (result.diagnostics.length > 0) {
-    printDiagnostics(result.diagnostics, log)
-    return false
-  }
-
-  let resp = await sendSocketRequest({pageUrl: markdownPageUrl(mdFile), action: 'list', log})
+  let resp = await sendSocketRequest({pageUrl: markdownPageUrl(md.path), action: 'list', log})
   if (!resp) return false
 
   let componentIds = (resp.componentIds || []) as string[]
@@ -135,20 +114,17 @@ export async function listMdFileQueries(mdArg: string, telemetry?: CliTelemetry,
   return true
 }
 
-export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string, options: {format?: RunFormat; inputs?: RunInputs; telemetry?: CliTelemetry} = {}): Promise<boolean> {
-  let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
-  options.telemetry?.event('workspace_scanned', {command: 'run', ...getWorkspaceScanCounts(files)})
-  let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
-  let mdContents = await fs.promises.readFile(mdAbsolutePath, 'utf-8')
-
-  let result = analyzeWorkspace({config, files: files.filter(file => file.path != mdRelativePath).concat({path: mdRelativePath, contents: mdContents, kind: 'md'})}, mdRelativePath)
-  if (result.diagnostics.length > 0) {
-    printDiagnostics(result.diagnostics)
+export async function runNamedQueryFromMd(mdArg: string, queryName: string, options: {format?: RunFormat; inputs?: RunInputs; telemetry?: CliTelemetry} = {}): Promise<boolean> {
+  let md = await analyzeMdFile(mdArg)
+  if (!md) return false
+  options.telemetry?.event('workspace_scanned', {command: 'run', ...md.scanCounts})
+  if (md.analysis.diagnostics.length > 0) {
+    printDiagnostics(md.analysis.diagnostics)
     return false
   }
 
-  let runQueryFence = [mdContents, '', '```sql', `from ${queryName} select *`, '```'].join('\n')
-  let queryFiles = toWorkspaceFiles(result)
+  let runQueryFence = [md.contents, '', '```sql', `from ${queryName} select *`, '```'].join('\n')
+  let queryFiles = toWorkspaceFiles(md.analysis)
   let queryResult = analyzeWorkspace({config, files: queryFiles.filter(file => file.path != 'input.md').concat({path: 'input.md', contents: runQueryFence, kind: 'md'})}, 'input.md')
   if (queryResult.diagnostics.length > 0) {
     printDiagnostics(queryResult.diagnostics)
@@ -168,6 +144,20 @@ export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: str
   if (options.format == 'csv') console.log(rowsToCsv(res.rows, input.queries[input.queries.length - 1].fields))
   else printTable(res.rows)
   return true
+}
+
+// Load a markdown file into the workspace and run the common static analysis used by run/list commands.
+async function analyzeMdFile(mdArg: string, log: (...args: any[]) => void = console.log) {
+  let mdFile = normalizeFile(mdArg)
+  if (!mdFile) {
+    log(`Couldn't find ${mdArg}`)
+    return null
+  }
+
+  let files = await loadWorkspace(config.root, false, config.ignoredFiles)
+  let contents = process.env.NODE_ENV == 'test' && mockFileMap[mdFile] ? mockFileMap[mdFile] : readFileSync(path.resolve(config.root, mdFile), 'utf-8')
+  let analysis = analyzeWorkspace({config, files: files.filter(file => file.path != mdFile).concat({path: mdFile, contents, kind: 'md'})}, mdFile)
+  return {path: mdFile, contents, analysis, scanCounts: getWorkspaceScanCounts(files)}
 }
 
 async function sendSocketRequest({pageUrl, action, chart, format, log}: {pageUrl: string; action: 'check' | 'list'; chart?: string; format?: RunFormat; log: (...args: any[]) => void}) {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -11,6 +11,7 @@ import type {GrapheneError} from '../lang/index.d.ts'
 
 import {config} from '../lang/config.ts'
 import {analyzeWorkspace, getFile, loadWorkspace, toSql} from '../lang/core.ts'
+import {rowsToCsv} from '../lang/csv.ts'
 import {type AnalysisResult, type WorkspaceFileInput} from '../lang/types.ts'
 import {pollFor} from '../lang/util.ts'
 import {openInBrowser} from './auth.ts'
@@ -24,6 +25,7 @@ import {getWorkspaceScanCounts, type CliTelemetry} from './telemetry/index.ts'
 export interface RunMdFileOptions {
   mdArg: string
   chart?: string
+  format?: RunFormat
   headless?: boolean
   inputs?: RunInputs
   log?: (...args: any[]) => void
@@ -31,6 +33,7 @@ export interface RunMdFileOptions {
 }
 
 type RunInputs = Record<string, string | string[]>
+export type RunFormat = 'table' | 'csv'
 
 let browserConnections: {url: string; socket: WebSocket}[] = []
 let pendingRequests: Record<string, {response: ServerResponse<IncomingMessage>}> = {}
@@ -59,9 +62,19 @@ export async function runMdFile(options: RunMdFileOptions): Promise<boolean> {
   }
 
   let pageUrl = markdownPageUrl(mdFile, options.inputs)
-  let request = {pageUrl, action: 'check' as const, chart: options.chart, log}
+  let request = {pageUrl, action: 'check' as const, chart: options.chart, format: options.format || 'table', log}
   let resp = options.headless ? await runHeadlessPageRequest(request) : await sendSocketRequest(request)
   if (!resp) return false
+
+  if (options.format == 'csv') {
+    if (resp.csv === undefined) {
+      log(`Could not find chart "${options.chart}" on ${mdFile}`)
+      return false
+    }
+    console.log(resp.csv)
+    return true
+  }
+
   log('Page available at', runHost() + pageUrl)
 
   let errors = Array.from(resp.errors || []) as GrapheneError[]
@@ -122,7 +135,7 @@ export async function listMdFileQueries(mdArg: string, telemetry?: CliTelemetry,
   return true
 }
 
-export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string, options: {inputs?: RunInputs; telemetry?: CliTelemetry} = {}): Promise<boolean> {
+export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: string, options: {format?: RunFormat; inputs?: RunInputs; telemetry?: CliTelemetry} = {}): Promise<boolean> {
   let files = await loadWorkspace(process.cwd(), false, config.ignoredFiles)
   options.telemetry?.event('workspace_scanned', {command: 'run', ...getWorkspaceScanCounts(files)})
   let mdRelativePath = path.relative(process.cwd(), mdAbsolutePath)
@@ -152,15 +165,16 @@ export async function runNamedQueryFromMd(mdAbsolutePath: string, queryName: str
     return false
   }
   let res = await runQuery(sql)
-  printTable(res.rows)
+  if (options.format == 'csv') console.log(rowsToCsv(res.rows, input.queries[input.queries.length - 1].fields))
+  else printTable(res.rows)
   return true
 }
 
-async function sendSocketRequest({pageUrl, action, chart, log}: {pageUrl: string; action: 'check' | 'list'; chart?: string; log: (...args: any[]) => void}) {
+async function sendSocketRequest({pageUrl, action, chart, format, log}: {pageUrl: string; action: 'check' | 'list'; chart?: string; format?: RunFormat; log: (...args: any[]) => void}) {
   let host = runHost()
   if (!(await ensureBackgroundServer(log))) return null
 
-  let resp = await fetchSocketRequest({host, pageUrl, action, chart})
+  let resp = await fetchSocketRequest({host, pageUrl, action, chart, format})
 
   if (resp.error == 'no_server') {
     log('Failed to start Graphene server')
@@ -171,7 +185,7 @@ async function sendSocketRequest({pageUrl, action, chart, log}: {pageUrl: string
     log(`Opening page ${host}${pageUrl}`)
     openInBrowser(host + pageUrl)
     await new Promise(resolve => setTimeout(resolve, 500))
-    resp = await fetchSocketRequest({host, pageUrl, action, chart})
+    resp = await fetchSocketRequest({host, pageUrl, action, chart, format})
   }
 
   if (resp.error == 'no_tab') {
@@ -212,7 +226,7 @@ function runHost() {
   return `http://localhost:${config.port}`
 }
 
-async function fetchSocketRequest({host, pageUrl, action, chart}: {host: string; pageUrl: string; action: 'check' | 'list'; chart?: string}) {
+async function fetchSocketRequest({host, pageUrl, action, chart, format}: {host: string; pageUrl: string; action: 'check' | 'list'; chart?: string; format?: RunFormat}) {
   let abort = new AbortController()
   let timeout = setTimeout(() => abort.abort(), 30_000)
   let browserHost = host.replace('127.0.0.1', 'localhost')
@@ -220,7 +234,7 @@ async function fetchSocketRequest({host, pageUrl, action, chart}: {host: string;
     let response = await fetch(`${host}/_api/check`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({pageUrl: browserHost + pageUrl, action, chart}),
+      body: JSON.stringify({pageUrl: browserHost + pageUrl, action, chart, format}),
       signal: abort.signal,
     })
     clearTimeout(timeout)
@@ -244,7 +258,7 @@ async function fetchSocketRequest({host, pageUrl, action, chart}: {host: string;
 export async function proxyRunRequest(req: IncomingMessage, res: ServerResponse<IncomingMessage>): Promise<void> {
   let chunks = [] as any[]
   for await (let chunk of req) chunks.push(chunk)
-  let {pageUrl, action, chart} = JSON.parse(Buffer.concat(chunks).toString())
+  let {pageUrl, action, chart, format} = JSON.parse(Buffer.concat(chunks).toString())
   let id = Math.random().toString(36).slice(2)
   res.setHeader('Content-Type', 'application/json')
 
@@ -256,11 +270,11 @@ export async function proxyRunRequest(req: IncomingMessage, res: ServerResponse<
     return
   }
 
-  conn.socket.send(JSON.stringify({action, chart, requestId: id}))
+  conn.socket.send(JSON.stringify({action, chart, format, requestId: id}))
   pendingRequests[id] = {response: res}
 }
 
-async function runHeadlessPageRequest({pageUrl, action, chart, log}: {pageUrl: string; action: 'check' | 'list'; chart?: string; log: (...args: any[]) => void}) {
+async function runHeadlessPageRequest({pageUrl, action, chart, format, log}: {pageUrl: string; action: 'check' | 'list'; chart?: string; format?: RunFormat; log: (...args: any[]) => void}) {
   if (!(await ensureBackgroundServer(log))) return null
 
   let host = runHost()
@@ -293,6 +307,12 @@ async function runHeadlessPageRequest({pageUrl, action, chart, log}: {pageUrl: s
       )
       await context.close()
       return {componentIds}
+    }
+
+    if (format === 'csv') {
+      let csv = await exportChartCsv(page, chart || '')
+      await context.close()
+      return {csv}
     }
 
     let errors = await page.evaluate(() => ((window as any).$GRAPHENE?.getErrors?.() || []) as GrapheneError[])
@@ -357,6 +377,15 @@ async function captureChart(page: Page, chart: string) {
   }, chart)
   if (!selector) return undefined
   return await page.locator(selector).screenshot({animations: 'disabled', scale: 'css'})
+}
+
+async function exportChartCsv(page: Page, chart: string) {
+  if (!chart) return undefined
+  return await page.evaluate(chart => {
+    let graphene = (window as any).$GRAPHENE
+    if (typeof graphene?.exportChartCsv !== 'function') return undefined
+    return graphene.exportChartCsv(chart)
+  }, chart)
 }
 
 function toWorkspaceFiles(analysis: AnalysisResult): WorkspaceFileInput[] {

--- a/cli/telemetry/index.ts
+++ b/cli/telemetry/index.ts
@@ -12,7 +12,7 @@ export type {TelemetryCommand, TelemetryEventName, TelemetryPayloads} from './ty
 
 const DEFAULT_TELEMETRY_ENDPOINT = 'https://app.graphenedata.com/cli-telemetry'
 const SAFE_FLAG_NAMES: Partial<Record<TelemetryCommand, Record<string, string[]>>> = {
-  run: {chart: ['--chart', '-c'], headless: ['--headless'], input: ['--input'], port: ['--port'], query: ['--query', '-q']},
+  run: {chart: ['--chart', '-c'], format: ['--format'], headless: ['--headless'], input: ['--input'], port: ['--port'], query: ['--query', '-q']},
   serve: {bg: ['--bg'], port: ['--port']},
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,7 @@ graphene check path/to/page.md # Check for one specific markdown file
 
 # `run` is the primary command for iterating on queries and pages
 graphene run "from flights select count() as total" # Run inline GSQL and print results
+graphene run "from flights select count() as total" --format csv # Print query results as CSV
 graphene run 'from flights where carrier = $carrier select count() as total' --input carrier=AA # Provide parameter input values
 graphene run - # Read GSQL from stdin and print results
 graphene run path/to/page.md # Open the page in your system browser and save a full-page screenshot
@@ -24,10 +25,12 @@ graphene run path/to/page.md --input carrier=AA # Run the page with input values
 
 # `-c/--chart` can target either a chart title or the chart's `queryId`. For charts without titles use `graphene list` to see the exact IDs for charts on a page.
 graphene run path/to/page.md -c "Chart Title" # Run the page and screenshot one chart by title
+graphene run path/to/page.md -c "Chart Title" --format csv # Export the data backing one chart as CSV
 graphene run path/to/page.md -c 'Query (data="query_name" x="category" y="total")' # Run the page and screenshot one chart by queryId
 
 # `-q/--query` can target anything usable in a chart `data` prop (for example, a gsql table or a named code-fenced query in the markdown file).
 graphene run path/to/page.md -q query_name # Run a named query/table from the markdown context and print results
+graphene run path/to/page.md -q query_name --format csv # Run a named query/table and print results as CSV
 graphene run path/to/page.md -q query_name --input carrier=AA # Run a parameterized named query/table
 
 # `--input` values are strings. Repeat the flag to pass multiple values for one input.

--- a/lang/csv.test.ts
+++ b/lang/csv.test.ts
@@ -1,0 +1,35 @@
+/// <reference types="vitest/globals" />
+import {expect} from 'vitest'
+
+import {rowsToCsv} from './csv.ts'
+import {scalarType} from './types.ts'
+
+describe('rowsToCsv', () => {
+  it('serializes headers and rows with csv escaping', () => {
+    let rows = [
+      {name: 'Alice', note: 'hello, "world"', bio: 'line 1\nline 2'},
+      {name: 'Bob', note: null, bio: undefined},
+    ]
+
+    expect(rowsToCsv(rows)).toBe(['name,note,bio', 'Alice,"hello, ""world""","line 1\nline 2"', 'Bob,,'].join('\n'))
+  })
+
+  it('uses field order and resolves row keys case-insensitively', () => {
+    let fields = [
+      {name: 'carrier', type: scalarType('string')},
+      {name: 'total', type: scalarType('number')},
+    ]
+
+    expect(rowsToCsv([{CARRIER: 'AA', TOTAL: 12}], fields)).toBe(['carrier,total', 'AA,12'].join('\n'))
+  })
+
+  it('serializes arrays, objects, dates, and bigint values', () => {
+    let rows = [{id: 1n, tags: ['a', 'b'], payload: {ok: true}, created_at: new Date('2024-01-02T03:04:05.000Z')}]
+
+    expect(rowsToCsv(rows)).toBe(['id,tags,payload,created_at', '1,"[""a"",""b""]","{""ok"":true}",2024-01-02T03:04:05.000Z'].join('\n'))
+  })
+
+  it('can emit a header-only csv for empty results with known fields', () => {
+    expect(rowsToCsv([], [{name: 'carrier'}, {name: 'total'}])).toBe('carrier,total')
+  })
+})

--- a/lang/csv.ts
+++ b/lang/csv.ts
@@ -1,0 +1,44 @@
+export interface CsvField {
+  name: string
+}
+
+export function rowsToCsv(rows: Record<string, unknown>[], fields: CsvField[] = []): string {
+  let headers = csvHeaders(rows, fields)
+  if (headers.length === 0) return ''
+
+  let lines = [headers.map(escapeCsvCell).join(',')]
+  for (let row of rows) {
+    lines.push(headers.map(header => escapeCsvCell(csvValue(row, header))).join(','))
+  }
+  return lines.join('\n')
+}
+
+function csvHeaders(rows: Record<string, unknown>[], fields: CsvField[]) {
+  if (fields.length > 0) return fields.map(field => field.name)
+
+  let headers: string[] = []
+  for (let row of rows) {
+    for (let key of Object.keys(row)) {
+      if (!headers.includes(key)) headers.push(key)
+    }
+  }
+  return headers
+}
+
+function csvValue(row: Record<string, unknown>, header: string) {
+  if (Object.hasOwn(row, header)) return row[header]
+
+  let rowKey = Object.keys(row).find(key => key.toLowerCase() == header.toLowerCase())
+  return rowKey ? row[rowKey] : undefined
+}
+
+function escapeCsvCell(value: unknown) {
+  if (value === null || value === undefined) return ''
+  if (value instanceof Date) value = value.toISOString()
+  if (typeof value == 'bigint') value = String(value)
+  if (typeof value == 'object') value = JSON.stringify(value)
+
+  let text = String(value)
+  if (!/[",\r\n]/.test(text)) return text
+  return `"${text.replace(/"/g, '""')}"`
+}

--- a/ui/components/CsvDownload.svelte
+++ b/ui/components/CsvDownload.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import {rowsToCsv} from '../../lang/csv.ts'
+  import type {QueryResult} from '../component-utilities/types.ts'
+
+  interface Props {
+    data: QueryResult
+    exportId: string
+    title?: string
+  }
+
+  let {data, exportId, title = undefined}: Props = $props()
+
+  $effect(() => {
+    if (data.error) return
+    window.$GRAPHENE.chartExports ||= {}
+    window.$GRAPHENE.chartExports[exportId] = {rows: data.rows || [], fields: data.fields || []}
+    return () => {
+      delete window.$GRAPHENE.chartExports?.[exportId]
+    }
+  })
+
+  function downloadCsv() {
+    if (data.error) return
+
+    let csv = rowsToCsv(data.rows || [], data.fields || [])
+    let blob = new Blob([csv], {type: 'text/csv;charset=utf-8'})
+    let url = URL.createObjectURL(blob)
+    let link = document.createElement('a')
+    link.href = url
+    link.download = `${csvFileName(title || exportId || 'graphene-chart')}.csv`
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+  }
+
+  function csvFileName(value: string) {
+    let normalized = value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+    return normalized || 'graphene-chart'
+  }
+</script>
+
+<button class="csv-download" type="button" aria-label="Download chart data as CSV" title="Download chart data as CSV" onclick={downloadCsv}>
+  <svg viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M12 3v12" />
+    <path d="m7 10 5 5 5-5" />
+    <path d="M5 21h14" />
+  </svg>
+</button>
+
+<style>
+  .csv-download {
+    position: absolute;
+    top: -0.375rem;
+    right: 1rem;
+    z-index: 2;
+    display: grid;
+    place-items: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    color: #6b7280;
+    background: transparent;
+    border: 0;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 120ms ease, color 120ms ease;
+  }
+
+  :global(.echarts:hover) .csv-download,
+  :global(.echarts:focus-within) .csv-download,
+  .csv-download:hover,
+  .csv-download:focus-visible {
+    opacity: 1;
+  }
+
+  .csv-download:hover,
+  .csv-download:focus-visible {
+    color: #111827;
+  }
+
+  .csv-download:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+  }
+
+  .csv-download svg {
+    width: 1rem;
+    height: 1rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+</style>

--- a/ui/components/ECharts.svelte
+++ b/ui/components/ECharts.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {init} from 'echarts'
   import {onDestroy, onMount, untrack} from 'svelte'
+  import {rowsToCsv} from '../../lang/csv.ts'
   import ErrorDisplay from '../internal/ErrorDisplay.svelte'
   import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
   import {enrich, horizontalBarCount} from '../component-utilities/enrich.ts'
@@ -49,6 +50,7 @@
   function handleResults (res: QueryResult) {
     chartError = null
     loaded = res
+    registerChartExport()
     if (res?.error) chartLogger.error(res.error, {...res.error, componentId: displayId})
   }
 
@@ -66,6 +68,7 @@
       }
     } else {
       loaded = data
+      registerChartExport()
     }
   })
 
@@ -73,6 +76,7 @@
     resizeObserver?.disconnect()
     resizeObserver = null
     window.$GRAPHENE.unsubscribe(handleResults)
+    delete window.$GRAPHENE.chartExports?.[displayId]
     destroyChart()
   })
 
@@ -111,8 +115,8 @@
     // clone config, since enriching mutates the config, and mutating a prop is weird
     // structuredClone doesn't like proxies, so use state.snapshot
     let cloned = structuredClone($state.snapshot(config)) as EChartsConfig
-    let rows = loaded.rows
-    let fields = loaded.fields || []
+    let rows = structuredClone(loaded.rows || [])
+    let fields = structuredClone(loaded.fields || [])
     cloned.legendSelection = chart.getOption()?.legend?.[0]?.selected
     let enriched = enrich(cloned, rows, fields)
 
@@ -173,9 +177,44 @@
     return dim
   }
 
+  function registerChartExport() {
+    if (!loaded || loaded.error) return
+    window.$GRAPHENE.chartExports ||= {}
+    window.$GRAPHENE.chartExports[displayId] = {rows: loaded.rows || [], fields: loaded.fields || []}
+  }
+
+  function downloadCsv() {
+    if (!loaded || loaded.error) return
+
+    let csv = rowsToCsv(loaded.rows || [], loaded.fields || [])
+    let blob = new Blob([csv], {type: 'text/csv;charset=utf-8'})
+    let url = URL.createObjectURL(blob)
+    let link = document.createElement('a')
+    link.href = url
+    link.download = `${csvFileName(chartTitle || displayId || 'graphene-chart')}.csv`
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+  }
+
+  function csvFileName(value: string) {
+    let normalized = value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+    return normalized || 'graphene-chart'
+  }
+
 </script>
 
 <div class="echarts" bind:this={node} style={chartSizeStyle} data-component-id={mountedComponentId} data-chart-title={chartTitle}>
+  {#if loaded && !loaded.error && !chartError}
+    <button class="csv-download" type="button" aria-label="Download chart data as CSV" title="Download chart data as CSV" onclick={downloadCsv}>
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 3v12" />
+        <path d="m7 10 5 5 5-5" />
+        <path d="M5 21h14" />
+      </svg>
+    </button>
+  {/if}
   {#if loaded?.error || chartError}
     <ErrorDisplay error={loaded?.error || chartError} />
   {:else if !loaded}
@@ -188,6 +227,53 @@
 <style>
   .echarts {
     position: relative;
+  }
+
+  .csv-download {
+    position: absolute;
+    top: -0.375rem;
+    right: 1rem;
+    z-index: 2;
+    display: grid;
+    place-items: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    color: #6b7280;
+    background: rgba(255, 255, 255, 0.88);
+    border: 1px solid rgba(209, 213, 219, 0.8);
+    border-radius: 0.375rem;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 120ms ease, color 120ms ease, background-color 120ms ease;
+  }
+
+  .echarts:hover .csv-download,
+  .echarts:focus-within .csv-download,
+  .csv-download:hover,
+  .csv-download:focus-visible {
+    opacity: 1;
+  }
+
+  .csv-download:hover,
+  .csv-download:focus-visible {
+    color: #111827;
+    background: rgba(255, 255, 255, 0.98);
+  }
+
+  .csv-download:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+  }
+
+  .csv-download svg {
+    width: 1rem;
+    height: 1rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
 
   .empty-chart {

--- a/ui/components/ECharts.svelte
+++ b/ui/components/ECharts.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import {init} from 'echarts'
   import {onDestroy, onMount, untrack} from 'svelte'
-  import {rowsToCsv} from '../../lang/csv.ts'
   import ErrorDisplay from '../internal/ErrorDisplay.svelte'
   import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
   import {enrich, horizontalBarCount} from '../component-utilities/enrich.ts'
   import type {EChartsConfig, NormalConfig, QueryResult} from '../component-utilities/types.ts'
   import '../component-utilities/theme.ts'
+  import CsvDownload from './CsvDownload.svelte'
   import Skeleton from './Skeleton.svelte'
 
   interface Props {
@@ -50,7 +50,6 @@
   function handleResults (res: QueryResult) {
     chartError = null
     loaded = res
-    registerChartExport()
     if (res?.error) chartLogger.error(res.error, {...res.error, componentId: displayId})
   }
 
@@ -68,7 +67,6 @@
       }
     } else {
       loaded = data
-      registerChartExport()
     }
   })
 
@@ -76,7 +74,6 @@
     resizeObserver?.disconnect()
     resizeObserver = null
     window.$GRAPHENE.unsubscribe(handleResults)
-    delete window.$GRAPHENE.chartExports?.[displayId]
     destroyChart()
   })
 
@@ -177,43 +174,11 @@
     return dim
   }
 
-  function registerChartExport() {
-    if (!loaded || loaded.error) return
-    window.$GRAPHENE.chartExports ||= {}
-    window.$GRAPHENE.chartExports[displayId] = {rows: loaded.rows || [], fields: loaded.fields || []}
-  }
-
-  function downloadCsv() {
-    if (!loaded || loaded.error) return
-
-    let csv = rowsToCsv(loaded.rows || [], loaded.fields || [])
-    let blob = new Blob([csv], {type: 'text/csv;charset=utf-8'})
-    let url = URL.createObjectURL(blob)
-    let link = document.createElement('a')
-    link.href = url
-    link.download = `${csvFileName(chartTitle || displayId || 'graphene-chart')}.csv`
-    document.body.appendChild(link)
-    link.click()
-    link.remove()
-    URL.revokeObjectURL(url)
-  }
-
-  function csvFileName(value: string) {
-    let normalized = value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
-    return normalized || 'graphene-chart'
-  }
-
 </script>
 
 <div class="echarts" bind:this={node} style={chartSizeStyle} data-component-id={mountedComponentId} data-chart-title={chartTitle}>
   {#if loaded && !loaded.error && !chartError}
-    <button class="csv-download" type="button" aria-label="Download chart data as CSV" title="Download chart data as CSV" onclick={downloadCsv}>
-      <svg viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M12 3v12" />
-        <path d="m7 10 5 5 5-5" />
-        <path d="M5 21h14" />
-      </svg>
-    </button>
+    <CsvDownload data={loaded} exportId={displayId} title={chartTitle} />
   {/if}
   {#if loaded?.error || chartError}
     <ErrorDisplay error={loaded?.error || chartError} />
@@ -227,52 +192,6 @@
 <style>
   .echarts {
     position: relative;
-  }
-
-  .csv-download {
-    position: absolute;
-    top: -0.375rem;
-    right: 1rem;
-    z-index: 2;
-    display: grid;
-    place-items: center;
-    width: 1.75rem;
-    height: 1.75rem;
-    padding: 0;
-    color: #6b7280;
-    background: transparent;
-    border: 0;
-    border-radius: 0.375rem;
-    cursor: pointer;
-    opacity: 0;
-    transition: opacity 120ms ease, color 120ms ease;
-  }
-
-  .echarts:hover .csv-download,
-  .echarts:focus-within .csv-download,
-  .csv-download:hover,
-  .csv-download:focus-visible {
-    opacity: 1;
-  }
-
-  .csv-download:hover,
-  .csv-download:focus-visible {
-    color: #111827;
-  }
-
-  .csv-download:focus-visible {
-    outline: 2px solid #2563eb;
-    outline-offset: 2px;
-  }
-
-  .csv-download svg {
-    width: 1rem;
-    height: 1rem;
-    fill: none;
-    stroke: currentColor;
-    stroke-width: 2;
-    stroke-linecap: round;
-    stroke-linejoin: round;
   }
 
   .empty-chart {

--- a/ui/components/ECharts.svelte
+++ b/ui/components/ECharts.svelte
@@ -240,12 +240,12 @@
     height: 1.75rem;
     padding: 0;
     color: #6b7280;
-    background: rgba(255, 255, 255, 0.88);
-    border: 1px solid rgba(209, 213, 219, 0.8);
+    background: transparent;
+    border: 0;
     border-radius: 0.375rem;
     cursor: pointer;
     opacity: 0;
-    transition: opacity 120ms ease, color 120ms ease, background-color 120ms ease;
+    transition: opacity 120ms ease, color 120ms ease;
   }
 
   .echarts:hover .csv-download,
@@ -258,7 +258,6 @@
   .csv-download:hover,
   .csv-download:focus-visible {
     color: #111827;
-    background: rgba(255, 255, 255, 0.98);
   }
 
   .csv-download:focus-visible {

--- a/ui/internal/runSocket.ts
+++ b/ui/internal/runSocket.ts
@@ -1,6 +1,7 @@
 // WebSocket connection for the `graphene run` command.
 // Listens for run requests, waits for queries to finish, captures screenshots, and reports errors.
 
+import {rowsToCsv} from '../../lang/csv.ts'
 import {getErrors} from './telemetry.ts'
 
 let socket: WebSocket | null = null
@@ -13,14 +14,27 @@ async function loadHtml2Canvas() {
 }
 
 async function captureChart(chart: string) {
-  let escaped = window.CSS.escape(chart)
-  let chartEl = document.querySelector(`[data-chart-title="${escaped}"]`) as HTMLElement | null
-  chartEl ||= document.querySelector(`[data-component-id="${escaped}"]`) as HTMLElement | null
+  let chartEl = findChartElement(chart)
   if (!chartEl) return undefined
 
   await loadHtml2Canvas()
   let canvas = await html2canvas(chartEl, {useCORS: true, allowTaint: true, scale: 1, liveDOM: true})
   return canvas?.toDataURL('image/png')
+}
+
+function exportChartCsv(chart: string) {
+  let chartEl = findChartElement(chart)
+  let componentId = chartEl?.getAttribute('data-component-id') || ''
+  let data = componentId ? window.$GRAPHENE.chartExports?.[componentId] : undefined
+  if (!data) return undefined
+  return rowsToCsv(data.rows || [], data.fields || [])
+}
+
+function findChartElement(chart: string) {
+  let escaped = window.CSS.escape(chart)
+  let chartEl = document.querySelector(`[data-chart-title="${escaped}"]`) as HTMLElement | null
+  chartEl ||= document.querySelector(`[data-component-id="${escaped}"]`) as HTMLElement | null
+  return chartEl
 }
 
 function listComponentIds() {
@@ -42,7 +56,7 @@ function connect() {
   socket.onopen = () => socket!.send(JSON.stringify({type: 'register', url: window.location.href}))
 
   socket.onmessage = async event => {
-    let {requestId, action, chart} = JSON.parse(event.data)
+    let {requestId, action, chart, format} = JSON.parse(event.data)
     let finished = await window.$GRAPHENE.waitForLoad(20_000)
 
     if (action === 'list') {
@@ -50,7 +64,14 @@ function connect() {
       return
     }
 
+    if (format === 'csv') {
+      socket!.send(JSON.stringify({type: 'checkResponse', requestId, csv: chart ? exportChartCsv(chart) : undefined, stillLoading: !finished}))
+      return
+    }
+
     let screenshot = chart ? await captureChart(chart) : await takeScreenshot()
     socket!.send(JSON.stringify({type: 'checkResponse', requestId, errors: getErrors(), stillLoading: !finished, screenshot}))
   }
 }
+
+window.$GRAPHENE.exportChartCsv = exportChartCsv

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -493,6 +493,37 @@ test('cli list prints chart component IDs', async ({server, page}) => {
   expect(outputLines()).toEqual('BarChart (data="chart_data" x="carrier" y="total_distance")')
 })
 
+test('cli run with --chart exports chart data as csv', async ({server, page}) => {
+  let csv = ''
+  let originalLog = console.log
+  server.mockFile(
+    '/index.md',
+    `
+    # Chart CSV
+    \`\`\`sql chart_data
+    from flights where carrier in ('AA', 'DL') select carrier, count() as total_flights group by 1 order by carrier
+    \`\`\`
+    <BarChart data="chart_data" x="carrier" y="total_flights" title="Carrier Flights" />
+  `,
+  )
+
+  try {
+    console.log = (...args: any[]) => {
+      csv += args.map(arg => String(arg)).join(' ') + '\n'
+    }
+
+    await page.goto(server.url())
+    let result = await runMdFile({mdArg: 'index.md', chart: 'Carrier Flights', format: 'csv', log})
+    expect(result).toBe(true)
+    expect(csv.startsWith('carrier,total_flights\n')).toBe(true)
+    expect(csv).toContain('AA,')
+    expect(csv).toContain('DL,')
+    expect(outputLines()).toEqual('')
+  } finally {
+    console.log = originalLog
+  }
+})
+
 test('cli run with --chart captures a chart screenshot by component ID', async ({server, page}) => {
   server.mockFile(
     '/index.md',

--- a/ui/tests/matchers.ts
+++ b/ui/tests/matchers.ts
@@ -35,16 +35,28 @@ const extendedExpect = baseExpect.extend({
       return {message: () => `Screenshot ${snapshotName} is not a valid png (might need to LFS pull)`, pass: false}
     }
 
-    let result = await (page as any)._expectScreenshot({
-      animations: 'disabled',
-      caret: 'hide',
-      scale: 'css',
-      locator,
-      maxDiffPixelRatio: 0, // strict: no differing pixels allowed
-      threshold: 0.01, // strict per-pixel color matching
-      timeout: 5_000,
-      expected: expectedBuffer,
+    await (page as Page).evaluate(() => {
+      let style = document.createElement('style')
+      style.id = '__graphene_screenshot_hide_transient_ui'
+      style.textContent = '.csv-download { display: none !important; }'
+      document.head.appendChild(style)
     })
+
+    let result
+    try {
+      result = await (page as any)._expectScreenshot({
+        animations: 'disabled',
+        caret: 'hide',
+        scale: 'css',
+        locator,
+        maxDiffPixelRatio: 0, // strict: no differing pixels allowed
+        threshold: 0.01, // strict per-pixel color matching
+        timeout: 5_000,
+        expected: expectedBuffer,
+      })
+    } finally {
+      await (page as Page).evaluate(() => document.getElementById('__graphene_screenshot_hide_transient_ui')?.remove())
+    }
     if (!result) throw new Error('Playwright did not return screenshot result')
 
     // update snapshot if needed/allowed

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -1,6 +1,8 @@
 // Tests that various echarts render as expected.
 // When writing these tests, prefer just using a screenshot, and avoid adding assertions that check things already visible in the screenshot.
 
+import fs from 'node:fs/promises'
+
 import {scalarType} from '../../lang/types.ts'
 import {expect, test} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
@@ -53,6 +55,7 @@ function scatterData() {
 
 test.beforeEach(async ({sharedPage}) => {
   await sharedPage.setViewportSize({width: 680, height: 400})
+  await sharedPage.mouse.move(679, 399)
 })
 
 test('echarts query error state', async ({mount, chart}) => {
@@ -148,6 +151,40 @@ test('echarts heatmap supports numeric values on explicit category axis', async 
 test('bar chart', async ({mount, chart}) => {
   await mount('components/BarChart.svelte', {data: timeseries(), x: 'month', y: 'sales_usd0k', title: 'Monthly Sales'})
   await expect(chart.el).screenshot('bar-chart')
+})
+
+test('chart download button exports raw csv rows', async ({mount, chart, sharedPage}) => {
+  try {
+    await mount('components/BarChart.svelte', {
+      data: {
+        rows: [
+          {category: 'A, Inc', value: 10},
+          {category: 'B "Team"', value: 12},
+        ],
+        fields: [
+          {name: 'category', type: scalarType('string')},
+          {name: 'value', type: scalarType('number')},
+        ],
+      },
+      x: 'category',
+      y: 'value',
+      title: 'Download Test',
+    })
+
+    let button = chart.el.getByRole('button', {name: 'Download chart data as CSV'})
+    await button.hover()
+    await expect(button).toHaveCSS('opacity', '1')
+    let downloadPromise = sharedPage.waitForEvent('download')
+    await button.click()
+    let download = await downloadPromise
+    let csv = await fs.readFile((await download.path())!, 'utf-8')
+
+    expect(download.suggestedFilename()).toBe('download-test.csv')
+    expect(csv).toBe(['category,value', '"A, Inc",10', '"B ""Team""",12'].join('\n'))
+  } finally {
+    await sharedPage.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+    await sharedPage.mouse.move(679, 399)
+  }
 })
 
 test('bar chart supports multiple y fields', async ({mount, chart}) => {


### PR DESCRIPTION
This PR adds support for exporting query results in CSV format. This is exposed in the CLI with a `--format csv` param on `graphene run`, which works when running a raw GSQL query, targeting a query with `-q`, or a chart with `-c`. Exporting the query results backing a chart is also supported in the UI with a download button that appears in the top right on hover, and looks like:

<img width="617" height="356" alt="Screenshot 2026-06-09 at 7 39 50 AM" src="https://github.com/user-attachments/assets/0f364c40-53c2-429b-b90d-26d7738e009a" />

Fixes #461