### PR TITLE
Add precision metadata

### DIFF
--- a/docs/references/gsql.md
+++ b/docs/references/gsql.md
@@ -153,6 +153,7 @@ from othertable
 | `#pct` | no | Value is already 0–100; rendered as `value%` (e.g. `42` → `42%`) |
 | `#currency=<code>` | no | Adds currency symbol and compacts to K/M/B. Accepts ISO 4217 currency codes like `USD`, `EUR`, and `JPY` |
 | `#unit=<unit>` | no | Appends the provided value to the end of labels in visualizations (e.g. `unit=minutes` appends "minutes", or "(minutes)" on axes). Any non-empty value is accepted |
+| `#precision=<digits>` | no | Sets the number of decimal places to display for numbers. Can also be 0 to make `1M` become `$1,102,148`) |
 | `#timeGrain=<grain>` | yes (from `date_trunc`, `date_bin`, casts) | Controls time axis label format. Values: `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, `second` |
 | `#timeOrdinal=<ordinal>` | yes (from `extract`) | Treats extracted time values as ordered positions. Values: `hour_of_day`, `day_of_month`, `day_of_year`, `week_of_year`, `month_of_year`, `quarter_of_year`, `dow_0s` (0=Sun), `dow_1s` (1=Sun), `dow_1m` (1=Mon) |
 | `#description=<text>` | no | Description text for a table or field. `--` comments are also collected as descriptions |

--- a/lang/index.d.ts
+++ b/lang/index.d.ts
@@ -24,6 +24,7 @@ export type FieldMeta = {
   pct?: true // 0 to 100 value
   currency?: string // ISO 4217 currency code
   unit?: string // physical unit label
+  precision?: string // decimal places to display
   timeGrain?: TimeGrain // resolution when the field is a date or timestamp
   timeOrdinal?: TimeOrdinal // if the value represents something special like day_of_week, week_of_year, etc
   defaultName?: string // preferred output column name when an expression is selected without an alias

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -918,23 +918,25 @@ describe('lang', () => {
         amount int -- revenue #currency=ZZZ
         dow int #timeOrdinal=dow
         weight int #unit=parsecs
+        margin number #precision=1.5
       )
     `).toHaveDiagnostic(/Invalid value "mont" for "#timeGrain"/)
     expect(getDiagnostics().some(d => /Invalid value "ZZZ" for "#currency"/.test(d.message))).toBe(true)
     expect(getDiagnostics().some(d => /Invalid value "dow" for "#timeOrdinal"/.test(d.message))).toBe(true)
+    expect(getDiagnostics().some(d => /Invalid value "1.5" for "#precision"/.test(d.message))).toBe(true)
   })
 
   it('accepts ISO currency codes and arbitrary unit metadata values', () => {
     analyze(`
       table foo (
-        revenue int #currency=eur
+        revenue int #currency=eur #precision=0
         distance int #unit=lightyears
       )
     `)
     expect(getDiagnostics().filter(d => d.severity === 'error')).toEqual([])
 
     let table = getTable('foo')!
-    expect(table.columns.find(c => c.name === 'revenue')!.metadata).toMatchObject({currency: 'eur'})
+    expect(table.columns.find(c => c.name === 'revenue')!.metadata).toMatchObject({currency: 'eur', precision: '0'})
     expect(table.columns.find(c => c.name === 'distance')!.metadata).toMatchObject({unit: 'lightyears'})
   })
 

--- a/lang/metadata.ts
+++ b/lang/metadata.ts
@@ -30,6 +30,7 @@ let metadataKeyRules = {
   pii: {kind: 'flag'},
   currency: {kind: 'currency'},
   unit: {kind: 'string'},
+  precision: {kind: 'integer'},
   timeGrain: {kind: 'enum', values: ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second']},
   timeOrdinal: {kind: 'enum', values: ['hour_of_day', 'day_of_month', 'day_of_year', 'week_of_year', 'month_of_year', 'quarter_of_year', 'dow_0s', 'dow_1s', 'dow_1m']},
   description: {kind: 'string'},
@@ -126,6 +127,17 @@ export function validateMetadataEntries(entries: MetadataEntry[]): MetadataDiagn
       if (isoCurrencyCodes.has(entry.value.toLowerCase())) continue
       diagnostics.push({
         message: `Invalid value "${entry.value}" for "#currency". Expected an ISO 4217 currency code.`,
+        from: entry.valueFrom ?? entry.from,
+        to: entry.valueTo ?? entry.to,
+      })
+      continue
+    }
+
+    if (rule.kind == 'integer') {
+      let value = Number(entry.value)
+      if (entry.hasValue && Number.isInteger(value) && value >= 0 && value <= 20) continue
+      diagnostics.push({
+        message: `Invalid value "${entry.value}" for "#${entry.key}". Expected an integer from 0 to 20.`,
         from: entry.valueFrom ?? entry.from,
         to: entry.valueTo ?? entry.to,
       })

--- a/ui/component-utilities/format.ts
+++ b/ui/component-utilities/format.ts
@@ -38,20 +38,22 @@ export function formatSingleValue(value: any, field?: Field, options: ValueForma
   let amount = Number(value)
   if (!Number.isFinite(amount)) return String(value ?? '')
 
+  let precision = getPrecision(field)
   if (field?.metadata?.timeGrain === 'year' && Number.isInteger(amount)) return String(amount)
-  if (field?.metadata?.ratio) return `${percent.format(amount * 100)}%`
-  if (field?.metadata?.pct) return `${percent.format(amount)}%`
+  if (field?.metadata?.ratio) return `${formatFixed(amount * 100, precision ?? 0)}%`
+  if (field?.metadata?.pct) return `${formatFixed(amount, precision ?? 0)}%`
 
   let currency = field?.metadata?.currency?.toUpperCase()
   if (currency && supportedCurrencyCodes.has(currency)) {
     let sign = amount < 0 ? '-' : ''
-    let formatted = currencyCompact.format(Math.abs(amount)).replace('K', 'k').replace('M', 'm').replace('B', 'b')
+    let formatted = precision == null ? currencyCompact.format(Math.abs(amount)).replace('K', 'k').replace('M', 'm').replace('B', 'b') : formatFixed(Math.abs(amount), precision)
     return `${sign}${formatCurrencySymbol(currency)}${formatted}`
   }
 
-  if (amount === 0) return addUnit('0', field, options)
+  if (amount === 0) return addUnit(formatFixed(0, precision), field, options)
   let sign = amount < 0 ? '-' : ''
   let absolute = Math.abs(amount)
+  if (precision != null) return addUnit(`${sign}${formatFixed(absolute, precision)}`, field, options)
   let formatted = ''
 
   if (absolute >= 1e12) formatted = `${compactValue(absolute / 1e12)}T`
@@ -71,6 +73,18 @@ export function formatSingleValue(value: any, field?: Field, options: ValueForma
 function formatCurrencySymbol(currency: string) {
   let parts = new Intl.NumberFormat('en-US', {style: 'currency', currency, currencyDisplay: 'symbol', maximumFractionDigits: 0}).formatToParts(0)
   return parts.find(part => part.type === 'currency')?.value || currency
+}
+
+function getPrecision(field?: Field) {
+  let raw = field?.metadata?.precision
+  if (raw == null) return undefined
+  let precision = Number(raw)
+  return Number.isInteger(precision) && precision >= 0 && precision <= 20 ? precision : undefined
+}
+
+function formatFixed(value: number, precision?: number) {
+  if (precision == null) return percent.format(value)
+  return new Intl.NumberFormat('en-US', {minimumFractionDigits: precision, maximumFractionDigits: precision}).format(value)
 }
 
 function addUnit(value: string, field: Field | undefined, options: ValueFormatterOptions) {

--- a/ui/tests/bigValue.test.ts
+++ b/ui/tests/bigValue.test.ts
@@ -24,6 +24,54 @@ test('big value percent formatting', async ({mount, sharedPage}) => {
   await expect(sharedPage.locator('#component-test')).screenshot('big-value-percent')
 })
 
+test('big value precision disables compact currency formatting', async ({mount, sharedPage}) => {
+  await mount('components/BigValue.svelte', {
+    data: preciseCurrencyData(),
+    value: 'revenue',
+    title: 'Revenue',
+  })
+
+  await expect(sharedPage.getByText('Revenue')).toBeVisible()
+  await expect(sharedPage.getByText('$1,102,148')).toBeVisible()
+  await expect(sharedPage.locator('#component-test')).screenshot('big-value-currency-precision')
+})
+
+test('big value without precision uses compact currency formatting', async ({mount, sharedPage}) => {
+  await mount('components/BigValue.svelte', {
+    data: compactCurrencyData(),
+    value: 'revenue',
+    title: 'Revenue',
+  })
+
+  await expect(sharedPage.getByText('Revenue')).toBeVisible()
+  await expect(sharedPage.getByText('$1.1m')).toBeVisible()
+  await expect(sharedPage.locator('#component-test')).screenshot('big-value-currency-without-precision')
+})
+
+test('big value precision controls percentage decimals', async ({mount, sharedPage}) => {
+  await mount('components/BigValue.svelte', {
+    data: precisePercentData(),
+    value: 'win_pct',
+    title: 'Win Rate',
+  })
+
+  await expect(sharedPage.getByText('Win Rate')).toBeVisible()
+  await expect(sharedPage.getByText('12.75%')).toBeVisible()
+  await expect(sharedPage.locator('#component-test')).screenshot('big-value-percent-precision')
+})
+
+test('big value without precision rounds percentages', async ({mount, sharedPage}) => {
+  await mount('components/BigValue.svelte', {
+    data: roundedPercentData(),
+    value: 'win_pct',
+    title: 'Win Rate',
+  })
+
+  await expect(sharedPage.getByText('Win Rate')).toBeVisible()
+  await expect(sharedPage.getByText('13%')).toBeVisible()
+  await expect(sharedPage.locator('#component-test')).screenshot('big-value-percent-without-precision')
+})
+
 test('big value can render a non-default row', async ({mount, sharedPage}) => {
   await mount('components/BigValue.svelte', {
     data: rowData(),
@@ -53,6 +101,30 @@ test('big value null renders em dash', async ({mount, sharedPage}) => {
 function percentData() {
   let rows = [{ratio: 0.314}] as any
   let fields = [{name: 'ratio', type: 'number', metadata: {ratio: true}}] as any
+  return {rows, fields}
+}
+
+function preciseCurrencyData() {
+  let rows = [{revenue: 1102148}] as any
+  let fields = [{name: 'revenue', type: 'number', metadata: {currency: 'USD', precision: '0'}}] as any
+  return {rows, fields}
+}
+
+function compactCurrencyData() {
+  let rows = [{revenue: 1102148}] as any
+  let fields = [{name: 'revenue', type: 'number', metadata: {currency: 'USD'}}] as any
+  return {rows, fields}
+}
+
+function precisePercentData() {
+  let rows = [{win_pct: 12.75}] as any
+  let fields = [{name: 'win_pct', type: 'number', metadata: {pct: true, precision: '2'}}] as any
+  return {rows, fields}
+}
+
+function roundedPercentData() {
+  let rows = [{win_pct: 12.75}] as any
+  let fields = [{name: 'win_pct', type: 'number', metadata: {pct: true}}] as any
   return {rows, fields}
 }
 

--- a/ui/tests/snapshots/bigValue.test.ts/big-value-currency-precision.png
+++ b/ui/tests/snapshots/bigValue.test.ts/big-value-currency-precision.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fee7fd9827e7e4b356575ade0f1d994d43bd334728655f6d87bdad943cf0f17
+size 3847

--- a/ui/tests/snapshots/bigValue.test.ts/big-value-currency-without-precision.png
+++ b/ui/tests/snapshots/bigValue.test.ts/big-value-currency-without-precision.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0843f92ca487b93b4629cd87ed2dd735a4c95925085cedcb7385b2fc8583305
+size 2173

--- a/ui/tests/snapshots/bigValue.test.ts/big-value-percent-precision.png
+++ b/ui/tests/snapshots/bigValue.test.ts/big-value-percent-precision.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:816cb28d38e0d5c70b727100d2e35ff5a62a2f8c8b7d4618daa42f1e517f8dfb
+size 3273

--- a/ui/tests/snapshots/bigValue.test.ts/big-value-percent-without-precision.png
+++ b/ui/tests/snapshots/bigValue.test.ts/big-value-percent-without-precision.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01cd0f51a2b014adb427643bc4aba592a4d8630a4bbe62bf7b6352aa6b910ab4
+size 2722

--- a/ui/tests/snapshots/viz.test.ts/line-chart-tooltip-percent-precision.png
+++ b/ui/tests/snapshots/viz.test.ts/line-chart-tooltip-percent-precision.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36cacec6524acfeedd58f3441bfbc6c3e8fa65688c811baf00caa39598783207
+size 10948

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -348,6 +348,29 @@ test('line chart uses ratio metadata for axis and tooltip percentage formatting'
   await expect(chart.el).screenshot('line-chart-ratio-metadata-percent-axis')
 })
 
+test('line chart respects precision metadata in tooltips', async ({mount, sharedPage, chart}) => {
+  let rows = [
+    {month: 'Jan', win_pct: 12.75},
+    {month: 'Feb', win_pct: 13.25},
+  ]
+  let fields = [
+    {name: 'month', type: scalarType('string')},
+    {name: 'win_pct', type: scalarType('number'), metadata: {pct: true, precision: '2'}},
+  ]
+
+  await mount('components/LineChart.svelte', {data: {rows, fields}, x: 'month', y: 'win_pct', title: 'Win Rate'})
+  let tooltip = await sharedPage.evaluate(() => {
+    let domNode = document.querySelector('#component-test .echarts') as HTMLElement
+    let option = window.$GRAPHENE.getChart(domNode).getOption()
+    let series = Array.isArray(option.series) ? option.series[0] : option.series
+    return series.tooltip.valueFormatter(12.75)
+  })
+
+  expect(tooltip).toBe('12.75%')
+  await chart.chartDispatchAction({type: 'showTip', seriesIndex: 0, dataIndex: 0})
+  await expect(chart.el).screenshot('line-chart-tooltip-percent-precision')
+})
+
 test('line chart uses unit metadata for axis and tooltip formatting', async ({mount, sharedPage, chart}) => {
   let rows = [
     {month: 'Jan', duration: 42},


### PR DESCRIPTION
This allows you to set the preferred precision a given column or measure will use in the ui.