### PR TITLE
Fix explicit bar chart sorting with splitBy

### DIFF
--- a/ui/component-utilities/dataShaping.ts
+++ b/ui/component-utilities/dataShaping.ts
@@ -122,7 +122,7 @@ export function applySorting(config: NormalConfig, rows: Record<string, any>[], 
   let categoryField = [...config.xAxis, ...config.yAxis].find(axis => axis?.type === 'category')?.field?.name
   if (explicitSort) {
     if (!categoryField) throw new Error('sort is only supported when the chart has a categorical axis')
-    sortCategoriesByField(rows, categoryField, explicitSort.field, explicitSort.direction, fields)
+    sortCategoriesByField(rows, categoryField, explicitSort.field, explicitSort.direction, fields, series)
     return
   }
 
@@ -268,12 +268,12 @@ function sortCategoriesByValue(rows: Record<string, any>[], categoryField: strin
   sortRowsByCategoryOrder(rows, categoryField, orderedCategoryKeys)
 }
 
-// Sort categories by a specific field.
-// Numeric fields are summed per category; non-numeric fields use first value seen.
-function sortCategoriesByField(rows: Record<string, any>[], categoryField: string, sortField: string, direction: 'asc' | 'desc', fields: Field[]) {
+// Sort categories by a specific field. Sorting by the value axis aggregates per category;
+// sorting by any other field uses the category's sort key directly.
+function sortCategoriesByField(rows: Record<string, any>[], categoryField: string, sortField: string, direction: 'asc' | 'desc', fields: Field[], series: SeriesWithGroupingHint[]) {
   let sortType = inferFieldType(fields, sortField)
 
-  if (sortType === 'number') {
+  if (sortType === 'number' && isValueAxisSort(categoryField, sortField, series)) {
     sortCategoriesByValue(rows, categoryField, row => Number(row?.[sortField]) || 0, direction)
     return
   }
@@ -289,6 +289,12 @@ function sortCategoriesByField(rows: Record<string, any>[], categoryField: strin
   orderedCategoryKeys.sort((left, right) => {
     let leftValue = sortValueByCategory.get(left)
     let rightValue = sortValueByCategory.get(right)
+
+    if (sortType === 'number') {
+      let leftNumber = sortableValue(leftValue, 'number')
+      let rightNumber = sortableValue(rightValue, 'number')
+      return direction === 'asc' ? leftNumber - rightNumber : rightNumber - leftNumber
+    }
 
     if (sortType === 'date') {
       let leftDate = sortableValue(leftValue, 'date')
@@ -400,6 +406,14 @@ function isHorizontalBar(config: NormalConfig) {
   let yAxis = config.yAxis[0]
   let hasBarSeries = config.series.some(series => series?.type === 'bar')
   return Boolean(hasBarSeries && xAxis?.type === 'value' && yAxis?.type === 'category')
+}
+
+function isValueAxisSort(categoryField: string, sortField: string, series: SeriesWithGroupingHint[]) {
+  return series.some(entry => {
+    let x = getSeriesXField(entry)
+    let y = getSeriesYField(entry)
+    return (x === categoryField && y === sortField) || (y === categoryField && x === sortField)
+  })
 }
 
 function getSeriesXField(series?: SeriesWithGroupingHint) {

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-explicit-numeric-category-sort-sparse-split.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-explicit-numeric-category-sort-sparse-split.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd0f01408f1582a5cd07c8297bd68511339be3329e4c0ee63a10cdc6f1038849
+size 10042

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -608,6 +608,34 @@ test('bar chart explicit sort orders categories by another column', async ({moun
   await expect(chart.el).screenshot('bar-chart-explicit-sort-column')
 })
 
+test('bar chart explicit numeric category sort handles sparse split data', async ({mount, chart}) => {
+  let rows = [
+    {day_bucket: '4', bucket_order: 4, transition: 'Phase I > Phase II', deal_count: 3},
+    {day_bucket: '4', bucket_order: 4, transition: 'Phase II > Phase III', deal_count: 2},
+    {day_bucket: '4', bucket_order: 4, transition: 'Phase III > Closed', deal_count: 1},
+    {day_bucket: '10', bucket_order: 10, transition: 'Phase I > Phase II', deal_count: 3},
+    {day_bucket: '20+', bucket_order: 21, transition: 'Phase I > Phase II', deal_count: 1},
+  ]
+
+  let fields = [
+    {name: 'day_bucket', type: scalarType('string')},
+    {name: 'bucket_order', type: scalarType('number')},
+    {name: 'transition', type: scalarType('string')},
+    {name: 'deal_count', type: scalarType('number')},
+  ]
+
+  await mount('components/BarChart.svelte', {
+    data: {rows, fields},
+    x: 'day_bucket',
+    y: 'deal_count',
+    splitBy: 'transition',
+    arrange: 'group',
+    sort: 'bucket_order asc',
+    title: 'Sparse Explicit Category Sort',
+  })
+  await expect(chart.el).screenshot('bar-chart-explicit-numeric-category-sort-sparse-split')
+})
+
 test('line chart sorts time axis, and shows gap for missing points', async ({mount, chart}) => {
   await mount('components/LineChart.svelte', {data: sparseGroupedMonthRows(), x: 'month', y: 'value', splitBy: 'metric', title: 'Line Missing + Sort'})
   await expect(chart.el).screenshot('line-chart-grouped-missing-sort')


### PR DESCRIPTION
When a bar chart specifies sort, the x-axis should be ordered by that column. For numeric sort columns, we were using the same helper that sorts by bar values, which sums the sort field across rows for each x-axis category.

That breaks charts using splitBy because each x-axis category can have multiple rows. For example, bucket_order 4 repeated across three transition rows became 12, so bucket "4" sorted after bucket "10".

Only aggregate numeric sort fields when the sort column is the encoded value axis. Otherwise, sort each x-axis category by the provided sort column value.

Add a viz regression test for splitBy bar sorting.