### PR TITLE
support multi-repo cloud auth

### DIFF
--- a/cli/auth.ts
+++ b/cli/auth.ts
@@ -117,7 +117,8 @@ export async function loginPkce(opener?: (url: string) => Promise<void>) {
   let redirect_uri = `${loop.url}/callback`
 
   // Build authorize URL (merge with provided URL if present)
-  let authorizeUrl = new URL(`${config.host}/authenticate`)
+  let cloudOrigin = new URL(config.host!).origin
+  let authorizeUrl = new URL(`${cloudOrigin}/authenticate`)
   authorizeUrl.search = new URLSearchParams({
     redirect_uri,
     code_challenge,
@@ -135,7 +136,7 @@ export async function loginPkce(opener?: (url: string) => Promise<void>) {
   if (!result.code) throw new Error('No authorization code received')
   if (result.state !== state) throw new Error('State mismatch')
 
-  let res = await fetch(`${config.host}/_api/oauth2/token`, {
+  let res = await fetch(`${cloudOrigin}/_api/oauth2/token`, {
     method: 'POST',
     headers: {'content-type': 'application/json'},
     body: JSON.stringify({
@@ -153,8 +154,9 @@ export async function loginPkce(opener?: (url: string) => Promise<void>) {
 
 async function refreshAccessToken() {
   let refresh_token = (await readEntry())?.refresh_token
+  let cloudOrigin = new URL(config.host!).origin
   if (!refresh_token) throw new Error('No refresh token available; run `graphene login`')
-  let res = await fetch(new URL('/_api/oauth2/token', config.host).toString(), {
+  let res = await fetch(new URL('/_api/oauth2/token', cloudOrigin).toString(), {
     method: 'POST',
     headers: {'content-type': 'application/json'},
     body: JSON.stringify({grant_type: 'refresh_token', refresh_token, client_id: authClientId()}),
@@ -178,7 +180,8 @@ export async function authenticatedFetch(pathOrUrl: string, init: RequestInit = 
   if (!token) throw new Error('Failed to obtain access token')
 
   // make a request with the authorization header set
-  let url = new URL(pathOrUrl, config.host)
+  let cloudOrigin = new URL(config.host!).origin
+  let url = new URL(pathOrUrl, cloudOrigin)
   let headers = new Headers(init.headers || {})
   headers.set('authorization', `Bearer ${token}`)
 

--- a/cli/connections/index.ts
+++ b/cli/connections/index.ts
@@ -52,10 +52,13 @@ export async function runQuery(sql: string, options: RunQueryOptions = {}): Prom
     let headers: Record<string, string> = {'Content-Type': 'application/json'}
     if (cacheControl) headers['Cache-Control'] = cacheControl
 
+    // A Cloud host path selects the repo to query, e.g. https://example.graphenedata.com/nba proxies through the `nba` repo connection.
+    let repoId = new URL(config.host!).pathname.replace(/^\/+|\/+$/g, '')
+
     let resp = await authenticatedFetch('/_api/query', {
       method: 'POST',
       headers,
-      body: JSON.stringify({sql, params}),
+      body: JSON.stringify({sql, params, repoId}),
     })
     let json = await resp.json()
     if (!resp.ok) throw new Error(json.message || json.error || `Query failed with HTTP ${resp.status}`)

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -181,7 +181,7 @@ async function handleQuery(req: IncomingMessage, res: ServerResponse<IncomingMes
     return res.end()
   }
 
-  if (config.host) console.log(`Proxying query to ${config.host}/_api/query`)
+  if (config.host) console.log(`Proxying query to ${config.host}`)
   let cacheControl = Array.isArray(req.headers['cache-control']) ? req.headers['cache-control'].join(',') : req.headers['cache-control']
   let queryResults = await runQuery(sql, {cacheControl})
   let totalRows = queryResults.totalRows ?? queryResults.rows.length


### PR DESCRIPTION
If an org has multiple projects set up, we need a way to specify which project we're connecting to. I'm opting to just make this part of the `host` config option.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>