### PR TITLE
don't compile normal counts to distinct

### DIFF
--- a/examples/ecomm/models/inventory_items.gsql
+++ b/examples/ecomm/models/inventory_items.gsql
@@ -15,7 +15,7 @@ table inventory_items (
   join one products on products.id = product_id
   join one distribution_centers on distribution_centers.id = product_distribution_center_id
 
-  sold_count: count(case when sold_at is not null then 1 else null end)
+  sold_count: count(distinct case when sold_at is not null then 1 else null end)
   in_stock_count: count(*) - sold_count
   avg_days_in_inventory: avg(timestamp_diff(sold_at, created_at, minute)) / 1440.0
   inventory_turnover: safe_divide(sold_count, count(*))

--- a/examples/ecomm/models/order_items.gsql
+++ b/examples/ecomm/models/order_items.gsql
@@ -22,7 +22,7 @@ table order_items (
   fulfillment_time_days: timestamp_diff(shipped_at, created_at, minute) / 1440.0
   delivery_time_days: timestamp_diff(delivered_at, shipped_at, minute) / 1440.0
 
-  units_sold: count(case when is_rev_recognized then 1 else null end)
+  units_sold: count(distinct case when is_rev_recognized then 1 else null end)
   revenue: sum(case when is_rev_recognized then sale_price else 0 end) -- Aka net revenue/sales
   cogs: sum(case when is_rev_recognized then cost else 0 end) -- Cost of goods sold
   gross_profit: revenue - cogs

--- a/examples/ecomm/models/orders.gsql
+++ b/examples/ecomm/models/orders.gsql
@@ -14,7 +14,7 @@ table orders (
 
   is_rev_recognized: status in ('Processing', 'Shipped', 'Complete')
 
-  rev_rec_order_count: count(case when is_rev_recognized then 1 else null end)
+  rev_rec_order_count: count(distinct case when is_rev_recognized then 1 else null end)
   aov: safe_divide(order_items.revenue, rev_rec_order_count) -- average order value
   avg_order_cycle_time_days: avg(timestamp_diff(delivered_at, created_at, minute)) / 1440.0 -- time from order creation to delivery
   customer_count: count(distinct case when is_rev_recognized then user_id else null end)

--- a/examples/ecomm/models/users.gsql
+++ b/examples/ecomm/models/users.gsql
@@ -29,7 +29,7 @@ table users (
   days_to_first_purchase: timestamp_diff(user_facts.first_purchase_at, created_at, minute) / 1440.0
   -- timestamp_diff(current_timestamp(), last_purchase_at, minute) as time_since_last_purchase_minutes -- current_timestamp() not supported yet
 
-  conversion_rate: safe_divide(orders.customer_count, count(id)) -- percentage of users who made at least one purchase #ratio
+  conversion_rate: safe_divide(orders.customer_count, count(distinct id)) -- percentage of users who made at least one purchase #ratio
 )
 
 -- Do not query this directly

--- a/examples/flights/carrier_detail.md
+++ b/examples/flights/carrier_detail.md
@@ -157,7 +157,7 @@ select
   aircraft_models.manufacturer as manufacturer,
   aircraft_models.model as model,
   year_built::text as year_built,
-  count(flights.id2) as flights_flown,
+  count(distinct flights.id2) as flights_flown,
   sum(flights.miles_flown) as miles_flown
 order by flights_flown desc
 limit 100

--- a/examples/postgres/index.md
+++ b/examples/postgres/index.md
@@ -28,7 +28,7 @@ order by 1
 from customers
 select
   region,
-  count(orders.id) as orders,
+  count(distinct orders.id) as orders,
   total_revenue
 group by 1
 order by 3 desc
@@ -41,7 +41,7 @@ from customers
 cross join unnest(tags) as tag
 select
   tag,
-  count(id) as customers
+  count(distinct id) as customers
 group by 1
 order by 2 desc
 ```

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -832,13 +832,15 @@ class AnalysisSession implements Analyzer {
         let inner = node.getChild('Expression')
         if (inner) {
           let expr = this.analyzeExpr(inner, scope)
+          let isDistinct = node.getChildren('Kw').some(keyword => txt(keyword).toLowerCase() == 'distinct')
+          let sensitivePaths = isDistinct ? expr.fanout?.sensitivePaths : mergeSensitiveFanouts(expr.fanout?.sensitivePaths, [expr.fanout?.path || extendFanoutPath(scope.fanoutPath)])
           return {
-            sql: `count(distinct ${expr.sql})`,
+            sql: `count(${isDistinct ? 'distinct ' : ''}${expr.sql})`,
             type: scalarType('number'),
             metadata: {defaultName: 'count'},
             isAgg: true,
             canWindow: true,
-            fanout: normalizeExprFanout({sensitivePaths: mergeSensitiveFanouts(expr.fanout?.sensitivePaths), conflict: expr.fanout?.conflict}),
+            fanout: normalizeExprFanout({sensitivePaths, conflict: expr.fanout?.conflict}),
           }
         }
         return {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -440,7 +440,7 @@ describe('lang', () => {
 
   it('expands measures', async () => {
     expect('from users select name, total_orders').toRenderSql(
-      'select users.name as name, (count(distinct orders.id)) as total_orders from users as users left join orders as orders on orders.user_id=users.id group by 1 order by 2 desc nulls last',
+      'select users.name as name, (count(orders.id)) as total_orders from users as users left join orders as orders on orders.user_id=users.id group by 1 order by 2 desc nulls last',
     )
 
     await expect('from users select name, total_orders').toReturnRows(['Alice', 2], ['Bob', 1])
@@ -724,19 +724,23 @@ describe('lang', () => {
     expect('from users select distinct name, email').toRenderSql('select users.name as name, users.email as email from users as users group by 1,2 order by 1 asc nulls last')
   })
 
-  it('coun(distinct)', () => {
+  it('supports count(distinct)', () => {
     expect('from users select count(distinct name)').toRenderSql('select count(distinct users.name) as count from users as users')
+  })
+
+  it('supports count without implicit distinct', () => {
+    expect('from users select count(name)').toRenderSql('select count(users.name) as count from users as users')
   })
 
   it('adds groupBy to select if needed', () => {
     expect('from users select count(orders.id) as total group by name').toRenderSql(
-      'select users.name as name, count(distinct orders.id) as total from users as users left join orders as orders on orders.user_id=users.id group by 1 order by 2 desc nulls last',
+      'select users.name as name, count(orders.id) as total from users as users left join orders as orders on orders.user_id=users.id group by 1 order by 2 desc nulls last',
     )
   })
 
   it('doesnt duplicate groupBys', () => {
     expect('from users select name, count(orders.id) group by name').toRenderSql(
-      'select users.name as name, count(distinct orders.id) as count from users as users left join orders as orders on orders.user_id=users.id group by 1 order by 2 desc nulls last',
+      'select users.name as name, count(orders.id) as count from users as users left join orders as orders on orders.user_id=users.id group by 1 order by 2 desc nulls last',
     )
   })
 
@@ -1100,7 +1104,7 @@ describe('lang', () => {
   })
 
   it('can correctly count through a join', () => {
-    expect('from orders select count(users.id)').toRenderSql('select count(distinct users.id) as count from orders as orders left join users as users on users.id=orders.user_id')
+    expect('from orders select count(users.id)').toRenderSql('select count(users.id) as count from orders as orders left join users as users on users.id=orders.user_id')
   })
 
   it('handles min/max through a join', () => {
@@ -2237,8 +2241,12 @@ describe('lang', () => {
     `).toHaveNoErrors()
   })
 
-  it('treats count(id) as distinct-safe when it mixes with a fanout grain', () => {
-    expect('from users select name, count(id), sum(orders.order_items.quantity)').toHaveNoErrors()
+  it('reports fanout when count(id) mixes with a fanout grain', () => {
+    expect('from users select name, count(id), sum(orders.order_items.quantity)').toHaveDiagnostic(/Aggregate expression `count\(id\)` is fanned out by join to table `order_items`/i)
+  })
+
+  it('treats count(distinct id) as distinct-safe when it mixes with a fanout grain', () => {
+    expect('from users select name, count(distinct id), sum(orders.order_items.quantity)').toHaveNoErrors()
   })
 
   it('reports fanout when count(*) mixes with a fanout grain', () => {


### PR DESCRIPTION
Agents seem pretty confused by the fact that GSQL compiles `count(col)` to `count(distinct col)`, to the point of considering it a bug. This may in part be a documentation problem, but even if it were better documented I think it is a confusing departure from ANSI SQL.