### PR TITLE
Add `make-token`

### DIFF
--- a/cli/auth.test.ts
+++ b/cli/auth.test.ts
@@ -1,0 +1,36 @@
+/// <reference types="vitest/globals" />
+// Covers delegated CLI authentication, which bypasses the renewable credentials saved by `graphene login`.
+
+import {createServer} from 'node:http'
+
+import {config, normalizeConfig, setGlobalConfig} from '../lang/config.ts'
+import {authenticatedFetch} from './auth.ts'
+
+// A delegated token should work without a local login and be sent unchanged to Graphene Cloud.
+test('authenticatedFetch uses GRAPHENE_TOKEN', async () => {
+  let originalConfig = structuredClone(config)
+  let originalToken = process.env.GRAPHENE_TOKEN
+  let authorization = ''
+  let server = createServer((req, res) => {
+    authorization = req.headers.authorization || ''
+    res.end('ok')
+  })
+
+  try {
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    let address = server.address()
+    if (!address || typeof address == 'string') throw new Error('Failed to start auth test server')
+    setGlobalConfig(normalizeConfig({root: '/tmp/delegated-token-test', clickhouse: {}, cloud: `http://127.0.0.1:${address.port}`}))
+    process.env.GRAPHENE_TOKEN = 'short-lived-support-token'
+
+    let response = await authenticatedFetch('/query')
+
+    expect(await response.text()).toBe('ok')
+    expect(authorization).toBe('Bearer short-lived-support-token')
+  } finally {
+    await new Promise(resolve => server.close(resolve))
+    setGlobalConfig(originalConfig)
+    if (originalToken === undefined) delete process.env.GRAPHENE_TOKEN
+    else process.env.GRAPHENE_TOKEN = originalToken
+  }
+})

--- a/cli/auth.ts
+++ b/cli/auth.ts
@@ -166,12 +166,30 @@ async function refreshAccessToken() {
   await updateEntry(json)
 }
 
-// Makes a request to your Graphene cloud server with credentials stored from `graphene login`
+// Refreshes the saved login and returns a full-lifetime access token for short-lived delegation.
+export async function makeAccessToken(): Promise<string> {
+  await refreshAccessToken()
+  let token = (await readEntry())?.access_token
+  if (!token) throw new Error('Failed to obtain access token')
+  return token
+}
+
+// Makes an authenticated request using an explicitly delegated token or credentials from `graphene login`.
 export async function authenticatedFetch(pathOrUrl: string, init: RequestInit = {}): Promise<Response> {
+  let cloudOrigin = new URL(config.cloud!).origin
+  let url = new URL(pathOrUrl, cloudOrigin)
+  let headers = new Headers(init.headers || {})
+
+  let delegatedToken = process.env.GRAPHENE_TOKEN
+  if (delegatedToken) {
+    headers.set('authorization', `Bearer ${delegatedToken}`)
+    return fetch(url.toString(), {...init, headers})
+  }
+
   let entry = await readEntry()
   if (!entry) throw new Error('Not logged in; run `graphene login`')
 
-  // if we know the access token is no good, refresh it now
+  // If we know the access token is no good, refresh it now.
   if (!entry.access_token || entry.expires_at < Date.now()) {
     await refreshAccessToken()
     entry = await readEntry()
@@ -179,15 +197,10 @@ export async function authenticatedFetch(pathOrUrl: string, init: RequestInit = 
   let token = entry?.access_token
   if (!token) throw new Error('Failed to obtain access token')
 
-  // make a request with the authorization header set
-  let cloudOrigin = new URL(config.cloud!).origin
-  let url = new URL(pathOrUrl, cloudOrigin)
-  let headers = new Headers(init.headers || {})
   headers.set('authorization', `Bearer ${token}`)
-
   let res = await fetch(url.toString(), {...init, headers})
 
-  // if the request failed, try refreshing our access token
+  // If the request failed, try refreshing our saved access token.
   if (res.status === 401 || res.status === 403) {
     await refreshAccessToken()
     token = (await readEntry())?.access_token

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -10,7 +10,7 @@ import {config, loadConfig, setGlobalConfig} from '../lang/config.ts'
 import {analyzeWorkspace, getFile, loadWorkspace, toSql, type Query} from '../lang/core.ts'
 import {rowsToCsv} from '../lang/csv.ts'
 import {parseWarehouseFieldType, type AnalysisResult} from '../lang/types.ts'
-import {loginPkce} from './auth.ts'
+import {loginPkce, makeAccessToken} from './auth.ts'
 import {getGrapheneCache, runServeInBackground, stopGrapheneIfRunning} from './background.ts'
 import {check} from './check.ts'
 import {getConnection, runQuery} from './connections/index.ts'
@@ -222,6 +222,14 @@ program
       return exit(res ? 0 : 1) // if we started the server in the background, just returning won't actually exit the process.
     }),
   )
+
+program
+  .command('make-token')
+  .description('Print a fresh short-lived Graphene Cloud access token')
+  .action(async () => {
+    if (!config.cloud) throw new Error('No Graphene Cloud URL is configured for this project')
+    console.log(await makeAccessToken())
+  })
 
 program
   .command('login')


### PR DESCRIPTION
Generates a short-lived access token to the graphene cloud instance you're logged in to.