### PR TITLE
support screenshotting table with `graphene run -c`

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -65,7 +65,7 @@ program
   .command('run')
   .description('Run a query or screenshot a Graphene page')
   .argument('[input]', 'Path to file, a raw string, or "-" for stdin')
-  .option('-c, --chart <chartTitleOrComponentId>', 'Title or component ID of a specific chart to capture')
+  .option('-c, --chart <chartTitleOrComponentId>', 'Title or component ID of a specific chart or table to capture')
   .option('--format <format>', 'Output format for query or chart data: table or csv', 'table')
   .option('--headless', 'Run markdown pages in a headless browser instead of opening the system browser')
   .option('--port <port>', 'Port for the local Graphene server')
@@ -134,7 +134,7 @@ program
 
 program
   .command('list')
-  .description('List the component IDs for charts on a markdown page')
+  .description('List the component IDs for charts and tables on a markdown page')
   .argument('<file>', 'Markdown file to inspect')
   .action(
     withTelemetry('list', async (exit, fileArg: string) => {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -306,7 +306,7 @@ async function runHeadlessPageRequest({pageUrl, action, chart, format, log}: {pa
     }
 
     let errors = await page.evaluate(() => ((window as any).$GRAPHENE?.getErrors?.() || []) as GrapheneError[])
-    let screenshot = chart ? await captureChart(page, chart) : await page.screenshot({fullPage: true, animations: 'disabled', scale: 'css'})
+    let screenshot = chart ? await captureComponent(page, chart) : await page.screenshot({fullPage: true, animations: 'disabled', scale: 'css'})
     await context.close()
     return {errors, stillLoading: !finished, screenshot}
   } catch (err) {
@@ -358,13 +358,14 @@ async function launchHeadlessBrowser(log: (...args: any[]) => void) {
   return null
 }
 
-async function captureChart(page: Page, chart: string) {
-  let selector = await page.evaluate(chart => {
-    let escaped = window.CSS.escape(chart)
+async function captureComponent(page: Page, component: string) {
+  let selector = await page.evaluate(component => {
+    let escaped = window.CSS.escape(component)
     if (document.querySelector(`[data-chart-title="${escaped}"]`)) return `[data-chart-title="${escaped}"]`
+    if (document.querySelector(`[data-component-title="${escaped}"]`)) return `[data-component-title="${escaped}"]`
     if (document.querySelector(`[data-component-id="${escaped}"]`)) return `[data-component-id="${escaped}"]`
     return null
-  }, chart)
+  }, component)
   if (!selector) return undefined
   return await page.locator(selector).screenshot({animations: 'disabled', scale: 'css'})
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,10 +23,10 @@ graphene run path/to/page.md --input carrier=AA # Run the page with input values
 # The command prints the live page URL, e.g. http://localhost:4000/path/to/page, and the server keeps running for hot reloads.
 # After iterating until the screenshot looks acceptable, agents can link users directly to that localhost URL.
 
-# `-c/--chart` can target either a chart title or the chart's `queryId`. For charts without titles use `graphene list` to see the exact IDs for charts on a page.
-graphene run path/to/page.md -c "Chart Title" # Run the page and screenshot one chart by title
-graphene run path/to/page.md -c "Chart Title" --format csv # Export the data backing one chart as CSV
-graphene run path/to/page.md -c 'Query (data="query_name" x="category" y="total")' # Run the page and screenshot one chart by queryId
+# `-c/--chart` can target a chart or table title, or the component ID printed by `graphene list`.
+graphene run path/to/page.md -c "Chart Title" # Run the page and screenshot one chart/table by title
+graphene run path/to/page.md -c "Chart Title" --format csv # Export the data backing one chart/table as CSV
+graphene run path/to/page.md -c 'BarChart (data="query_name" x="category" y="total")' # Run the page and screenshot one chart/table by component ID
 
 # `-q/--query` can target anything usable in a chart `data` prop (for example, a gsql table or a named code-fenced query in the markdown file).
 graphene run path/to/page.md -q query_name # Run a named query/table from the markdown context and print results

--- a/ui/components/Table.svelte
+++ b/ui/components/Table.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import type {Snippet} from 'svelte'
+  import {untrack, type Snippet} from 'svelte'
   import type {QueryResult} from '../component-utilities/types.ts'
+  import {componentLogger} from '../internal/telemetry.ts'
   import QueryLoad from './QueryLoad.svelte'
   import TableInner from './_Table.svelte'
 
@@ -12,15 +13,19 @@
 
   let {data, children, ...restProps}: Props = $props()
 
+  let logger = untrack(() => componentLogger('DataTable', {data: typeof data == 'string' ? data : undefined}))
+  let componentTitle = $derived(restProps.title === undefined || restProps.title === null ? undefined : String(restProps.title))
   let spreadProps = $derived(Object.fromEntries(Object.entries(restProps).filter(([, value]) => value !== undefined)))
 </script>
 
 {#snippet tableContent(loaded: QueryResult)}
   {#if children}
-    <TableInner {...spreadProps} data={loaded} {children} />
+    <TableInner {...spreadProps} data={loaded} componentId={logger.id} {children} />
   {:else}
-    <TableInner {...spreadProps} data={loaded} />
+    <TableInner {...spreadProps} data={loaded} componentId={logger.id} />
   {/if}
 {/snippet}
 
-<QueryLoad {data} children={tableContent} />
+<div class="table-component" data-component-id={logger.id} data-component-title={componentTitle} data-chart-title={componentTitle}>
+  <QueryLoad {data} children={tableContent} componentId={logger.id} />
+</div>

--- a/ui/components/_Table.svelte
+++ b/ui/components/_Table.svelte
@@ -24,7 +24,7 @@
     headerColor?: string, headerFontColor?: string, formatColumnTitles?: boolean | string
     backgroundColor?: string, compact?: boolean | string, link?: string, showLinkCol?: boolean | string
     totalRow?: boolean | string, totalRowColor?: string, totalFontColor?: string, emptyMessage?: string
-    isFullPage?: boolean | string, children?: Snippet
+    isFullPage?: boolean | string, componentId?: string, children?: Snippet
   }
 
   const {resolveColor} = getThemeStores()
@@ -37,7 +37,7 @@
     wrapTitles = false, headerColor = undefined, headerFontColor = undefined, formatColumnTitles = true,
     backgroundColor = undefined, compact = undefined, link = undefined, showLinkCol = false,
     totalRow = false, totalRowColor = undefined, totalFontColor = undefined, emptyMessage = undefined,
-    isFullPage = undefined, children,
+    isFullPage = undefined, componentId = undefined, children,
   }: Props = $props()
 
   let rowsNum = $derived.by(() => {
@@ -204,6 +204,15 @@
   let dataTestId = $derived(processedState.dataTestId)
 
   let error = $derived(processedState.error)
+
+  $effect(() => {
+    if (!componentId || error) return
+    window.$GRAPHENE.chartExports ||= {}
+    window.$GRAPHENE.chartExports[componentId] = {rows: data.rows || [], fields: data.fields || []}
+    return () => {
+      delete window.$GRAPHENE.chartExports?.[componentId]
+    }
+  })
 
   // Sorting helpers
   const normalizeForSort = (value: unknown) => {

--- a/ui/internal/runSocket.ts
+++ b/ui/internal/runSocket.ts
@@ -13,28 +13,29 @@ async function loadHtml2Canvas() {
   html2canvas ||= (await import('@graphenedata/html2canvas'))?.default
 }
 
-async function captureChart(chart: string) {
-  let chartEl = findChartElement(chart)
-  if (!chartEl) return undefined
+async function captureComponent(component: string) {
+  let componentEl = findVisualComponentElement(component)
+  if (!componentEl) return undefined
 
   await loadHtml2Canvas()
-  let canvas = await html2canvas(chartEl, {useCORS: true, allowTaint: true, scale: 1, liveDOM: true})
+  let canvas = await html2canvas(componentEl, {useCORS: true, allowTaint: true, scale: 1, liveDOM: true})
   return canvas?.toDataURL('image/png')
 }
 
 function exportChartCsv(chart: string) {
-  let chartEl = findChartElement(chart)
-  let componentId = chartEl?.getAttribute('data-component-id') || ''
+  let componentEl = findVisualComponentElement(chart)
+  let componentId = componentEl?.getAttribute('data-component-id') || ''
   let data = componentId ? window.$GRAPHENE.chartExports?.[componentId] : undefined
   if (!data) return undefined
   return rowsToCsv(data.rows || [], data.fields || [])
 }
 
-function findChartElement(chart: string) {
-  let escaped = window.CSS.escape(chart)
-  let chartEl = document.querySelector(`[data-chart-title="${escaped}"]`) as HTMLElement | null
-  chartEl ||= document.querySelector(`[data-component-id="${escaped}"]`) as HTMLElement | null
-  return chartEl
+function findVisualComponentElement(component: string) {
+  let escaped = window.CSS.escape(component)
+  let componentEl = document.querySelector(`[data-chart-title="${escaped}"]`) as HTMLElement | null
+  componentEl ||= document.querySelector(`[data-component-title="${escaped}"]`) as HTMLElement | null
+  componentEl ||= document.querySelector(`[data-component-id="${escaped}"]`) as HTMLElement | null
+  return componentEl
 }
 
 function listComponentIds() {
@@ -69,7 +70,7 @@ function connect() {
       return
     }
 
-    let screenshot = chart ? await captureChart(chart) : await takeScreenshot()
+    let screenshot = chart ? await captureComponent(chart) : await takeScreenshot()
     socket!.send(JSON.stringify({type: 'checkResponse', requestId, errors: getErrors(), stillLoading: !finished, screenshot}))
   }
 }

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -412,6 +412,52 @@ test('cli run with --headless captures a screenshot without an open page', async
   )
 })
 
+test('cli run with --chart captures a table screenshot by title', async ({server, page}) => {
+  server.mockFile(
+    '/index.md',
+    `
+    # Table Screenshot
+    \`\`\`sql table_data
+    from flights select carrier, count() as total_flights group by 1 order by carrier limit 5
+    \`\`\`
+    <Table data="table_data" title="Carrier Totals" rows=5 />
+  `,
+  )
+
+  await page.goto(server.url())
+  await runMdFile({mdArg: 'index.md', chart: 'Carrier Totals', log})
+  expect(outputLines()).toEqual(
+    trimIndentation(`
+    Page available at http://localhost:<port>/
+    No errors found 💎
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
+  `),
+  )
+})
+
+test('cli run with --headless captures a table screenshot by title', async ({server}) => {
+  server.mockFile(
+    '/index.md',
+    `
+    # Table Screenshot
+    \`\`\`sql table_data
+    from flights select carrier, count() as total_flights group by 1 order by carrier limit 5
+    \`\`\`
+    <Table data="table_data" title="Carrier Totals" rows=5 />
+  `,
+  )
+
+  server.url()
+  await runMdFile({mdArg: 'index.md', headless: true, chart: 'Carrier Totals', log})
+  expect(outputLines()).toEqual(
+    trimIndentation(`
+    Page available at http://localhost:<port>/
+    No errors found 💎
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
+  `),
+  )
+})
+
 test('cli run with --input applies inputs to a full page run', async ({server, page}) => {
   let queryBodies: any[] = []
   server.mockFile(
@@ -493,6 +539,24 @@ test('cli list prints chart component IDs', async ({server, page}) => {
   expect(outputLines()).toEqual('BarChart (data="chart_data" x="carrier" y="total_distance")')
 })
 
+test('cli list prints table component IDs', async ({server, page}) => {
+  server.mockFile(
+    '/index.md',
+    `
+    # Query List
+    \`\`\`sql table_data
+    from flights select carrier, count() as total_flights group by 1 order by carrier limit 5
+    \`\`\`
+    <Table data="table_data" title="Carrier Totals" rows=5 />
+  `,
+  )
+
+  await page.goto(server.url())
+  let result = await listMdFileQueries('index.md', undefined, log)
+  expect(result).toBe(true)
+  expect(outputLines()).toEqual('DataTable (data="table_data")')
+})
+
 test('cli run with --chart exports chart data as csv', async ({server, page}) => {
   let csv = ''
   let originalLog = console.log
@@ -524,6 +588,37 @@ test('cli run with --chart exports chart data as csv', async ({server, page}) =>
   }
 })
 
+test('cli run with --chart exports table data as csv', async ({server, page}) => {
+  let csv = ''
+  let originalLog = console.log
+  server.mockFile(
+    '/index.md',
+    `
+    # Table CSV
+    \`\`\`sql table_data
+    from flights where carrier in ('AA', 'DL') select carrier, count() as total_flights group by 1 order by carrier
+    \`\`\`
+    <Table data="table_data" title="Carrier Totals" />
+  `,
+  )
+
+  try {
+    console.log = (...args: any[]) => {
+      csv += args.map(arg => String(arg)).join(' ') + '\n'
+    }
+
+    await page.goto(server.url())
+    let result = await runMdFile({mdArg: 'index.md', chart: 'Carrier Totals', format: 'csv', log})
+    expect(result).toBe(true)
+    expect(csv.startsWith('carrier,total_flights\n')).toBe(true)
+    expect(csv).toContain('AA,')
+    expect(csv).toContain('DL,')
+    expect(outputLines()).toEqual('')
+  } finally {
+    console.log = originalLog
+  }
+})
+
 test('cli run with --chart captures a chart screenshot by component ID', async ({server, page}) => {
   server.mockFile(
     '/index.md',
@@ -538,6 +633,29 @@ test('cli run with --chart captures a chart screenshot by component ID', async (
 
   await page.goto(server.url())
   await runMdFile({mdArg: 'index.md', chart: 'BarChart (data="chart_data" x="carrier" y="total_distance")', log})
+  expect(outputLines()).toEqual(
+    trimIndentation(`
+    Page available at http://localhost:<port>/
+    No errors found 💎
+    Screenshot saved to <project>/node_modules/.graphene/screenshots/<timestamp>.png
+  `),
+  )
+})
+
+test('cli run with --chart captures a table screenshot by component ID', async ({server, page}) => {
+  server.mockFile(
+    '/index.md',
+    `
+    # Table Screenshot
+    \`\`\`sql table_data
+    from flights select carrier, count() as total_flights group by 1 order by carrier limit 5
+    \`\`\`
+    <Table data="table_data" title="Carrier Totals" rows=5 />
+  `,
+  )
+
+  await page.goto(server.url())
+  await runMdFile({mdArg: 'index.md', chart: 'DataTable (data="table_data")', log})
   expect(outputLines()).toEqual(
     trimIndentation(`
     Page available at http://localhost:<port>/


### PR DESCRIPTION
This PR updates `graphene run -c` to support screenshotting table components as well as charts, as there are situations (e.g. `contentType=colorscale`) where the agent needs to visually iterate on a table.