### PR TITLE
Better handling for invalid defaults

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -173,7 +173,9 @@ select * from orders where status = $status
 ```
 ````
 
-For `multiple=true`, the input produces a list; filter with `where status in ($status)`. Static options can be nested inside the dropdown as `<DropdownOption value="complete" valueLabel="Complete" />`; `value` is required and `valueLabel` defaults to it.
+For `multiple=true`, the input produces a list; filter with `where status in ($status)`. Multiple defaults must be passed as an array, not a comma-separated string: `<Dropdown name=status multiple=true defaultValue={['Complete', 'Pending']} />`.
+
+Static options can be nested inside the dropdown as `<DropdownOption value="complete" valueLabel="Complete" />`; `value` is required and `valueLabel` defaults to it.
 
 ### `<TextInput>`
 Collects freeform text. `name` is required; optional attributes are `title`, `placeholder` (default `"Type to search"`), and `description`.

--- a/examples/flights/pages/dropdown_defaults_test.md
+++ b/examples/flights/pages/dropdown_defaults_test.md
@@ -1,0 +1,56 @@
+---
+title: Dropdown Defaults Test
+layout: dashboard
+---
+
+```gsql test_carrier_options
+from flights select carrier as code group by 1 order by 1
+```
+
+```gsql test_origin_options
+from flights where carrier = $carrier select origin as code group by 1 order by 1
+```
+
+```gsql test_destination_options
+from flights
+where carrier = $carrier and origin = $origin
+select destination as code group by 1 order by 1
+```
+
+<Row>
+  <Dropdown title="Carrier" name="carrier" data="test_carrier_options" value="code" defaultValue="WN" />
+  <Dropdown title="Origin" name="origin" data="test_origin_options" value="code" defaultValue="PHX" />
+  <Dropdown title="Invalid comma default" name="excluded_invalid" data="test_destination_options" value="code" multiple=true defaultValue="LAX, LAS" />
+  <Dropdown title="Valid array default" name="excluded_valid" data="test_destination_options" value="code" multiple=true defaultValue={['LAX', 'LAS']} />
+  <Dropdown title="Year" name="year" defaultValue="2005">
+    <DropdownOption value="2004" />
+    <DropdownOption value="2005" />
+  </Dropdown>
+</Row>
+
+```gsql invalid_result
+from flights
+where carrier = $carrier
+  and origin = $origin
+  and extract(year from dep_time) = cast($year as integer)
+  and destination not in ($excluded_invalid)
+select destination, count() as flights
+order by flights desc, destination
+limit 10
+```
+
+```gsql valid_result
+from flights
+where carrier = $carrier
+  and origin = $origin
+  and extract(year from dep_time) = cast($year as integer)
+  and destination not in ($excluded_valid)
+select destination, count() as flights
+order by flights desc, destination
+limit 10
+```
+
+<Row>
+  <BarChart title="Comma string default" data="invalid_result" x="destination" y="flights" />
+  <BarChart title="Array default" data="valid_result" x="destination" y="flights" />
+</Row>

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -37,6 +37,7 @@
   }: Props & Record<string, unknown> = $props()
 
   let logger = untrack(() => componentLogger('Dropdown', {name}))
+  let defaultLogger = untrack(() => componentLogger('Dropdown defaultValue', {name}))
   untrack(() => logExtraProps(logger, 'Dropdown', extraProps))
 
   let mounted = false
@@ -132,6 +133,7 @@
         label: resolvedLabelField ? row[resolvedLabelField] : row[value],
       }))
       syncSelection(false)
+      validateDefaultValue()
     }
     if (typeof window !== 'undefined' && window.$GRAPHENE?.query) {
       window.$GRAPHENE.query(data, columns, handler)
@@ -311,6 +313,7 @@
     mounted = true
     syncSelection(false)
     setupQuery()
+    if (!data) void tick().then(validateDefaultValue)
     if (typeof document !== 'undefined') {
       document.addEventListener('pointerdown', handlePointerDown)
       window.addEventListener('resize', updateTriggerWidth)
@@ -353,6 +356,17 @@
       if (multi && selectAllDefault && !touched && !selection.length) nextSelection = opts.map(o => o.value)
     }
     setSelection(nextSelection, {fromUser, persist: true})
+  }
+
+  // Warn once the complete queried or manual option set proves an authored default is invalid.
+  function validateDefaultValue() {
+    let missing = ensureArray(defaultValue).filter(defaultItem => !valueMap.has(optionKey(defaultItem)))
+    if (!missing.length) return defaultLogger.warn(null)
+
+    let values = missing.map(item => `"${String(item)}"`).join(', ')
+    let noun = missing.length === 1 ? 'value is' : 'values are'
+    let hint = multi && typeof defaultValue === 'string' && defaultValue.includes(',') ? ' For multiple defaults, pass an array rather than a comma-separated string.' : ''
+    defaultLogger.warn(`Dropdown "${name}" default ${noun} not present in its options: ${values}.${hint}`)
   }
 
   function sameSelection(left: any[], right: any[]) {

--- a/ui/components/ECharts.svelte
+++ b/ui/components/ECharts.svelte
@@ -95,7 +95,6 @@
       renderChart()
       chartError = null
     } catch (error) {
-      console.error('Chart failed to render', error)
       chartError = error instanceof Error ? error : new Error(String(error))
       chartLogger.error(chartError, {componentId: displayId})
       window.$GRAPHENE?.renderComplete?.(`chart:${chart.id}`)

--- a/ui/internal/telemetry.ts
+++ b/ui/internal/telemetry.ts
@@ -47,8 +47,16 @@ export function componentLogger(componentName: string, identifiers: Record<strin
     id,
     error(error: unknown, ctx: Partial<GrapheneError> = {}) {
       if (!error) return componentErrors.delete(id)
-      let err = error instanceof Error ? error : new Error(String(error))
-      componentErrors.set(id, {message: err.message, stack: err.stack, componentId: id, ...ctx})
+      let message = ctx.message || (error instanceof Error ? error.message : String(error))
+      let err = error instanceof Error ? error : new Error(message)
+      console.error(`[Graphene] ${id}: ${message}`, err)
+      componentErrors.set(id, {message, stack: err.stack, componentId: id, ...ctx})
+    },
+    warn(warning: unknown, ctx: Partial<GrapheneError> = {}) {
+      if (!warning) return componentErrors.delete(id)
+      let err = warning instanceof Error ? warning : new Error(String(warning))
+      console.warn(`[Graphene] ${id}: ${err.message}`)
+      componentErrors.set(id, {message: err.message, stack: err.stack, componentId: id, severity: 'warn', ...ctx})
     },
   }
 }

--- a/ui/tests/extraProps.test.ts
+++ b/ui/tests/extraProps.test.ts
@@ -6,6 +6,11 @@ test.beforeEach(async ({sharedPage}) => {
 })
 
 test('display components report unsupported props', async ({mount, sharedPage}) => {
+  let browserErrors: string[] = []
+  sharedPage.on('console', message => {
+    if (message.type() === 'error' && message.text().startsWith('[Graphene] ')) browserErrors.push(message.text())
+  })
+
   await mount('components/Value.svelte', {data: singleDim(), column: 'value', fmt: 'usd'})
   await expectUnsupportedProp(sharedPage, 'Unsupported prop "fmt" on Value.')
 
@@ -14,6 +19,7 @@ test('display components report unsupported props', async ({mount, sharedPage}) 
 
   await mount('components/ScatterPlot.svelte', {data: singleDim(), x: 'category', y: 'value', subtitle: 'Ignored'})
   await expectUnsupportedProp(sharedPage, 'Unsupported prop "subtitle" on ScatterPlot.')
+  expect(browserErrors.some(message => message.startsWith('[Graphene] Value (column="value"): Unsupported prop "fmt" on Value.'))).toBe(true)
 })
 
 test('input components report unsupported props', async ({mount, sharedPage}) => {

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -209,6 +209,38 @@ test('dropdown defaultValue and disabled state render correctly', async ({server
   await expect(disabledTrigger).screenshot('dropdown-disabled')
 })
 
+test('dropdown validates single and multiple defaults against loaded options', async ({server, page}) => {
+  let browserWarnings: string[] = []
+  page.on('console', message => {
+    if (message.type() === 'warning' && message.text().startsWith('[Graphene] ')) browserWarnings.push(message.text())
+  })
+
+  await loadDropdownPage(
+    server,
+    page,
+    `
+    <Dropdown name="invalid_default" data="dropdown_options" value="code" label="label" title="Invalid Default" multiple=true defaultValue="AA, AS" />
+    <Dropdown name="valid_defaults" data="dropdown_options" value="code" label="label" title="Valid Defaults" multiple=true defaultValue={['AA', 'AS']} />
+  `,
+  )
+
+  await expect(page.getByRole('combobox', {name: 'Valid Defaults'})).toContainText('AA')
+  await expect(page.getByRole('combobox', {name: 'Valid Defaults'})).toContainText('AS')
+
+  await expect
+    .poll(() => page.evaluate(() => window.$GRAPHENE.getErrors().map(({message, componentId, severity}) => ({message, componentId, severity}))))
+    .toEqual([
+      {
+        message: 'Dropdown "invalid_default" default value is not present in its options: "AA, AS". For multiple defaults, pass an array rather than a comma-separated string.',
+        componentId: 'Dropdown defaultValue (name="invalid_default")',
+        severity: 'warn',
+      },
+    ])
+  expect(browserWarnings).toContain(
+    '[Graphene] Dropdown defaultValue (name="invalid_default"): Dropdown "invalid_default" default value is not present in its options: "AA, AS". For multiple defaults, pass an array rather than a comma-separated string.',
+  )
+})
+
 test('dropdown boolean-string attributes handle defaults and footer actions', async ({server, page}) => {
   await loadDropdownPage(
     server,

--- a/ui/tests/logWatcher.ts
+++ b/ui/tests/logWatcher.ts
@@ -38,6 +38,7 @@ export function trackBrowserConsole(page: Page) {
   page.on('console', msg => {
     if (msg.type() !== 'warning' && msg.type() !== 'error') return
     let text = msg.text()
+    if (text.startsWith('[Graphene] ')) return // Telemetry logs are intentional and asserted through getErrors or CLI output.
     if (isExpected(text)) return
 
     let location = msg.location()

--- a/ui/tests/snapshots/run-examples.test.ts/example-flights-pages-dropdown-defaults-test.png
+++ b/ui/tests/snapshots/run-examples.test.ts/example-flights-pages-dropdown-defaults-test.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d550c08fcb1bfcd66d9ab64e1b5cc7f85b6c477455debd435dc43de8a432daa0
+size 33981


### PR DESCRIPTION
Had a case where multi-select defaults were specified incorrectly (was just a comma-separated list instead of json).

Clarify the format in the docs, and warn whenever a default value is not found.