### PR TITLE
Use json string for multiple defaultValues

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -173,7 +173,7 @@ select * from orders where status = $status
 ```
 ````
 
-For `multiple=true`, the input produces a list; filter with `where status in ($status)`. Multiple defaults must be passed as an array, not a comma-separated string: `<Dropdown name=status multiple=true defaultValue={['Complete', 'Pending']} />`.
+For `multiple=true`, the input produces a list; filter with `where status in ($status)`. Pass multiple defaults as a JSON array string: `<Dropdown name=status multiple=true defaultValue="['Complete', 'Pending']" />`.
 
 Static options can be nested inside the dropdown as `<DropdownOption value="complete" valueLabel="Complete" />`; `value` is required and `valueLabel` defaults to it.
 

--- a/examples/flights/pages/dropdown_defaults_test.md
+++ b/examples/flights/pages/dropdown_defaults_test.md
@@ -21,7 +21,7 @@ select destination as code group by 1 order by 1
   <Dropdown title="Carrier" name="carrier" data="test_carrier_options" value="code" defaultValue="WN" />
   <Dropdown title="Origin" name="origin" data="test_origin_options" value="code" defaultValue="PHX" />
   <Dropdown title="Invalid comma default" name="excluded_invalid" data="test_destination_options" value="code" multiple=true defaultValue="LAX, LAS" />
-  <Dropdown title="Valid array default" name="excluded_valid" data="test_destination_options" value="code" multiple=true defaultValue={['LAX', 'LAS']} />
+  <Dropdown title="Valid array default" name="excluded_valid" data="test_destination_options" value="code" multiple=true defaultValue="['LAX', 'LAS']" />
   <Dropdown title="Year" name="year" defaultValue="2005">
     <DropdownOption value="2004" />
     <DropdownOption value="2005" />

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {onMount, setContext, tick, untrack, type Snippet} from 'svelte'
-  import {ensureArray, toBoolean} from '../component-utilities/inputUtils'
+  import {toBoolean} from '../component-utilities/inputUtils'
   import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
 
   interface Option {
@@ -18,7 +18,7 @@
     title?: string
     placeholder?: string
     multiple?: boolean | string
-    defaultValue?: string | string[]
+    defaultValue?: string
     selectAllByDefault?: boolean | string
     noDefault?: boolean | string
     disableSelectAll?: boolean | string
@@ -94,6 +94,7 @@
   let hidePrint = $derived(toBoolean(hideDuringPrint))
   let isDisabled = $derived(toBoolean(disabled))
   let disableSelectAllButton = $derived(toBoolean(disableSelectAll))
+  let defaultValues = $derived(parseDefaultValue(defaultValue, multi))
 
   let resolvedLabelField = $derived(optionLabel || labelField || (label && data ? label : undefined))
   let resolvedTitle = $derived(title || (!data ? label : undefined))
@@ -300,8 +301,7 @@
   })
 
   $effect(() => {
-    let defaults = ensureArray(defaultValue)
-    let defaultParam = !hasNoDefault && defaults.length ? writeSelection(defaults) : null
+    let defaultParam = !hasNoDefault && defaultValues.length ? writeSelection(defaultValues) : null
     let unsub = window.$GRAPHENE.param(name, multi ? 'array' : 'scalar', defaultParam, value => {
       let nextSelection = readSelection(value)
       if (!sameSelection(selection, nextSelection)) setSelection(nextSelection, {persist: false})
@@ -358,14 +358,21 @@
     setSelection(nextSelection, {fromUser, persist: true})
   }
 
+  // Multiple defaults use an array serialized as a string because Markdown attributes cannot safely pass Svelte values.
+  function parseDefaultValue(value: string | undefined, multiple: boolean): any[] {
+    if (value === undefined) return []
+    if (!multiple || !value.trim().startsWith('[')) return [value]
+    return JSON.parse(value.replaceAll("'", '"'))
+  }
+
   // Warn once the complete queried or manual option set proves an authored default is invalid.
   function validateDefaultValue() {
-    let missing = ensureArray(defaultValue).filter(defaultItem => !valueMap.has(optionKey(defaultItem)))
+    let missing = defaultValues.filter(defaultItem => !valueMap.has(optionKey(defaultItem)))
     if (!missing.length) return defaultLogger.warn(null)
 
     let values = missing.map(item => `"${String(item)}"`).join(', ')
     let noun = missing.length === 1 ? 'value is' : 'values are'
-    let hint = multi && typeof defaultValue === 'string' && defaultValue.includes(',') ? ' For multiple defaults, pass an array rather than a comma-separated string.' : ''
+    let hint = multi && defaultValue?.includes(',') ? ' For multiple defaults, pass a JSON array string such as "[\'one\', \'two\']".' : ''
     defaultLogger.warn(`Dropdown "${name}" default ${noun} not present in its options: ${values}.${hint}`)
   }
 

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -220,7 +220,7 @@ test('dropdown validates single and multiple defaults against loaded options', a
     page,
     `
     <Dropdown name="invalid_default" data="dropdown_options" value="code" label="label" title="Invalid Default" multiple=true defaultValue="AA, AS" />
-    <Dropdown name="valid_defaults" data="dropdown_options" value="code" label="label" title="Valid Defaults" multiple=true defaultValue={['AA', 'AS']} />
+    <Dropdown name="valid_defaults" data="dropdown_options" value="code" label="label" title="Valid Defaults" multiple=true defaultValue="['AA', 'AS']" />
   `,
   )
 
@@ -231,13 +231,13 @@ test('dropdown validates single and multiple defaults against loaded options', a
     .poll(() => page.evaluate(() => window.$GRAPHENE.getErrors().map(({message, componentId, severity}) => ({message, componentId, severity}))))
     .toEqual([
       {
-        message: 'Dropdown "invalid_default" default value is not present in its options: "AA, AS". For multiple defaults, pass an array rather than a comma-separated string.',
+        message: 'Dropdown "invalid_default" default value is not present in its options: "AA, AS". For multiple defaults, pass a JSON array string such as "[\'one\', \'two\']".',
         componentId: 'Dropdown defaultValue (name="invalid_default")',
         severity: 'warn',
       },
     ])
   expect(browserWarnings).toContain(
-    '[Graphene] Dropdown defaultValue (name="invalid_default"): Dropdown "invalid_default" default value is not present in its options: "AA, AS". For multiple defaults, pass an array rather than a comma-separated string.',
+    '[Graphene] Dropdown defaultValue (name="invalid_default"): Dropdown "invalid_default" default value is not present in its options: "AA, AS". For multiple defaults, pass a JSON array string such as "[\'one\', \'two\']".',
   )
 })
 


### PR DESCRIPTION
Instead of svelte arrays. I'm not sold on putting svelte syntax in to the surface area of Graphene quite yet.

This is breaking change, but hopefully rarely used.