### PR TITLE
Match local report CSP to Graphene Cloud

### DIFF
--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -13,6 +13,7 @@ import type {AnalysisResult, QueryField, WorkspaceFileInput} from '../lang/types
 
 import {config} from '../lang/config.ts'
 import {analyzeWorkspace, loadWorkspace, toSql} from '../lang/core.ts'
+import {grapheneCsp} from '../ui/csp.ts'
 import {runQuery} from './connections/index.ts'
 import {extractPageTitle, injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 import {missingMockFiles, mockFileMap} from './mockFiles.ts'
@@ -194,6 +195,7 @@ export function computeQueryHash(sql: string, fields: Pick<QueryField, 'name' | 
 
 async function handlePage(server: ViteDevServer, res: ServerResponse<IncomingMessage>) {
   res.setHeader('Content-Type', 'text/html')
+  if (config.csp !== false) res.setHeader('Content-Security-Policy', grapheneCsp)
 
   // Use a .html URL for transformIndexHtml so Vite doesn't run the svelte plugin on our HTML template.
   let html = await server.transformIndexHtml(

--- a/docs/references/config.md
+++ b/docs/references/config.md
@@ -46,6 +46,14 @@ Path (or array of paths) to `.env` files Graphene should load before connecting 
 
 Port for the local dev server. Defaults to `4000`, or the value of the `GRAPHENE_PORT` environment variable.
 
+## `csp`
+
+Content Security Policy for locally served report pages. Defaults to `"all"`, which applies the same policy as Graphene Cloud so blocked scripts, connections, and other resources also fail during local development. Set to `false` to disable the policy:
+
+```json
+"csp": false
+```
+
 ## `cloud`
 
 Graphene Cloud URL to proxy queries through, e.g. `https://example.graphenedata.com/my-repo`. The URL path selects the repo to query.

--- a/lang/config.ts
+++ b/lang/config.ts
@@ -11,6 +11,7 @@ export interface Config {
   telemetry?: boolean
   updateNotifier?: boolean
   port: number
+  csp?: 'all' | false
   cloud?: string
   envFile: string[] // array of paths where we can look for the env file
 
@@ -114,6 +115,7 @@ export function normalizeConfig(input: ConfigInput, defaultRoot = process.cwd(),
     root,
     projectName: projectName || path.basename(root),
     port: cfg.port || Number(env.GRAPHENE_PORT) || 4000,
+    csp: cfg.csp ?? 'all',
     ignoredFiles: cfg.ignoredFiles || [],
     envFile,
   } as Config

--- a/ui/csp.ts
+++ b/ui/csp.ts
@@ -1,0 +1,15 @@
+// Shared browser policy for locally served and Graphene Cloud report pages.
+// Keeping one policy ensures CSP failures reproduce the same way in both environments.
+export const grapheneCsp = [
+  "default-src 'none'",
+  "script-src 'self' 'unsafe-inline' blob:",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' data: blob: https://fonts.gstatic.com",
+  "img-src 'self' data: blob:",
+  "connect-src 'self' ws:",
+  "worker-src 'none'",
+  "frame-src 'none'",
+  "object-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'",
+].join('; ')

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -32,7 +32,7 @@ export interface ChartFixture {
 }
 
 export interface ServerFixture {
-  url: (options?: Config) => string
+  url: (options?: Partial<Config>) => string
   mockFile: (path: string, content: string) => void
   mockMissingFile: (path: string) => void
   /** Update a mock file and trigger HMR, simulating a real file edit */

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -1,4 +1,5 @@
 import {scalarType} from '../../lang/types.ts'
+import {grapheneCsp} from '../csp.ts'
 import {test, expect, waitForGrapheneLoad} from './fixtures.ts'
 import {expectConsoleError} from './logWatcher.ts'
 
@@ -30,6 +31,14 @@ test('loads markdown files', async ({server, page}) => {
   await expect(page.locator('main svg').first()).toBeVisible()
   await expect(page.locator('main#content')).toHaveCSS('max-width', '1200px')
   await expect(page).screenshot('loads-markdown-files')
+})
+
+test('serves the cloud CSP unless disabled', async ({server, page}) => {
+  let response = await page.goto(server.url())
+  expect(response!.headers()['content-security-policy']).toBe(grapheneCsp)
+
+  response = await page.goto(server.url({csp: false}))
+  expect(response!.headers()['content-security-policy']).toBeUndefined()
 })
 
 test('shows a placeholder when a repo has no index page', async ({server, page}) => {


### PR DESCRIPTION
Apply the shared Cloud policy to serve2 HTML responses by default.
Allow projects to disable it with csp: false and document the option.