### PR TITLE
fix test-examples flights flake

### DIFF
--- a/examples/flights/index.md
+++ b/examples/flights/index.md
@@ -40,6 +40,7 @@ select
     when 4 then 'Thu' when 5 then 'Fri' when 6 then 'Sat'
   end as day_label,
   round(avg(dep_delay), 1) as avg_delay
+order by day_label, hour_label
 ```
 
 ```sql airport_scatter

--- a/ui/tests/snapshots/run-examples.test.ts/example-flights-index.png
+++ b/ui/tests/snapshots/run-examples.test.ts/example-flights-index.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7259b032a35cdfce692dba5dd90a5718008461eb91b7a2da729fadb4bcb1f404
-size 58501
+oid sha256:bc13a11fe30ec6e3381e9233c4f83f10ce41952977a2e6bcf3ba6d1c8bc1f00e
+size 58533


### PR DESCRIPTION
The `test-examples` CI check has been flaking a lot in CI, and the cause appears to be non-determinism on the delay_heatmap order. Ran 10x locally with the change without a flake. The ordering issue is slightly subtle: The order doesn't determine the layout within the heatmap, it determines the _draw_ order, and cells have a slight overlap so the draw order can change colors on the edges of cells