### PR TITLE
Catch page render errors and display them nicely

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -279,6 +279,7 @@ async function readInput(arg: string | undefined): Promise<CliInput> {
   }
 
   let absolutePath = [path.resolve(process.cwd(), arg), path.resolve(config.root, arg)].find(p => fs.existsSync(p))
+  if (!absolutePath && arg.endsWith('.md')) throw new Error(`Couldn't find ${arg}`)
   if (!absolutePath) return {kind: 'query', contents: arg}
   return {kind: 'file', path: path.relative(config.root, absolutePath), contents: await fs.promises.readFile(absolutePath, 'utf-8')}
 }

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -278,8 +278,10 @@ function updateWorkspacePlugin(telemetry?: CliTelemetry) {
     resolveId(id: string) {
       if (id == 'virtual:nav') return '\0virtual:nav'
     },
-    load(id: string) {
+    async load(id: string) {
       if (id != '\0virtual:nav') return
+      // LocalApp uses this list to distinguish missing pages from broken ones, so never serve a partial startup scan.
+      await workspaceLoadPromise
 
       // in tests, inject mock files into the nav.
       // we do this on `load` as each test doesn't always refresh the workspace

--- a/ui/internal/LocalApp.svelte
+++ b/ui/internal/LocalApp.svelte
@@ -47,7 +47,14 @@
   // The md file is dynamically imported, so even if there's a compile error, we'll still load LocalApp and can show the user the issue
   let Page = $state<any>(null)
   let pageMeta = $state<any>({})
+  let runtimeError = $state<GrapheneError | null>(null)
   let blankForTests = $state(pathName == '__ct')
+
+  // Convert errors thrown while creating the page component into the same useful display as compilation failures.
+  function handlePageError(error: Error) {
+    runtimeError = {message: error.message, file: pathName + '.md'} as GrapheneError
+    setErrorFor('compile', runtimeError)
+  }
   let fileName = pathName.split('/').at(-1) + '.md'
   let pageTitle = $derived(pageMeta.title || prettyPrintFilename(fileName))
 
@@ -107,7 +114,13 @@
     {#if pageMeta.title}
       <h1 class="page-title">{pageMeta.title}</h1>
     {/if}
-    <Page />
+    <svelte:boundary onerror={handlePageError}>
+      <Page />
+      {#snippet failed()}
+        <h1 class="page-error-heading">Error loading page</h1>
+        <ErrorDisplay error={runtimeError!} />
+      {/snippet}
+    </svelte:boundary>
   {:else if compileError}
     <h1 class="page-error-heading">Error loading page</h1>
     <ErrorDisplay error={compileError} />

--- a/ui/tests/check.test.ts
+++ b/ui/tests/check.test.ts
@@ -289,6 +289,13 @@ test('cli run with md file reports big value query errors', async ({runCli, serv
   expect(outputLines(result.stdout + result.stderr)).toContain('cannot take square root of a negative number')
 })
 
+test('cli run reports a missing markdown file', async ({runCli}) => {
+  let result = await runCli(['run', 'missing.md'], config)
+
+  expect(result.code).toBe(1)
+  expect(outputLines(result.stdout + result.stderr)).toBe("Couldn't find missing.md")
+})
+
 test('cli run with md file reports html compilation errors', async ({runCli, server, page}) => {
   expectConsoleError('Failed to load resource')
   expectConsoleError('Internal Server Error')

--- a/ui/tests/hmr.test.ts
+++ b/ui/tests/hmr.test.ts
@@ -38,6 +38,17 @@ test('load broken page, fix via HMR', async ({server, page}) => {
   await expect(page.getByRole('heading', {name: 'Now Working'})).toBeVisible({timeout: 5000})
 })
 
+test('shows an error when a page uses an unknown component', async ({server, page}) => {
+  expectConsoleError('DataTable is not defined')
+  server.mockFile('/broken.md', '# Broken\n<DataTable />')
+
+  await page.goto(server.url() + '/broken')
+  await expect(page.getByRole('heading', {name: 'Error loading page'})).toBeVisible()
+  await expect(page.getByText('DataTable is not defined')).toBeVisible()
+  await expect(page.locator('.g-error__details')).toContainText('broken.md')
+  await expect(page).screenshot('unknown-page-component')
+})
+
 test('editing unrelated md does not reload current page', async ({server, page}) => {
   server.mockFile('/index.md', '# Main Page')
   server.mockFile('/other.md', '# Other Page')
@@ -101,15 +112,11 @@ test('compile errors in another tab do not affect current page', {timeout: 30000
   await expect(otherPage.getByRole('heading', {name: 'Other Page'})).toBeVisible()
 
   await server.updateMockFile('/other.md', '# Broken Page\n{#if true}<p>oops')
-  await expect(otherPage.getByRole('heading', {name: 'Error loading page'})).toBeVisible({timeout: 10000})
   await expect(page.getByRole('heading', {name: 'Main Page'})).toBeVisible()
   await expect(page.getByRole('heading', {name: 'Error loading page'})).toHaveCount(0)
 
-  let failingPage = await browser.newPage()
-  await failingPage.goto(server.url() + '/other', {waitUntil: 'domcontentloaded'})
-  await expect(failingPage.getByRole('heading', {name: 'Error loading page'})).toBeVisible({timeout: 10000})
-  await expect(failingPage).screenshot('hmr-other-tab-compile-error')
+  await expect(otherPage.getByRole('heading', {name: 'Error loading page'})).toBeVisible({timeout: 10000})
+  await expect(otherPage).screenshot('hmr-other-tab-compile-error')
 
-  await failingPage.close()
   await otherPage.close()
 })

--- a/ui/tests/snapshots/hmr.test.ts/unknown-page-component.png
+++ b/ui/tests/snapshots/hmr.test.ts/unknown-page-component.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:297b4e5fac88665861a5f0a2f3f11b7cae2caa3e4f6f8dd0f15fb937a96254a4
+size 15764


### PR DESCRIPTION
We already do this for individual charts, but if the page itself has a problem (like a non-existent component) we need to show that.