### PR TITLE
Share CLI schema inspection with Graphene Cloud

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -9,14 +9,15 @@ import {fileURLToPath} from 'url'
 import {config, loadConfig, setGlobalConfig} from '../lang/config.ts'
 import {analyzeWorkspace, getFile, loadWorkspace, toSql, type Query} from '../lang/core.ts'
 import {rowsToCsv} from '../lang/csv.ts'
-import {parseWarehouseFieldType, type AnalysisResult} from '../lang/types.ts'
-import {checkCloudAuth, loginPkce, makeAccessToken} from './auth.ts'
+import {type AnalysisResult} from '../lang/types.ts'
+import {authenticatedFetch, checkCloudAuth, loginPkce, makeAccessToken} from './auth.ts'
 import {getGrapheneCache, runServeInBackground, stopGrapheneIfRunning} from './background.ts'
 import {check} from './check.ts'
 import {getConnection, runQuery} from './connections/index.ts'
 import {installBrowser} from './installBrowser.ts'
 import {printDiagnostics, printTable} from './printer.ts'
 import {pageUrlForMd, sendToPage} from './run.ts'
+import {inspectSchema, printSchemaInspection, type SchemaInspection} from './schemaInspection.ts'
 import {CliTelemetry, getPresentFlags, type TelemetryCommand} from './telemetry/index.ts'
 import {checkForUpdate, showCachedUpdateNotice} from './updateNotifier.ts'
 
@@ -131,57 +132,25 @@ program.command('schema')
   .argument('[schema | table]', 'Optional schema or table name to describe')
   .action(
     withTelemetry('schema', async (_exit, tableArg: string) => {
-      let connection = await getConnection()
-      try {
-        let datasets = await connection.listDatasets()
-        let matchedDataset = tableArg ? findCaseInsensitive(datasets, tableArg) : null
-
-        // If there's no configured namespace and more than one dataset, list the datasets.
-        if (!tableArg && !config.defaultNamespace && datasets.length > 1) {
-          return console.log(`Datasets available:\n${datasets.join('\n')}`)
-        }
-
-        // figure out if you're wanting to list tables in a schema/dataset
-        let dsToList: string | null = null
-        let parts = tableArg ? tableArg.split('.') : []
-
-        if (tableArg && connection.listSchemas && parts.length == 1 && matchedDataset) {
-          let schemas = await connection.listSchemas(matchedDataset)
-          return console.log(`Schemas in ${matchedDataset}:\n${schemas.join('\n')}`)
-        }
-
-        if (matchedDataset)
-          dsToList = matchedDataset // you gave the name of a dataset
-        else if (!tableArg && config.defaultNamespace)
-          dsToList = config.defaultNamespace // default namespace configured
-        else if (!tableArg && datasets.length == 1)
-          dsToList = datasets[0] // only one dataset, and no args
-        else if (!tableArg && config.dialect == 'duckdb') dsToList = '<default>'
-        else if (tableArg && config.motherduck && parts.length == 2) dsToList = tableArg
-        else if (tableArg && config.dialect == 'snowflake' && parts.length == 2) {
-          let db = findCaseInsensitive(datasets, parts[0]) || parts[0]
-          dsToList = `${db}.${parts.slice(1).join('.')}`
-        }
-
-        if (dsToList) {
-          let tables = await connection.listTables(dsToList)
-          return console.log(`Tables${dsToList ? ` in ${dsToList}` : ''}:\n${tables.join('\n')}`)
-        }
-
-        // otherwise, assume you're wanting to see tables
-        let cols = await connection.describeTable(tableArg)
-        let tableLabel = config.dialect == 'snowflake' ? String(tableArg || '').toLowerCase() : tableArg
-        if (!cols.length) return console.log(`Table ${tableLabel} not found`)
-        console.log(`table ${tableLabel} (`)
-        cols.forEach(col => {
-          let parsed = parseWarehouseFieldType(col.dataType)
-          let renderedType = parsed.displayType || col.dataType
-          console.log(`  ${col.name} ${renderedType}`)
+      let result: SchemaInspection
+      if (config.cloud) {
+        await checkCloudAuth()
+        let repoSlug = new URL(config.cloud).pathname.replace(/^\/+|\/+$/g, '')
+        let response = await authenticatedFetch('/_api/schema', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({repoSlug, table: tableArg}),
         })
-        console.log(')')
-      } finally {
-        await connection.close()
+        result = await response.json() as SchemaInspection
+      } else {
+        let connection = await getConnection()
+        try {
+          result = await inspectSchema(connection, config, tableArg)
+        } finally {
+          await connection.close()
+        }
       }
+      printSchemaInspection(result)
     }),
   )
 
@@ -320,10 +289,6 @@ function renderSql(query: Query, inputs: Record<string, string | string[]>, exit
     else console.error(String(err))
     return exit(1)
   }
-}
-
-function findCaseInsensitive(values: string[], needle: string): string | null {
-  return values.find(value => value.toLowerCase() == needle.toLowerCase()) || null
 }
 
 class CliExit {}

--- a/cli/connections/bigQuery.ts
+++ b/cli/connections/bigQuery.ts
@@ -14,12 +14,12 @@ export class BigQueryConnection implements QueryConnection {
   protected readonly projectId: string
   protected readonly defaultNamespace?: string
 
-  constructor(options: BigQueryOptions = {}) {
+  constructor(options: BigQueryOptions = {}, defaultNamespace = config.defaultNamespace) {
     options.projectId ||= config.bigquery?.projectId
     if (!options.projectId) throw new Error('projectId must be set in config or provided in service account credentials')
     this.projectId = options.projectId
     this.client = new BigQuery({...options, userAgent: 'Graphene'})
-    this.defaultNamespace = config.defaultNamespace
+    this.defaultNamespace = defaultNamespace
   }
 
   async runQuery(sql: string, options?: QueryOptions): Promise<QueryResult> {

--- a/cli/connections/index.ts
+++ b/cli/connections/index.ts
@@ -64,12 +64,12 @@ export async function runQuery(sql: string, options: RunQueryOptions = {}): Prom
     if (cacheControl) headers['Cache-Control'] = cacheControl
 
     // A Cloud URL path selects the repo to query, e.g. https://example.graphenedata.com/nba proxies through the `nba` repo connection.
-    let repoId = new URL(config.cloud).pathname.replace(/^\/+|\/+$/g, '')
+    let repoSlug = new URL(config.cloud).pathname.replace(/^\/+|\/+$/g, '')
 
     let resp = await authenticatedFetch('/_api/query', {
       method: 'POST',
       headers,
-      body: JSON.stringify({sql, params, repoId}),
+      body: JSON.stringify({sql, params, repoSlug}),
     })
     let json = await resp.json()
     if (!Array.isArray(json.rows)) throw new Error('Query response did not include rows')

--- a/cli/schema.test.ts
+++ b/cli/schema.test.ts
@@ -4,6 +4,8 @@ import * as path from 'node:path'
 import {config, loadConfig, normalizeConfig, setGlobalConfig, type Config} from '../lang/config.ts'
 import {formatType, parseWarehouseFieldType} from '../lang/types.ts'
 import {localDbOptions as clickHouseOptions} from './connections/clickhouse.ts'
+import {type QueryConnection} from './connections/types.ts'
+import {inspectSchema} from './schemaInspection.ts'
 import {expect, test} from './testFixtures.ts'
 
 const dir = path.resolve(import.meta.url.replace('file://', ''), '../')
@@ -36,6 +38,24 @@ function parseSchemaOutput(stdout: string): string[] {
     .map(line => line.trim())
     .filter(line => line && !line.endsWith(':')) // filter out headers like "Datasets available:"
 }
+
+describe('schema inspection', () => {
+  test('distinguishes Snowflake database schemas from namespace-qualified tables', async () => {
+    let connection = {
+      listDatasets: vi.fn().mockResolvedValue(['ANALYTICS']),
+      listTables: vi.fn().mockResolvedValue(['public.orders']),
+      describeTable: vi.fn().mockResolvedValue([{name: 'id', dataType: 'NUMBER'}]),
+      close: vi.fn(),
+      runQuery: vi.fn(),
+    } as QueryConnection
+    let context = {dialect: 'snowflake', defaultNamespace: 'ANALYTICS.PUBLIC'}
+
+    await expect(inspectSchema(connection, context, 'analytics.public')).resolves.toMatchObject({kind: 'tables'})
+    await expect(inspectSchema(connection, context, 'public.orders')).resolves.toMatchObject({kind: 'table'})
+    expect(connection.listTables).toHaveBeenCalledWith('ANALYTICS.public')
+    expect(connection.describeTable).toHaveBeenCalledWith('ANALYTICS.public.orders')
+  })
+})
 
 describe('duckdb', () => {
   test('uses DuckDB SQL semantics for MotherDuck config', () => {

--- a/cli/schemaInspection.ts
+++ b/cli/schemaInspection.ts
@@ -1,0 +1,74 @@
+// Schema inspection is shared by the local CLI and Graphene Cloud so both paths interpret
+// database hierarchies identically. The caller owns the warehouse connection and renders the result.
+import {parseWarehouseFieldType} from '../lang/types.ts'
+import {type QueryConnection, type SchemaColumn} from './connections/types.ts'
+
+export interface SchemaContext {
+  dialect: string
+  defaultNamespace?: string
+}
+
+export type SchemaInspection =
+  | {kind: 'datasets'; datasets: string[]}
+  | {kind: 'schemas'; dataset: string; schemas: string[]}
+  | {kind: 'tables'; dataset: string; tables: string[]}
+  | {kind: 'table'; table: string; columns: SchemaColumn[]}
+
+// Resolve whether the user requested datasets, schemas, tables, or columns, then inspect the warehouse.
+export async function inspectSchema(connection: QueryConnection, context: SchemaContext, tableArg?: string): Promise<SchemaInspection> {
+  let datasets = await connection.listDatasets()
+  let matchedDataset = tableArg ? findCaseInsensitive(datasets, tableArg) : null
+
+  if (!tableArg && !context.defaultNamespace && datasets.length > 1) return {kind: 'datasets', datasets}
+
+  let dataset: string | null = null
+  let parts = tableArg ? tableArg.split('.') : []
+
+  if (tableArg && connection.listSchemas && parts.length == 1 && matchedDataset) {
+    return {kind: 'schemas', dataset: matchedDataset, schemas: await connection.listSchemas(matchedDataset)}
+  }
+
+  if (matchedDataset) dataset = matchedDataset
+  else if (!tableArg && context.defaultNamespace) dataset = context.defaultNamespace
+  else if (!tableArg && datasets.length == 1) dataset = datasets[0]
+  else if (!tableArg && context.dialect == 'duckdb') dataset = '<default>'
+  else if (tableArg && context.dialect == 'duckdb' && datasets.length && parts.length == 2) dataset = tableArg
+  else if (tableArg && context.dialect == 'snowflake' && parts.length == 2) {
+    let database = findCaseInsensitive(datasets, parts[0])
+    if (database) dataset = `${database}.${parts.slice(1).join('.')}`
+  }
+
+  if (dataset) return {kind: 'tables', dataset, tables: await connection.listTables(dataset)}
+
+  let target = qualifyTable(tableArg || '', context)
+  let columns = await connection.describeTable(target)
+  let table = context.dialect == 'snowflake' ? String(tableArg || '').toLowerCase() : String(tableArg || '')
+  return {kind: 'table', table, columns}
+}
+
+// Render structured inspection results in the established gsql-like CLI format.
+export function printSchemaInspection(result: SchemaInspection): void {
+  if (result.kind == 'datasets') return console.log(`Datasets available:\n${result.datasets.join('\n')}`)
+  if (result.kind == 'schemas') return console.log(`Schemas in ${result.dataset}:\n${result.schemas.join('\n')}`)
+  if (result.kind == 'tables') return console.log(`Tables in ${result.dataset}:\n${result.tables.join('\n')}`)
+  if (!result.columns.length) return console.log(`Table ${result.table} not found`)
+
+  console.log(`table ${result.table} (`)
+  result.columns.forEach(column => {
+    let parsed = parseWarehouseFieldType(column.dataType)
+    console.log(`  ${column.name} ${parsed.displayType || column.dataType}`)
+  })
+  console.log(')')
+}
+
+// Apply the configured namespace when connectors cannot infer it from an unqualified table name.
+function qualifyTable(table: string, context: SchemaContext): string {
+  if (!context.defaultNamespace) return table
+  if (!table.includes('.')) return `${context.defaultNamespace}.${table}`
+  if (context.dialect == 'snowflake' && table.split('.').length == 2) return `${context.defaultNamespace.split('.')[0]}.${table}`
+  return table
+}
+
+function findCaseInsensitive(values: string[], needle: string): string | null {
+  return values.find(value => value.toLowerCase() == needle.toLowerCase()) || null
+}

--- a/cli/testFixtures.ts
+++ b/cli/testFixtures.ts
@@ -28,7 +28,7 @@ class ProcessExit extends Error {
 }
 
 // Runs the public Commander program in-process while capturing the same stdout, stderr, and exit code a user sees.
-async function runCli(args: string[], invocationConfig: Config, options: RunCliOptions = {}): Promise<RunCliResult> {
+export async function runCliCommand(args: string[], invocationConfig: Config, options: RunCliOptions = {}): Promise<RunCliResult> {
   let stdout = ''
   let stderr = ''
   let originalConfig = structuredClone(config)
@@ -85,5 +85,5 @@ afterEach(resetDuckDbInstanceForTests)
 
 export const test = base.extend<{runCli: RunCli}>({
   // eslint-disable-next-line no-empty-pattern
-  runCli: ({}, use) => use(runCli),
+  runCli: ({}, use) => use(runCliCommand),
 })


### PR DESCRIPTION
Extract schema inspection and rendering into schemaInspection.ts so Cloud can use the same database hierarchy behavior. Route cloud-configured schema commands to the authenticated API and apply default namespaces to table descriptions.