### PR TITLE
don't do screenshot snapshots for ecomm example

### DIFF
--- a/ui/tests/run-examples.test.ts
+++ b/ui/tests/run-examples.test.ts
@@ -79,7 +79,7 @@ let testsDir = path.dirname(fileURLToPath(import.meta.url))
 let coreDir = path.resolve(testsDir, '../..')
 let examplesDir = path.join(coreDir, 'examples')
 
-async function runExample(exampleName: string, page: Page) {
+async function runExample(exampleName: string, page: Page, {suppressScreenshot = false}: {suppressScreenshot?: boolean} = {}) {
   let exampleDir = path.join(examplesDir, exampleName)
   let markdownFiles = listMarkdownFiles(exampleDir)
   expect(markdownFiles.length).toBeGreaterThan(0)
@@ -97,7 +97,9 @@ async function runExample(exampleName: string, page: Page) {
       console.log(`[run-examples] running ${exampleName}/${mdPath}`)
       await page.goto(`http://localhost:${port}${toPageUrl(mdPath)}`)
       await waitForGrapheneLoad(page, 120_000)
-      await expect(page).screenshot(`example-${exampleName}-${mdPath.replace(/\.md$/, '').replace(/[^a-z0-9]+/gi, '-')}`)
+      if (!suppressScreenshot) {
+        await expect(page).screenshot(`example-${exampleName}-${mdPath.replace(/\.md$/, '').replace(/[^a-z0-9]+/gi, '-')}`)
+      }
 
       let runResult = await runCli(['run', mdPath], exampleDir, childEnv)
       expectSuccess(`run ${exampleName}/${mdPath}`, runResult)
@@ -121,7 +123,7 @@ test.skipIf(!process.env.SLOW_TEST || true)('graphene run succeeds for clickhous
 })
 
 test.skipIf(!process.env.SLOW_TEST)('graphene run succeeds for ecomm example', {timeout: 180_000}, async ({page}) => {
-  await runExample('ecomm', page)
+  await runExample('ecomm', page, {suppressScreenshot: true /* dataset is continuously updated */})
 })
 
 test.skipIf(!process.env.SLOW_TEST)('graphene run succeeds for flights example', {timeout: 180_000}, async ({page}) => {

--- a/ui/tests/snapshots/run-examples.test.ts/example-ecomm-index.png
+++ b/ui/tests/snapshots/run-examples.test.ts/example-ecomm-index.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:114115e865e04cd21d944bb6976baad8551cf5a75c1f880b18b0d78b5ea9faea
-size 59058
+oid sha256:7325fd40cd9b290512f78cbdb49b0f7e601f9f29b408d44af6575adad880dee4
+size 57776

--- a/ui/tests/snapshots/run-examples.test.ts/example-ecomm-index.png
+++ b/ui/tests/snapshots/run-examples.test.ts/example-ecomm-index.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7325fd40cd9b290512f78cbdb49b0f7e601f9f29b408d44af6575adad880dee4
-size 57776

--- a/ui/tests/snapshots/run-examples.test.ts/example-ecomm-product-explorer.png
+++ b/ui/tests/snapshots/run-examples.test.ts/example-ecomm-product-explorer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09e784bfff7a3d07675e4bbe07bf37a3ce4ccf60494219130a7a138c0ee936b9
-size 77558
+oid sha256:f81dbfa9423512ac96cb5beedc87066fdf736c0c94fa5fb6e5d1138d6c08ea78
+size 78679

--- a/ui/tests/snapshots/run-examples.test.ts/example-ecomm-product-explorer.png
+++ b/ui/tests/snapshots/run-examples.test.ts/example-ecomm-product-explorer.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f81dbfa9423512ac96cb5beedc87066fdf736c0c94fa5fb6e5d1138d6c08ea78
-size 78679


### PR DESCRIPTION
~I'm not sure what's going on here but the screenshot snapshots for the ecomm example, added in #476, are consistently failing for me in CI.~ The ecomm dataset is continuously updated, so with how it is currently configured the graphs are expected to drift day-by-day as more data comes in.