### PR TITLE
Check cloud auth before CLI run and serve

### DIFF
--- a/cli/auth.ts
+++ b/cli/auth.ts
@@ -164,7 +164,7 @@ async function refreshAccessToken(staleAccessToken?: string) {
 
     let refresh_token = entry?.refresh_token
     let cloudOrigin = new URL(config.cloud!).origin
-    if (!refresh_token) throw new Error('No refresh token available; run `graphene login`')
+    if (!refresh_token) throw new Error('Not logged in to Graphene Cloud. Run `graphene login` and try again.')
     let res = await fetch(new URL('/_api/oauth2/token', cloudOrigin).toString(), {
       method: 'POST',
       headers: {'content-type': 'application/json'},
@@ -187,6 +187,11 @@ export async function makeAccessToken(): Promise<string> {
   return token
 }
 
+// Verifies Cloud credentials before commands that would otherwise fail later inside page/query requests.
+export async function checkCloudAuth(): Promise<void> {
+  await authenticatedFetch('/_api/nav', {headers: {accept: 'application/json'}})
+}
+
 // Makes an authenticated request using an explicitly delegated token or credentials from `graphene login`.
 export async function authenticatedFetch(pathOrUrl: string, init: RequestInit = {}): Promise<Response> {
   let cloudOrigin = new URL(config.cloud!).origin
@@ -200,7 +205,7 @@ export async function authenticatedFetch(pathOrUrl: string, init: RequestInit = 
   }
 
   let entry = await readEntry()
-  if (!entry) throw new Error('Not logged in; run `graphene login`')
+  if (!entry) throw new Error('Not logged in to Graphene Cloud. Run `graphene login` and try again.')
 
   // If we know the access token is no good, refresh it now.
   if (!entry.access_token || entry.expires_at < Date.now()) {
@@ -221,6 +226,13 @@ export async function authenticatedFetch(pathOrUrl: string, init: RequestInit = 
       headers.set('authorization', `Bearer ${token}`)
       res = await fetch(url.toString(), {...init, headers})
     }
+  }
+
+  if (!res.ok) {
+    let json = await res.json()
+    let err = new Error(json.message || json.error || `Request failed with HTTP ${res.status}`)
+    Object.assign(err, json)
+    throw err
   }
   return res
 }

--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -99,6 +99,19 @@ describe('cli serve', () => {
       await stopGrapheneIfRunning()
     }
   })
+
+  test('checks cloud auth before starting the server', async ({runCli}) => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-cli-no-cloud-creds-'))
+    try {
+      let res = await runCli(['serve', '--bg'], configFor(tmpDir, {cloud: 'https://example.graphenedata.com/flights'}), {env: {GRAPHENE_TOKEN: ''}})
+
+      expect(res.code).toBe(1)
+      expect(res.stdout).toBe('')
+      expect(res.stderr).toBe('Not logged in to Graphene Cloud. Run `graphene login` and try again.\n')
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
+  })
 })
 
 describe('cli run', () => {
@@ -119,6 +132,19 @@ describe('cli run', () => {
     let res = await runCli(['run', 'from flights select count() as total'], flightConfig)
     expectCliSuccess(res, 'run query')
     expect(res.stdout.toLowerCase()).toContain('total')
+  })
+
+  test('checks cloud auth before running a query', async ({runCli}) => {
+    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-cli-no-cloud-creds-'))
+    try {
+      let res = await runCli(['run', 'from flights select count() as total'], configFor(tmpDir, {cloud: 'https://example.graphenedata.com/flights'}), {env: {GRAPHENE_TOKEN: ''}})
+
+      expect(res.code).toBe(1)
+      expect(res.stdout).toBe('')
+      expect(res.stderr).toBe('Not logged in to Graphene Cloud. Run `graphene login` and try again.\n')
+    } finally {
+      await fsp.rm(tmpDir, {recursive: true, force: true})
+    }
   })
 
   test('prints query diagnostics without a stack trace', async ({runCli}) => {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -10,7 +10,7 @@ import {config, loadConfig, setGlobalConfig} from '../lang/config.ts'
 import {analyzeWorkspace, getFile, loadWorkspace, toSql, type Query} from '../lang/core.ts'
 import {rowsToCsv} from '../lang/csv.ts'
 import {parseWarehouseFieldType, type AnalysisResult} from '../lang/types.ts'
-import {loginPkce, makeAccessToken} from './auth.ts'
+import {checkCloudAuth, loginPkce, makeAccessToken} from './auth.ts'
 import {getGrapheneCache, runServeInBackground, stopGrapheneIfRunning} from './background.ts'
 import {check} from './check.ts'
 import {getConnection, runQuery} from './connections/index.ts'
@@ -60,6 +60,8 @@ program.command('run')
         command.outputHelp()
         return exit(0)
       }
+
+      if (config.cloud) await checkCloudAuth()
 
       let cliInput = await readInput(input)
       let params = parseRunInputs(options.param || [], exit)
@@ -188,6 +190,7 @@ program.command('serve')
   .option('--bg', 'Run the server in the background')
   .action(
     withTelemetry('serve', async (exit, options: {bg?: boolean; port?: string}) => {
+      if (config.cloud) await checkCloudAuth()
       await stopGrapheneIfRunning()
       if (options.bg) {
         let url = await runServeInBackground({entryPoint: fileURLToPath(import.meta.url)})

--- a/cli/connections/index.ts
+++ b/cli/connections/index.ts
@@ -72,7 +72,6 @@ export async function runQuery(sql: string, options: RunQueryOptions = {}): Prom
       body: JSON.stringify({sql, params, repoId}),
     })
     let json = await resp.json()
-    if (!resp.ok) throw new Error(json.message || json.error || `Query failed with HTTP ${resp.status}`)
     if (!Array.isArray(json.rows)) throw new Error('Query response did not include rows')
     return json
   }


### PR DESCRIPTION
Fail early for cloud-backed `graphene run` and `graphene serve` when local Cloud credentials are missing or invalid.