### PR TITLE
Fix select-all defaults for static dropdown options

### DIFF
--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -45,6 +45,8 @@
   let manualOptions: Option[] = $state([])
   let selection: any[] = $state([])
   let touched = false
+  let paramInitialized = false
+  let preserveInitialSelection = false
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
   let queryKey = ''
 
@@ -303,6 +305,10 @@
   $effect(() => {
     let defaultParam = !hasNoDefault && defaultValues.length ? writeSelection(defaultValues) : null
     let unsub = window.$GRAPHENE.param(name, multi ? 'array' : 'scalar', defaultParam, value => {
+      if (!paramInitialized) {
+        preserveInitialSelection = value != null
+        paramInitialized = true
+      }
       let nextSelection = readSelection(value)
       if (!sameSelection(selection, nextSelection)) setSelection(nextSelection, {persist: false})
     })
@@ -353,7 +359,9 @@
     }
     let nextSelection = selection.filter(val => valueMap.has(optionKey(val)))
     if (!fromUser) {
-      if (multi && selectAllDefault && !touched && !selection.length) nextSelection = opts.map(o => o.value)
+      // Manual options register one at a time, so keep expanding a select-all default until the user interacts.
+      // An explicit default or URL value remains authoritative.
+      if (multi && selectAllDefault && !touched && !preserveInitialSelection) nextSelection = opts.map(o => o.value)
     }
     setSelection(nextSelection, {fromUser, persist: true})
   }

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -291,6 +291,25 @@ test('dropdown boolean-string attributes handle defaults and footer actions', as
   await expect(page.getByRole('listbox')).screenshot('dropdown-select-all-default-disable-button')
 })
 
+test('static dropdown options apply select-all as each option registers', async ({server, page}) => {
+  await loadDropdownPage(
+    server,
+    page,
+    `
+    <Dropdown name="all_books" title="All Books" multiple=true selectAllByDefault=true>
+      <DropdownOption value="open" valueLabel="Has open AR" />
+      <DropdownOption value="past_due" valueLabel="Has past due AR" />
+      <DropdownOption value="all" valueLabel="All customers" />
+    </Dropdown>
+  `,
+  )
+
+  await page.getByRole('combobox', {name: 'All Books'}).click()
+  await expect(page.getByRole('listbox').locator('.dropdown-option.is-selected')).toHaveCount(3)
+  await lockOpenDropdownWidth(page)
+  await expect(page.getByRole('listbox')).screenshot('dropdown-manual-select-all-default')
+})
+
 test('dropdown supports manual options and labelField mapping', async ({server, page}) => {
   server.mockFile(
     '/index.md',

--- a/ui/tests/snapshots/inputs.test.ts/dropdown-manual-select-all-default.png
+++ b/ui/tests/snapshots/inputs.test.ts/dropdown-manual-select-all-default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7416b43ebfa8ad086f5e6c14d2fe1a7e5e0da0ed0e208d4a47a37656f31c92d
+size 9385


### PR DESCRIPTION
Keep expanding selectAllByDefault while manual options register, without overriding an explicit default or URL selection. Cover static option registration with a screenshot test.