### PR TITLE
Have waitForLoad track things that fail to load

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -81,11 +81,9 @@ program
         // If `run` is requesting a md page, we need to run it in a browser
         let resp = await sendToPage(cliInput.path, {params, chart: options.chart}, !!options.headless)
         printDiagnostics(resp.errors || [])
-        if (resp.errors?.length) exit(1)
+        if (resp.errors?.some(error => error.severity !== 'warn')) exit(1)
 
         if (resp.screenshot) {
-          if (resp.stillLoading) console.warn('Warning: Queries were still loading when the screenshot was taken')
-
           let screenshotDir = path.join(getGrapheneCache(config.root), 'screenshots')
           let screenshotPath = path.join(screenshotDir, `${new Date().toISOString().replace(/[:.]/g, '-')}.png`)
           let base64Data = resp.screenshot.replace(/^data:image\/png;base64,/, '')

--- a/ui/components/ECharts.svelte
+++ b/ui/components/ECharts.svelte
@@ -88,13 +88,12 @@
     if (!chart) {
       chart = init(node, 'graphene-theme', {renderer})
       chart.on('legendselectchanged', renderChart)
+      chart.on('finished', completeChartRender)
     }
 
     try {
-      window.$GRAPHENE?.renderStart?.(`chart:${chart.id}`)
       renderChart()
       chartError = null
-      window.$GRAPHENE?.renderComplete?.(`chart:${chart.id}`)
     } catch (error) {
       console.error('Chart failed to render', error)
       chartError = error instanceof Error ? error : new Error(String(error))
@@ -104,10 +103,10 @@
     }
   })
 
-  // Build a fresh enriched option each render so legend-driven stack rounding
-  // always reflects the currently visible series.
+  // Build a fresh enriched option and track it until ECharts fires finished, including legend-driven rerenders.
   function renderChart() {
     if (!chart || !loaded) return
+    window.$GRAPHENE?.renderStart?.(`chart:${chart.id}`)
 
     // clone config, since enriching mutates the config, and mutating a prop is weird
     // structuredClone doesn't like proxies, so use state.snapshot
@@ -122,9 +121,15 @@
     chart.setOption({...enriched, animation: false, animationDuration: 0, animationDurationUpdate: 0}, true)
   }
 
+  function completeChartRender() {
+    window.$GRAPHENE?.renderComplete?.(`chart:${chart.id}`)
+  }
+
   function destroyChart() {
     if (!chart) return
+    completeChartRender()
     chart.off('legendselectchanged', renderChart)
+    chart.off('finished', completeChartRender)
     chart.dispose()
     chart = null
   }

--- a/ui/internal/queryEngine.ts
+++ b/ui/internal/queryEngine.ts
@@ -223,6 +223,7 @@ export function translateData(data: any, node: QueryNode): QueryResult {
 }
 
 const isQueryLoading = () => !!queries.find(q => q.loading)
+const getLoadingQueries = () => queries.filter(q => q.loading).map(q => q.componentId || q.source || q.name || q.contents)
 
 function updatePageCacheState() {
   let timestamps = queries.map(q => q.runAt).filter(Boolean) as number[]
@@ -240,5 +241,6 @@ Object.assign(window.$GRAPHENE, {
   rerunQueries: runAll,
   refreshQueries,
   isQueryLoading,
+  getLoadingQueries,
   queryResults,
 })

--- a/ui/internal/runPage.ts
+++ b/ui/internal/runPage.ts
@@ -22,7 +22,6 @@ export interface PageRequest {
 export interface PageResponse {
   requestId?: string
   errors?: GrapheneError[]
-  stillLoading?: boolean
   screenshot?: string
   componentIds?: string[]
   data?: {
@@ -40,8 +39,9 @@ connect()
 
 // Waits for a stable page and executes the requested check, listing, or data export.
 export async function runPageRequest(request: PageRequest): Promise<PageResponse> {
-  let finished = await window.$GRAPHENE.waitForLoad(20_000)
+  let stillLoading = await window.$GRAPHENE.waitForLoad(20_000)
   let errors = getErrors()
+  errors.push(...(stillLoading || []).map(loading => ({severity: 'warn' as const, message: `Still loading when the screenshot was taken: ${loading}`})))
 
   // --chart tells us to focus on a single viz
   let componentEl = request.chart ? findVisualComponentElement(request.chart) : undefined
@@ -59,7 +59,7 @@ export async function runPageRequest(request: PageRequest): Promise<PageResponse
     .map(el => el.getAttribute('data-component-id') || '')
     .filter(componentId => componentId.trim().length > 0)
 
-  return {requestId: request.requestId, errors, stillLoading: !finished, screenshot, componentIds, data}
+  return {requestId: request.requestId, errors, screenshot, componentIds, data}
 }
 
 // Registers this tab with the local server and forwards CLI requests to runPageRequest.

--- a/ui/internal/waitForLoad.ts
+++ b/ui/internal/waitForLoad.ts
@@ -1,0 +1,48 @@
+// Shared page load tracking for local and cloud Graphene runtimes.
+// Queries report their own labels; this module owns render IDs and turns all pending work into a diagnostic-friendly list.
+
+let graphene = window.$GRAPHENE
+let nextRenderId = 0
+let pendingRenders = new Set<string>()
+
+graphene.renderStart = (id?: string | number) => {
+  let renderId = id == null ? `render:${++nextRenderId}` : String(id)
+  pendingRenders.add(renderId)
+  return renderId
+}
+
+graphene.renderComplete = (id?: string | number) => {
+  if (id == null) return
+  pendingRenders.delete(String(id))
+}
+
+// Lists app, query, and render work using labels suitable for CLI and agent warnings.
+function getStillLoading() {
+  let loading: string[] = []
+  if (graphene.appLoading) loading.push('app')
+
+  let queries = graphene.getLoadingQueries?.()
+  if (queries?.length) loading.push(...queries.map(query => `query:${query}`))
+  else if (graphene.isQueryLoading?.()) loading.push('queries')
+
+  loading.push(...pendingRenders)
+  return loading
+}
+
+// Returns null once the page is stable, or the exact work pending when the timeout expires.
+graphene.waitForLoad = async (timeout = 20_000) => {
+  let end = Date.now() + timeout
+
+  while (Date.now() < end) {
+    if (getStillLoading().length == 0) {
+      if (document.fonts?.ready) await document.fonts.ready
+      await new Promise(resolve => setTimeout(resolve, 300))
+      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+      if (getStillLoading().length == 0) return null
+    }
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+
+  let stillLoading = getStillLoading()
+  return stillLoading.length ? stillLoading : null
+}

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -175,8 +175,9 @@ export const test = base.extend<{browser: Browser; page: Page; sharedPage: Page;
           container.appendChild(el)
           window.__inst = window.$GRAPHENE.svelte.mount(window.$GRAPHENE.components[compName], {target: el, props})
 
-          // Wait for load
-          await window.$GRAPHENE?.waitForLoad?.()
+          // Wait for load and fail tests with the specific work that timed out.
+          let stillLoading = await window.$GRAPHENE?.waitForLoad?.()
+          if (stillLoading?.length) throw new Error(`Timed out waiting for Graphene: ${stillLoading.join(', ')}`)
           await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))
         },
         {compName, props: modifiedProps},
@@ -270,9 +271,9 @@ declare global {
 
 export async function waitForGrapheneLoad(page: Page, timeout = 20_000) {
   await page.waitForFunction(() => Boolean((window as any).$GRAPHENE), null, {timeout})
-  let loaded = await page.evaluate(ms => {
+  let stillLoading = await page.evaluate(ms => {
     let graphene = (window as any).$GRAPHENE
     return typeof graphene?.waitForLoad === 'function' ? graphene.waitForLoad(ms) : null
   }, timeout)
-  if (!loaded) throw new Error(`Timed out waiting for Graphene to finish loading after ${timeout}ms`)
+  if (stillLoading?.length) throw new Error(`Timed out waiting for Graphene after ${timeout}ms: ${stillLoading.join(', ')}`)
 }

--- a/ui/tests/matchers.ts
+++ b/ui/tests/matchers.ts
@@ -21,10 +21,11 @@ const extendedExpect = baseExpect.extend({
     let testFile = path.basename(testPath)
 
     // Wait for fonts, Graphene renders, and animations to settle before comparing pixels.
-    await (page as Page).evaluate(async () => {
+    let stillLoading = await (page as Page).evaluate(async () => {
       await document.fonts.ready
-      await (window as any).$GRAPHENE?.waitForLoad?.()
+      return await (window as any).$GRAPHENE?.waitForLoad?.()
     })
+    if (stillLoading?.length) throw new Error(`Timed out waiting for Graphene: ${stillLoading.join(', ')}`)
     await waitForAnimations(page as Page)
 
     let resultsDir = path.resolve(snapshotDir, '..', 'results', testFile)

--- a/ui/tests/waitForLoad.test.ts
+++ b/ui/tests/waitForLoad.test.ts
@@ -1,0 +1,26 @@
+// Tests the page-level load contract used by screenshots, CLI runs, and test fixtures.
+
+import {expect, test, waitForGrapheneLoad} from './fixtures.ts'
+
+test('waitForLoad identifies each kind of outstanding work', async ({server, page}) => {
+  server.mockFile('/index.md', '# Load tracking')
+  await page.goto(server.url() + '/')
+  await waitForGrapheneLoad(page)
+
+  let stillLoading = await page.evaluate(async () => {
+    let graphene = window.$GRAPHENE
+    let getLoadingQueries = graphene.getLoadingQueries
+    graphene.appLoading = true
+    graphene.getLoadingQueries = () => ['sales']
+    graphene.renderStart('chart:revenue')
+
+    let result = await graphene.waitForLoad(1)
+
+    graphene.appLoading = false
+    graphene.getLoadingQueries = getLoadingQueries
+    graphene.renderComplete('chart:revenue')
+    return {result, idle: await graphene.waitForLoad(0)}
+  })
+
+  expect(stillLoading).toEqual({result: ['app', 'query:sales', 'chart:revenue'], idle: null})
+})

--- a/ui/web.js
+++ b/ui/web.js
@@ -2,10 +2,9 @@ import './internal/telemetry.ts'
 import './internal/queryEngine.ts'
 import './internal/runPage.ts'
 import {getInstanceByDom} from 'echarts'
-
-import './app.css'
 import {mount, unmount} from 'svelte'
 
+import './app.css'
 import AreaChart from './components/AreaChart.svelte'
 import BarChart from './components/BarChart.svelte'
 import BigValue from './components/BigValue.svelte'
@@ -35,6 +34,7 @@ import TextInput from './components/TextInput.svelte'
 import Value from './components/Value.svelte'
 import ErrorChart from './internal/ErrorDisplay.svelte'
 import LocalApp from './internal/LocalApp.svelte'
+import './internal/waitForLoad.ts'
 
 // Having a global $GRAPHENE allows us to provide an api that pages can use without having to import and bundle a bunch of components.
 // That means that as you navigate around, we only have to a very small amount of js for the page itself, and the bulk of the container and component
@@ -43,37 +43,8 @@ import LocalApp from './internal/LocalApp.svelte'
 window.$GRAPHENE = window.$GRAPHENE || {}
 window.$GRAPHENE.appLoading = false
 
-let nextRenderId = 0
-let pendingRenders = new Set()
-
 window.$GRAPHENE.getChart = domNode => {
   return getInstanceByDom(domNode)
-}
-
-window.$GRAPHENE.renderStart = id => {
-  let renderId = id == null ? `render:${++nextRenderId}` : String(id)
-  pendingRenders.add(renderId)
-  return renderId
-}
-
-window.$GRAPHENE.renderComplete = id => {
-  if (id == null) return
-  pendingRenders.delete(String(id))
-}
-
-window.$GRAPHENE.waitForLoad = async (timeout = 20_000) => {
-  let g = window.$GRAPHENE
-  let end = Date.now() + timeout
-  while (Date.now() < end) {
-    if (!g.appLoading && !g.isQueryLoading() && pendingRenders.size == 0) {
-      if (document.fonts?.ready) await document.fonts.ready
-      await new Promise(resolve => setTimeout(resolve, 300))
-      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
-      if (!g.appLoading && !g.isQueryLoading() && pendingRenders.size == 0) return true
-    }
-    await new Promise(resolve => setTimeout(resolve, 100))
-  }
-  return false
 }
 
 window.$GRAPHENE.components = {


### PR DESCRIPTION
This lets agents see precisely what failed to load once we hit the 20s timeout.

Also fixed a regression where we weren't actually waiting on the EChart to finish before marking it as done.