### PR TITLE
Support environment overrides for database connections

### DIFF
--- a/cli/connections/athena.ts
+++ b/cli/connections/athena.ts
@@ -170,8 +170,11 @@ function parseAthenaValue(value: string | undefined, type: string) {
 export function localDbOptions(): AthenaOptions {
   return {
     ...config.athena,
-    region: config.athena?.region || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION,
-    database: config.athena?.database || config.defaultNamespace,
+    region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || config.athena?.region,
+    catalog: process.env.ATHENA_CATALOG || config.athena?.catalog,
+    database: process.env.ATHENA_DATABASE || config.athena?.database || config.defaultNamespace,
+    workGroup: process.env.ATHENA_WORK_GROUP || config.athena?.workGroup,
+    outputLocation: process.env.ATHENA_OUTPUT_LOCATION || config.athena?.outputLocation,
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     sessionToken: process.env.AWS_SESSION_TOKEN,

--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -91,14 +91,17 @@ export function normalizeBigQueryRows(rows: Record<string, any>[]) {
 }
 
 export async function localDbOptions(): Promise<BigQueryOptions> {
+  let projectId = process.env.BIGQUERY_PROJECT_ID || process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || config.bigquery?.projectId
   if (process.env.GOOGLE_CREDENTIALS_CONTENT) {
     let credentials = JSON.parse(process.env.GOOGLE_CREDENTIALS_CONTENT)
-    return {projectId: credentials.project_id, credentials}
+    return {projectId: projectId || credentials.project_id, credentials}
   }
-  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-    let body = await readFile(process.env.GOOGLE_APPLICATION_CREDENTIALS, {encoding: 'utf-8'})
+
+  let keyPath = process.env.BIGQUERY_KEY_PATH || process.env.GOOGLE_APPLICATION_CREDENTIALS || config.bigquery?.keyPath
+  if (keyPath) {
+    let body = await readFile(keyPath, {encoding: 'utf-8'})
     let credentials = JSON.parse(body)
-    return {projectId: credentials.project_id}
+    return {projectId: projectId || credentials.project_id, credentials}
   }
-  return {}
+  return {projectId}
 }

--- a/cli/connections/clickhouse.ts
+++ b/cli/connections/clickhouse.ts
@@ -79,15 +79,15 @@ function escapeClickHouseString(value: string) {
 }
 
 export function localDbOptions(): ClickHouseOptions {
-  let url = config.clickhouse?.url || process.env.CLICKHOUSE_URL
-  let username = config.clickhouse?.username || process.env.CLICKHOUSE_USERNAME
+  let url = process.env.CLICKHOUSE_URL || config.clickhouse?.url
+  let username = process.env.CLICKHOUSE_USERNAME || config.clickhouse?.username
   let password = process.env.CLICKHOUSE_PASSWORD
   if (!url || !username || !password) throw new Error('ClickHouse requires url and username in config or env, plus CLICKHOUSE_PASSWORD in env')
   return {
     url,
     username,
     password,
-    database: config.clickhouse?.database || config.defaultNamespace || 'default',
-    requestTimeout: config.clickhouse?.requestTimeout,
+    database: process.env.CLICKHOUSE_DATABASE || config.clickhouse?.database || config.defaultNamespace || 'default',
+    requestTimeout: Number(process.env.CLICKHOUSE_REQUEST_TIMEOUT) || config.clickhouse?.requestTimeout,
   }
 }

--- a/cli/connections/duckdb.ts
+++ b/cli/connections/duckdb.ts
@@ -130,9 +130,9 @@ export function localDbOptions(): DuckDbOptions {
   if (config.motherduck) {
     let token = process.env.MOTHERDUCK_TOKEN
     if (!token) throw new Error('MotherDuck requires MOTHERDUCK_TOKEN.')
-    return {motherduck: {...config.motherduck, token}}
+    return {motherduck: {...config.motherduck, database: process.env.MOTHERDUCK_DATABASE || config.motherduck.database, token}}
   }
-  return {...config.duckdb}
+  return {...config.duckdb, path: process.env.DUCKDB_PATH || config.duckdb?.path}
 }
 
 /** Create the shared DuckDB instance that one or more DuckDBConnections can connect to. */

--- a/cli/connections/postgres.ts
+++ b/cli/connections/postgres.ts
@@ -190,10 +190,10 @@ function postgresDisplayType(row: Record<string, unknown>) {
 export async function localDbOptions(): Promise<PostgresOptions> {
   if (config.postgres?.inMemory) return await inMemoryPostgresOptions()
 
-  let connectionString = config.postgres?.connectionString || process.env.POSTGRES_URL || process.env.DATABASE_URL
-  let host = config.postgres?.host || process.env.PGHOST || process.env.POSTGRES_HOST
-  let database = config.postgres?.database || process.env.PGDATABASE || process.env.POSTGRES_DATABASE
-  let user = config.postgres?.user || config.postgres?.username || process.env.PGUSER || process.env.POSTGRES_USER
+  let connectionString = process.env.POSTGRES_URL || process.env.DATABASE_URL || config.postgres?.connectionString
+  let host = process.env.PGHOST || process.env.POSTGRES_HOST || config.postgres?.host
+  let database = process.env.PGDATABASE || process.env.POSTGRES_DATABASE || config.postgres?.database
+  let user = process.env.PGUSER || process.env.POSTGRES_USER || config.postgres?.user || config.postgres?.username
   let password = process.env.PGPASSWORD || process.env.POSTGRES_PASSWORD
   if (!connectionString && (!host || !database || !user)) throw new Error('Postgres requires connectionString/POSTGRES_URL/DATABASE_URL or host, database, and user in config or env')
   return {
@@ -203,8 +203,8 @@ export async function localDbOptions(): Promise<PostgresOptions> {
     database,
     user,
     password,
-    schema: config.postgres?.schema || config.defaultNamespace,
-    port: config.postgres?.port || Number(process.env.PGPORT || process.env.POSTGRES_PORT) || undefined,
+    schema: process.env.PGSCHEMA || process.env.POSTGRES_SCHEMA || config.postgres?.schema || config.defaultNamespace,
+    port: Number(process.env.PGPORT || process.env.POSTGRES_PORT) || config.postgres?.port,
   }
 }
 

--- a/cli/connections/snowflake.ts
+++ b/cli/connections/snowflake.ts
@@ -11,6 +11,8 @@ export interface SnowflakeOptions {
   privateKeyPath?: string
   privateKeyPass?: string
   authenticator?: 'OAUTH_AUTHORIZATION_CODE' | 'EXTERNALBROWSER' | 'SNOWFLAKE_JWT'
+  database?: string
+  schema?: string
   logLevel?: string
   timeout?: number
   sessionParameters?: Record<string, unknown>
@@ -175,10 +177,13 @@ export function escapeSnowflakeString(value: string) {
 
 export function localDbOptions(): SnowflakeOptions {
   let snowflakeConfig = config.snowflake!
-  let {account, username} = snowflakeConfig
+  let account = process.env.SNOWFLAKE_ACCOUNT || snowflakeConfig.account
+  let username = process.env.SNOWFLAKE_USERNAME || snowflakeConfig.username
+  let database = process.env.SNOWFLAKE_DATABASE || snowflakeConfig.database
+  let schema = process.env.SNOWFLAKE_SCHEMA || snowflakeConfig.schema
   let privateKeyPath = process.env.SNOWFLAKE_PRI_KEY_PATH || snowflakeConfig.privateKeyPath
   let privateKey = process.env.SNOWFLAKE_PRI_KEY
-  let authenticator = snowflakeConfig.authenticator || 'SNOWFLAKE_JWT'
+  let authenticator = (process.env.SNOWFLAKE_AUTHENTICATOR as SnowflakeOptions['authenticator']) || snowflakeConfig.authenticator || 'SNOWFLAKE_JWT'
 
   // if you set a private key, we'll use that instead of the config
   if (privateKeyPath || privateKey) authenticator = 'SNOWFLAKE_JWT'
@@ -187,6 +192,8 @@ export function localDbOptions(): SnowflakeOptions {
     account,
     username,
     authenticator,
+    database,
+    schema,
     privateKeyPath,
     privateKey,
     privateKeyPass: process.env.SNOWFLAKE_PRI_PASSPHRASE,

--- a/cli/schema.test.ts
+++ b/cli/schema.test.ts
@@ -1,8 +1,9 @@
 /// <reference types="vitest/globals" />
 import * as path from 'node:path'
 
-import {loadConfig, normalizeConfig, type Config} from '../lang/config.ts'
+import {config, loadConfig, normalizeConfig, setGlobalConfig, type Config} from '../lang/config.ts'
 import {formatType, parseWarehouseFieldType} from '../lang/types.ts'
+import {localDbOptions as clickHouseOptions} from './connections/clickhouse.ts'
 import {expect, test} from './testFixtures.ts'
 
 const dir = path.resolve(import.meta.url.replace('file://', ''), '../')
@@ -41,6 +42,26 @@ describe('duckdb', () => {
     let cfg = normalizeConfig({motherduck: {database: 'sample_data'}, root: '/tmp/project'})
     expect(cfg.dialect).toBe('duckdb')
     expect(cfg.motherduck?.database).toBe('sample_data')
+  })
+
+  test('lets ClickHouse environment variables override its connection without changing the namespace', () => {
+    let previousConfig = {...config}
+    setGlobalConfig({clickhouse: {url: 'https://prod.clickhouse.test', username: 'prod-user', database: 'analytics'}, defaultNamespace: 'analytics', root: '/tmp/project'})
+    vi.stubEnv('CLICKHOUSE_URL', 'https://dev.clickhouse.test')
+    vi.stubEnv('CLICKHOUSE_USERNAME', 'dev-user')
+    vi.stubEnv('CLICKHOUSE_PASSWORD', 'password')
+    vi.stubEnv('CLICKHOUSE_DATABASE', 'dbt_dev')
+    vi.stubEnv('CLICKHOUSE_REQUEST_TIMEOUT', '30000')
+
+    expect(clickHouseOptions()).toEqual({url: 'https://dev.clickhouse.test', username: 'dev-user', password: 'password', database: 'dbt_dev', requestTimeout: 30000})
+    expect(config.defaultNamespace).toBe('analytics')
+    vi.unstubAllEnvs()
+    setGlobalConfig(previousConfig)
+  })
+
+  test('supports a connector-independent namespace override', () => {
+    let cfg = normalizeConfig({postgres: {database: 'analytics', schema: 'public'}, root: '/tmp/project'}, process.cwd(), undefined, {GRAPHENE_DEFAULT_NAMESPACE: 'dbt_alice'})
+    expect(cfg.defaultNamespace).toBe('dbt_alice')
   })
 
   test('lists available tables when no argument is provided', async ({runCli}) => {

--- a/docs/references/config.md
+++ b/docs/references/config.md
@@ -22,6 +22,8 @@ Changes to `package.json` are read once at startup, so restart the dev server (`
 
 The schema/database used to resolve unqualified table names in GSQL. For BigQuery this is typically `project.dataset`; for Snowflake `DATABASE.SCHEMA`; for DuckDB usually `main`. Also accepted as `namespace`.
 
+Set `GRAPHENE_DEFAULT_NAMESPACE` to override this value temporarily. Connection environment variables are separate: for example, `CLICKHOUSE_DATABASE` changes the ClickHouse connection database but does not change GSQL table resolution.
+
 ## `ignoredFiles`
 
 An array of glob patterns for files that Graphene should skip when discovering `.gsql` and `.md` files. Patterns are matched relative to the project root using the [`glob`](https://www.npmjs.com/package/glob) package's syntax (case-insensitive).
@@ -66,7 +68,7 @@ Exactly one of the following blocks should be present. The dialect is inferred f
 "motherduck": {"database": "sample_data"}
 ```
 
-- `database` — MotherDuck database name to open with `md:<database>`. If omitted, Graphene opens `md:` and attaches all databases available to the token.
+- `database` — MotherDuck database name to open with `md:<database>`. If omitted, Graphene opens `md:` and attaches all databases available to the token. Override with `MOTHERDUCK_DATABASE`.
 
 MotherDuck uses DuckDB SQL syntax, so Graphene analyzes GSQL with the DuckDB dialect. Store credentials in a `.env` file and include it with `envFile`:
 
@@ -80,7 +82,7 @@ MOTHERDUCK_TOKEN=<your-token>
 "duckdb": {"path": "./data.duckdb"}
 ```
 
-- `path` — path to the `.duckdb` file, relative to the project root. If omitted, Graphene runs in-memory.
+- `path` — path to the `.duckdb` file, relative to the project root. If omitted, Graphene discovers a `.duckdb` file in the project directory. Override with `DUCKDB_PATH`.
 
 ## `snowflake`
 
@@ -100,7 +102,7 @@ MOTHERDUCK_TOKEN=<your-token>
 - `authenticator` — optional Snowflake authenticator: `SNOWFLAKE_JWT`, `OAUTH_AUTHORIZATION_CODE`, or `EXTERNALBROWSER`. Defaults to `SNOWFLAKE_JWT` when `privateKeyPath` or `SNOWFLAKE_PRI_KEY_PATH` is set; otherwise `graphene login` defaults to `OAUTH_AUTHORIZATION_CODE`, using Snowflake's built-in local application OAuth flow.
 - `database`, `schema` — optional defaults applied to unqualified queries.
 
-The matching private key passphrase env var is `SNOWFLAKE_PRI_PASSPHRASE`.
+Connection fields can be overridden with `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USERNAME`, `SNOWFLAKE_DATABASE`, `SNOWFLAKE_SCHEMA`, `SNOWFLAKE_AUTHENTICATOR`, and `SNOWFLAKE_PRI_KEY_PATH`. The matching inline key and passphrase variables are `SNOWFLAKE_PRI_KEY` and `SNOWFLAKE_PRI_PASSPHRASE`.
 
 ## `bigquery`
 
@@ -111,8 +113,10 @@ The matching private key passphrase env var is `SNOWFLAKE_PRI_PASSPHRASE`.
 }
 ```
 
-- `projectId` — Google Cloud project ID for billing/jobs.
-- `keyPath` — absolute path to the service account JSON key. Usually set via the `GOOGLE_APPLICATION_CREDENTIALS` env var instead.
+- `projectId` — Google Cloud project ID for billing/jobs. Override with `BIGQUERY_PROJECT_ID`, `GOOGLE_CLOUD_PROJECT`, or `GCLOUD_PROJECT`.
+- `keyPath` — absolute path to the service account JSON key. Override with `BIGQUERY_KEY_PATH` or `GOOGLE_APPLICATION_CREDENTIALS`.
+
+`GOOGLE_CREDENTIALS_CONTENT` can contain the service account JSON directly.
 
 ## `clickhouse`
 
@@ -130,7 +134,7 @@ The matching private key passphrase env var is `SNOWFLAKE_PRI_PASSPHRASE`.
 - `database` — default database for unqualified queries.
 - `requestTimeout` — per-request timeout in milliseconds.
 
-The matching password env var is `CLICKHOUSE_PASSWORD`.
+Override connection fields with `CLICKHOUSE_URL`, `CLICKHOUSE_USERNAME`, `CLICKHOUSE_DATABASE`, and `CLICKHOUSE_REQUEST_TIMEOUT`. `CLICKHOUSE_PASSWORD` supplies the password. Use `GRAPHENE_DEFAULT_NAMESPACE` separately when unqualified GSQL should also point at a different namespace.
 
 ## `postgres`
 
@@ -144,7 +148,23 @@ The matching password env var is `CLICKHOUSE_PASSWORD`.
 }
 ```
 
-- `connectionString` — full Postgres connection string. If omitted, Graphene also checks `POSTGRES_URL` and `DATABASE_URL`.
-- `host`, `port`, `database`, `user`/`username` — connection fields used when no connection string is set. These can also come from the matching `PG*` or `POSTGRES_*` env vars.
-- `schema` — default schema for unqualified table names. Falls back to `defaultNamespace`, then `public`.
+- `connectionString` — full Postgres connection string. Override with `POSTGRES_URL` or `DATABASE_URL`.
+- `host`, `port`, `database`, `user`/`username` — connection fields used when no connection string is set. Override with `PGHOST`/`POSTGRES_HOST`, `PGPORT`/`POSTGRES_PORT`, `PGDATABASE`/`POSTGRES_DATABASE`, and `PGUSER`/`POSTGRES_USER`.
+- `schema` — default schema used by schema inspection. Override with `PGSCHEMA` or `POSTGRES_SCHEMA`. Falls back to `defaultNamespace`, then `public`.
 - `ssl`, `max`, `idleTimeoutMillis`, `connectionTimeoutMillis`, `queryTimeout`, `statementTimeout` — passed through to `node-postgres`.
+
+Supply the password with `PGPASSWORD` or `POSTGRES_PASSWORD`.
+
+## `athena`
+
+```json
+"athena": {
+  "region": "us-east-1",
+  "catalog": "AwsDataCatalog",
+  "database": "analytics",
+  "workGroup": "primary",
+  "outputLocation": "s3://my-query-results/"
+}
+```
+
+Override fields with `AWS_REGION`/`AWS_DEFAULT_REGION`, `ATHENA_CATALOG`, `ATHENA_DATABASE`, `ATHENA_WORK_GROUP`, and `ATHENA_OUTPUT_LOCATION`. The AWS SDK also reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`.

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -87,7 +87,7 @@ export function setGlobalConfig(cfg: ConfigInput | Config, projectName?: string)
   Object.assign(config, normalizeConfig(cfg, process.cwd(), projectName))
 }
 
-export function normalizeConfig(input: ConfigInput, defaultRoot = process.cwd(), projectName?: string): Config {
+export function normalizeConfig(input: ConfigInput, defaultRoot = process.cwd(), projectName?: string, env: NodeJS.ProcessEnv = process.env): Config {
   let cfg = {...input}
   let root = path.resolve(cfg.root || defaultRoot)
   if (cfg.namespace && !cfg.defaultNamespace) cfg.defaultNamespace = cfg.namespace
@@ -100,6 +100,10 @@ export function normalizeConfig(input: ConfigInput, defaultRoot = process.cwd(),
   else if (cfg.athena) dialect = 'athena'
   else if (cfg.motherduck) dialect = 'duckdb'
   else if (cfg.duckdb) dialect = 'duckdb'
+
+  // Unlike connector-specific environment variables, this affects GSQL table resolution.
+  cfg.defaultNamespace = env.GRAPHENE_DEFAULT_NAMESPACE || cfg.defaultNamespace
+
   let envFile = ['.env']
   if (Array.isArray(cfg.envFile)) envFile = cfg.envFile
   else if (cfg.envFile) envFile = [cfg.envFile]
@@ -109,7 +113,7 @@ export function normalizeConfig(input: ConfigInput, defaultRoot = process.cwd(),
     dialect,
     root,
     projectName: projectName || path.basename(root),
-    port: cfg.port || Number(process.env.GRAPHENE_PORT) || 4000,
+    port: cfg.port || Number(env.GRAPHENE_PORT) || 4000,
     ignoredFiles: cfg.ignoredFiles || [],
     envFile,
   } as Config


### PR DESCRIPTION
Resolve connector-specific environment variables in each localDbOptions function, keeping connection configuration separate from GSQL namespace resolution. Add GRAPHENE_DEFAULT_NAMESPACE for explicit namespace overrides and document the supported variables.

Fixes https://github.com/graphene-data/graphene/issues/521