### PR TITLE
Debounce text input query updates

### DIFF
--- a/ui/components/TextInput.svelte
+++ b/ui/components/TextInput.svelte
@@ -19,20 +19,32 @@
   untrack(() => logExtraProps(logger, 'TextInput', extraProps))
 
   let value = $state('')
+  let updateTimer: ReturnType<typeof setTimeout> | undefined
 
   let hidePrint = $derived(toBoolean(hideDuringPrint))
   let displayLabel = $derived(title || label)
 
   $effect(() => {
     let unsub = window.$GRAPHENE.param(name, 'scalar', defaultValue ?? null, next => {
+      clearTimeout(updateTimer)
+      updateTimer = undefined
       value = Array.isArray(next) ? String(next[0] ?? '') : String(next ?? '')
     })
-    return unsub
+    return () => {
+      clearTimeout(updateTimer)
+      unsub()
+    }
   })
 
+  // Update the visible value immediately, but wait until typing pauses before rerunning queries.
   function onInput(event: Event) {
     let next = (event.currentTarget as HTMLInputElement).value
-    window.$GRAPHENE.updateParam(name, next === '' ? null : next)
+    value = next
+    clearTimeout(updateTimer)
+    updateTimer = setTimeout(() => {
+      updateTimer = undefined
+      window.$GRAPHENE.updateParam(name, next === '' ? null : next)
+    }, 200)
   }
 </script>
 

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -394,8 +394,12 @@ test('text input updates params and date range applies preset', async ({mount, s
   await expect(textInput).toHaveValue('alpha')
 
   await startParamTracking(sharedPage)
+  await textInput.fill('del')
+  await sharedPage.waitForTimeout(100)
   await textInput.fill('delta')
-  expect(await lastParamUpdate(sharedPage, 'search_text')).toEqual({name: 'search_text', value: 'delta'})
+  await sharedPage.waitForTimeout(150)
+  expect(await lastParamUpdate(sharedPage, 'search_text')).toBeNull()
+  await expect.poll(() => lastParamUpdate(sharedPage, 'search_text')).toEqual({name: 'search_text', value: 'delta'})
   await textInput.blur()
   await expect(sharedPage.locator('#component-test')).screenshot('text-input-basic')
 
@@ -477,6 +481,7 @@ test('inputs sync url state on load, change, and reload', {timeout: 20000}, asyn
   ).toBe(true)
 
   await page.getByLabel('Search Text').fill('omega')
+  await expect.poll(() => queryBodies.some(body => body.params.search_text === 'omega')).toBe(true)
   await page.getByRole('combobox', {name: 'Carriers'}).click()
   await page.getByRole('option', {name: 'DL'}).click()
   await page.locator('#daterange-window-start').evaluate((el: HTMLInputElement) => {


### PR DESCRIPTION
Wait 200ms after the final text input event before updating URL params and rerunning dependent queries.