### PR TITLE
Add hidden URL parameter input

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -188,6 +188,15 @@ Collects freeform text. `name` is required; optional attributes are `title`, `pl
 
 For example, filter with `where email ilike concat('%', $search, '%')`.
 
+### `<Hidden>`
+Declares a URL parameter without displaying an input on the page. `name` is required and `defaultValue` is optional. Use it when a report should accept a value from its URL but users should not edit that value in the report.
+
+```md
+<Hidden name=account_id defaultValue="all" />
+```
+
+Reference the value as `$account_id` in GSQL. A URL such as `?account_id=123` overrides the default; the default is used when the parameter is absent.
+
 ### `<DateRange>`
 Collects start and end dates. `name` is required; optional attributes are `title`, `description`, `data` and `dates` (to infer the available date domain), `start`, `end`, `defaultValue`, and `presetRanges`.
 

--- a/ui/components/Hidden.svelte
+++ b/ui/components/Hidden.svelte
@@ -1,0 +1,17 @@
+<!-- Declares a scalar URL/query parameter without rendering a control on the page. -->
+<script lang="ts">
+  import {untrack} from 'svelte'
+  import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
+
+  interface Props {
+    name: string
+    defaultValue?: string
+  }
+
+  let {name, defaultValue, ...extraProps}: Props & Record<string, unknown> = $props()
+
+  let logger = untrack(() => componentLogger('Hidden', {name}))
+  untrack(() => logExtraProps(logger, 'Hidden', extraProps))
+
+  $effect(() => window.$GRAPHENE.param(name, 'scalar', defaultValue ?? null, () => undefined))
+</script>

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -425,6 +425,39 @@ test('text input updates params and date range applies preset', async ({mount, s
   await expect(sharedPage.locator('#component-test')).screenshot('date-range-preset')
 })
 
+test('hidden input applies URL values and defaults without rendering a control', async ({server, page}) => {
+  let queryBodies: any[] = []
+  server.mockFile(
+    '/index.md',
+    `
+    # Hidden input
+
+    <Hidden name="carrier" defaultValue="AA" />
+
+    \`\`\`sql selected_flights
+    from flights select carrier where carrier = $carrier limit 5
+    \`\`\`
+
+    <Table data="selected_flights" />
+  `,
+  )
+  await page.route('**/_api/query', async route => {
+    queryBodies.push(route.request().postDataJSON())
+    await route.continue()
+  })
+
+  await page.goto(server.url() + '/?carrier=UA')
+  await waitForGrapheneLoad(page)
+  expect(queryBodies.some(body => body.params.carrier === 'UA')).toBe(true)
+  await expect(page.locator('main#content')).screenshot('hidden-input-url-param')
+
+  queryBodies = []
+  await page.goto(server.url() + '/')
+  await waitForGrapheneLoad(page)
+  expect(queryBodies.some(body => body.params.carrier === 'AA')).toBe(true)
+  await expect(page.locator('main#content').locator('input, button, select')).toHaveCount(0)
+})
+
 test('inputs sync url state on load, change, and reload', {timeout: 20000}, async ({server, page}) => {
   let queryBodies: any[] = []
   server.mockFile(

--- a/ui/tests/snapshots/inputs.test.ts/hidden-input-url-param.png
+++ b/ui/tests/snapshots/inputs.test.ts/hidden-input-url-param.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae987c37dd0dec52f0b87885a62682239ff220eb6493807f0ee97c1061b7e6c2
+size 9688

--- a/ui/web.js
+++ b/ui/web.js
@@ -14,6 +14,7 @@ import Dropdown from './components/Dropdown.svelte'
 import DropdownOption from './components/DropdownOption.svelte'
 import ECharts from './components/ECharts.svelte'
 import GrapheneQuery from './components/GrapheneQuery.svelte'
+import Hidden from './components/Hidden.svelte'
 import InlineDelta from './components/InlineDelta.svelte'
 import LineChart from './components/LineChart.svelte'
 import PieChart from './components/PieChart.svelte'
@@ -58,6 +59,7 @@ window.$GRAPHENE.components = {
   ECharts,
   ErrorChart,
   GrapheneQuery,
+  Hidden,
   InlineDelta,
   LineChart,
   PieChart,


### PR DESCRIPTION
Register a non-rendering Hidden component that exposes scalar URL parameters and optional defaults to GSQL queries. Document usage and cover URL overrides, defaults, and the absence of visible controls.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/graphene-data/codesmith/graphene/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788471585&installation_model_id=430899&pr_number=537&repository=graphene-data%2Fgraphene&return_to=https%3A%2F%2Fgithub.com%2Fgraphene-data%2Fgraphene%2Fpull%2F537&signature=b905d2d5fa3158be5dc68077ffd1e1b3fb727c7b7e9dd8c7ca3d03d921f7b12e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->