### PR TITLE
preserve metadata through casts by default

### DIFF
--- a/docs/references/gsql.md
+++ b/docs/references/gsql.md
@@ -133,7 +133,7 @@ table orders (
 ### Metadata annotations
 Metadata can be attached to fields to aid with automatic formatting. It can be applied to fields in a `table`, or in a `select`.
 Functions like data_trunc and extract automatically add correct metadata, but in other cases you'll have to add it manually.
-Metadata cascades through selects, so you don't have to re-set metadata when selecting a field.
+Metadata cascades through selects and casts, so you don't have to re-set metadata when selecting or retyping a field. Temporal metadata is only preserved through casts when the result type still has compatible temporal or numeric semantics.
 
 ```gsql
 table foo (

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -1021,7 +1021,7 @@ class AnalysisSession implements Analyzer {
         if (!parsed.type) return this.diag(typeNode, `Unsupported cast type: ${rawType.toLowerCase()}`, {sql: 'NULL', type: scalarType('error')})
         let resultType = parsed.type
         let targetType = this.renderCastType(rawType)
-        return {...expr, sql: `CAST(${expr.sql} AS ${targetType})`, type: resultType, metadata: this.preserveTemporalMetadataThroughCast(expr, resultType)}
+        return {...expr, sql: `CAST(${expr.sql} AS ${targetType})`, type: resultType, metadata: this.preserveMetadataThroughCast(expr, resultType)}
       }
 
       case 'ExtractExpression': {
@@ -1144,10 +1144,24 @@ class AnalysisSession implements Analyzer {
     return {...expr, sql: `${targetType.toUpperCase()} '${parsed.literal}'`, type: scalarType(targetType)}
   }
 
-  private preserveTemporalMetadataThroughCast(expr: Expr, resultType: FieldType): FieldMeta | undefined {
-    if (!expr.metadata?.timeGrain) return undefined
-    if (!isScalarType(resultType, 'date') && !isScalarType(resultType, 'timestamp')) return undefined
-    return {timeGrain: expr.metadata.timeGrain, ...(expr.metadata.defaultName ? {defaultName: expr.metadata.defaultName} : {})}
+  private preserveMetadataThroughCast(expr: Expr, resultType: FieldType): FieldMeta | undefined {
+    if (!expr.metadata) return undefined
+    let metadata = {...expr.metadata}
+    let droppedTemporalMetadata = false
+
+    let resultIsTemporal = isScalarType(resultType, 'date') || isScalarType(resultType, 'timestamp')
+    let numericToNumeric = isScalarType(expr.type, 'number') && isScalarType(resultType, 'number')
+    if (metadata.timeGrain && !resultIsTemporal && !numericToNumeric) {
+      delete metadata.timeGrain
+      droppedTemporalMetadata = true
+    }
+    if (metadata.timeOrdinal && !numericToNumeric) {
+      delete metadata.timeOrdinal
+      droppedTemporalMetadata = true
+    }
+    if (droppedTemporalMetadata) delete metadata.defaultName
+
+    return Object.keys(metadata).length ? metadata : undefined
   }
 
   private sameFieldMetadata(left?: FieldMeta, right?: FieldMeta) {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -977,6 +977,24 @@ describe('lang', () => {
     expect(query.fields[0].metadata).toMatchObject({currency: 'USD'})
   })
 
+  it('preserves non-temporal field metadata through casts', () => {
+    updateFile(
+      `table revenue (
+        amount int -- gross revenue #currency=USD #unit=dollars #pii #source=warehouse
+      )`,
+      'revenue.gsql',
+    )
+
+    let [query] = analyze('from revenue select cast(amount as varchar) as amount_text')
+    expect(query.fields[0].metadata).toMatchObject({
+      description: 'gross revenue',
+      currency: 'USD',
+      unit: 'dollars',
+      pii: 'true',
+      source: 'warehouse',
+    })
+  })
+
   it('parses field metadata from select items', () => {
     updateFile('table scores (wins int, games int)', 'scores.gsql')
 
@@ -1259,6 +1277,36 @@ describe('lang', () => {
 
     let [reshaped] = analyze('from events select extract(year from month_start) as year_num')
     expect(reshaped.fields[0].metadata).toEqual({timeGrain: 'year', defaultName: 'year'})
+  })
+
+  it('drops temporal metadata through casts when the result type no longer has temporal semantics', () => {
+    updateFile(
+      `
+      table events (
+        event_date date
+        created_at timestamp
+        month_start: date_trunc('month', event_date)
+        month_number: extract(month from created_at)
+      )
+    `,
+      'events.gsql',
+    )
+
+    let [timeGrainToString] = analyze('from events select cast(month_start as varchar) as month_text')
+    expect(timeGrainToString.fields[0].metadata).toBeUndefined()
+
+    let [timeOrdinalToString] = analyze('from events select cast(month_number as varchar) as month_number_text')
+    expect(timeOrdinalToString.fields[0].metadata).toBeUndefined()
+  })
+
+  it('preserves numeric temporal metadata through numeric casts', () => {
+    updateFile('table events (created_at timestamp)', 'events.gsql')
+
+    let [timeOrdinal] = analyze('from events select cast(extract(month from created_at) as int) as month_number')
+    expect(timeOrdinal.fields[0].metadata).toEqual({timeOrdinal: 'month_of_year', defaultName: 'month'})
+
+    let [yearGrain] = analyze('from events select cast(extract(year from created_at) as int) as year_number')
+    expect(yearGrain.fields[0].metadata).toEqual({timeGrain: 'year', defaultName: 'year'})
   })
 
   it('drops temporal grain on set operations when branches disagree', () => {


### PR DESCRIPTION
Per the discussion in #397, this PR updates GSQL to preserve field metadata through casts, with the exception of temporal metadata which is only preserved if the cast type is compatible. Fixes #397