### PR TITLE
Clarify Markdown script and asset support

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -83,15 +83,10 @@ where status <> 'cancelled'
 
 Queries can be referenced by other queries in the `from` or `join` to form DAGs of data logic within the page.
 
-## HTML and CSS
-Pages can use safe HTML markup for custom layout and styling. Common layout and text tags are supported, along with `class`, `id`, `role`, `aria-*`, and `data-*` attributes. Use `<style>` blocks to customize page visuals or target Graphene components.
+## HTML, CSS, and Javascript
+Pages can use HTML and Svelte markup for custom behavior, layout, and styling. This includes `<style>` blocks, inline styles, framework directives, and inline `<script>` blocks.
 
-Graphene treats page CSS as visual customization, not executable code. CSS can use external visual resources, including `@import`, font files, and image URLs. Inline `style=""` attributes are not supported; use classes and `<style>` blocks instead.
-
-Unsupported:
-- Javascript of any kind, including `<script>`, event handlers, framework directives, dynamic markup expressions, and raw HTML injection
-- Automatic embedded/resource tags such as `<iframe>`, `<object>`, `<embed>`, `<link>`, `<meta>`, `<img>`, `<video>`, `<audio>`, `<svg>`, and `<math>`
-- Form controls such as `<form>`, `<input>`, `<button>`, `<textarea>`, and `<select>`
+The `src` attribute on `<script>` is not yet supported. Network-loaded images and fonts are also blocked by default; Google Fonts is the only external asset source currently allowed.
 
 ## Page titles and frontmatter
 Use a Markdown h1 to display a page title. Automatically sets the page's title in the nav.


### PR DESCRIPTION
Document inline script support and the current CSP restrictions on external scripts, images, and fonts.