### PR TITLE
Reduce successful test output

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,8 +10,10 @@ export default defineConfig({
     testTimeout: process.env.GRAPHENE_DEBUG ? 0 : 10_000,
     maxWorkers: process.env.CI ? 1 : 4, // as this gets higher, the first test in each worker takes longer until it exceeds the timeout
     environment: 'node',
-    reporters: ['default', 'json'],
+    reporters: ['dot', 'json'],
     outputFile: 'node_modules/.testResults.json',
+    silent: 'passed-only',
+    hideSkippedTests: true,
     slowTestThreshold: 5_000,
     onConsoleLog(log) {
       // silence some expected logs that aren't helpful in tests


### PR DESCRIPTION
Use Vitest's dot reporter and suppress console logs from passing tests.