### PR TITLE
Add hideInNav page frontmatter

### DIFF
--- a/cli/mdCompile.test.ts
+++ b/cli/mdCompile.test.ts
@@ -2,7 +2,7 @@
 import {compile} from 'mdsvex'
 import {compile as compileSvelte} from 'svelte/compiler'
 
-import {extractFrontmatter, extractPageTitle, injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
+import {extractFrontmatter, injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 
 async function compileMarkdownPage(src: string) {
   let out = await compile(src, {extensions: ['.md'], remarkPlugins, rehypePlugins, filename: '/tmp/repro.md'})
@@ -14,32 +14,37 @@ async function compileMarkdownPage(src: string) {
 }
 
 describe('extractFrontmatter', () => {
-  it('parses title', () => {
-    let fm = extractFrontmatter('---\ntitle: My Page\nlayout: dashboard\n---\n\n# Hello')
-    expect(fm).toEqual({title: 'My Page'})
+  it('uses frontmatter title and navigation visibility together', () => {
+    let metadata = extractFrontmatter('---\ntitle: My Page\nhideInNav: true\nlayout: dashboard\n---\n\n# Hello')
+    expect(metadata).toEqual({title: 'My Page', hideInNav: true, layout: 'dashboard'})
   })
 
-  it('returns empty object when no frontmatter', () => {
-    expect(extractFrontmatter('# Just a heading')).toEqual({})
+  it('only hides pages for the boolean true value', () => {
+    expect(extractFrontmatter('---\nhideInNav: false\n---')).toEqual({})
+    expect(extractFrontmatter('---\nhideInNav: "true"\n---')).toEqual({})
+  })
+
+  it('uses a static Markdown h1 without a frontmatter title', () => {
+    expect(extractFrontmatter('---\nhideInNav: true\n---\n# Detail Page')).toEqual({title: 'Detail Page', hideInNav: true})
+    expect(extractFrontmatter('Intro\n\n# Page title\n\nContent')).toEqual({title: 'Page title'})
+  })
+
+  it('extracts a scheduled value outside YAML parsing', () => {
+    let metadata = extractFrontmatter('---\nscheduled: "0 9 * * 1-5" @grant\n---\n# Report')
+    expect(metadata).toEqual({title: 'Report', scheduled: '"0 9 * * 1-5" @grant'})
+  })
+
+  it('rejects duplicate scheduled fields', () => {
+    expect(() => extractFrontmatter('---\nscheduled: "0 9 * * 1-5" @grant\nscheduled: "30 16 * * *" #operations\n---')).toThrow('Multiple scheduled fields are not supported')
   })
 
   it('handles leading whitespace', () => {
     expect(extractFrontmatter('\n---\ntitle: Trimmed\n---')).toEqual({title: 'Trimmed'})
   })
-})
-
-describe('extractPageTitle', () => {
-  it('uses frontmatter before a Markdown h1', () => {
-    expect(extractPageTitle('---\ntitle: Navigation title\n---\n# Page title')).toBe('Navigation title')
-  })
-
-  it('uses a Markdown h1 without frontmatter', () => {
-    expect(extractPageTitle('Intro\n\n# Page title\n\nContent')).toBe('Page title')
-  })
 
   it('ignores dynamic and missing h1 titles', () => {
-    expect(extractPageTitle('# Report for {year}')).toBeUndefined()
-    expect(extractPageTitle('Content without a title')).toBeUndefined()
+    expect(extractFrontmatter('# Report for {year}')).toEqual({})
+    expect(extractFrontmatter('Content without a title')).toEqual({})
   })
 })
 

--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -87,25 +87,30 @@ export function componentNames() {
   return cachedComponentNames || []
 }
 
-export type PageFrontmatter = {title?: string}
+export type PageFrontmatter = {title?: string; hideInNav?: boolean; layout?: string; scheduled?: string}
 
-// Parse YAML frontmatter from the --- delimited block at the top of a markdown file.
+// Extract supported frontmatter without compiling the page. When frontmatter omits a title,
+// use the first static Markdown h1 so callers get all page discovery metadata in one pass.
 const frontmatterRe = /^---\s*\n([\s\S]*?)\n---(?:\n|$)/
 export function extractFrontmatter(contents: string): PageFrontmatter {
   let match = contents.trimStart().match(frontmatterRe)
-  if (!match) return {}
-  let raw = yaml.safeLoad(match[1]) as Record<string, any> | undefined
-  return {title: raw?.title ? String(raw.title) : undefined}
-}
+  let lines = match?.[1].split(/\r?\n/) || []
+  let scheduledLines = lines.filter(line => /^scheduled\s*:/i.test(line))
+  if (scheduledLines.length > 1) throw new Error('Multiple scheduled fields are not supported')
+  let scheduled = scheduledLines[0]?.replace(/^scheduled\s*:\s*/i, '').trim()
+  let yamlContents = lines.filter(line => !/^scheduled\s*:/i.test(line)).join('\n')
+  let raw = yamlContents ? yaml.safeLoad(yamlContents) as Record<string, any> | undefined : undefined
+  let metadata: PageFrontmatter = {}
 
-// Resolve the nav title without compiling the page. Frontmatter wins; otherwise use the first static Markdown h1.
-export function extractPageTitle(contents: string) {
-  let frontmatterTitle = extractFrontmatter(contents).title
-  if (frontmatterTitle) return frontmatterTitle
-
-  let markdownTitle = contents.match(/^#[ \t]+(.+?)[ \t]*#*[ \t]*$/m)?.[1]?.trim()
-  if (!markdownTitle || /[<{]/.test(markdownTitle)) return
-  return markdownTitle
+  if (raw?.title) metadata.title = String(raw.title)
+  else {
+    let markdownTitle = contents.match(/^#[ \t]+(.+?)[ \t]*#*[ \t]*$/m)?.[1]?.trim()
+    if (markdownTitle && !/[<{]/.test(markdownTitle)) metadata.title = markdownTitle
+  }
+  if (raw?.hideInNav === true) metadata.hideInNav = true
+  if (raw?.layout) metadata.layout = String(raw.layout)
+  if (scheduled) metadata.scheduled = scheduled
+  return metadata
 }
 
 export const remarkPlugins: Array<Plugin> = [extractQueries, escapeAngles]

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -15,7 +15,7 @@ import {config} from '../lang/config.ts'
 import {analyzeWorkspace, loadWorkspace, toSql} from '../lang/core.ts'
 import {grapheneCsp} from '../ui/csp.ts'
 import {runQuery} from './connections/index.ts'
-import {extractPageTitle, injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
+import {extractFrontmatter, injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 import {missingMockFiles, mockFileMap} from './mockFiles.ts'
 import {runVitePlugin} from './run.ts'
 import {getWorkspaceScanCounts, type CliTelemetry} from './telemetry/index.ts'
@@ -271,7 +271,7 @@ function fixHmrForFailedModules() {
 // Also tracks all the md files in the workspace to populate the nav sidebar
 let workspaceLoadPromise: Promise<void> | undefined
 let workspaceFiles: WorkspaceFileInput[] = []
-let mdFiles: {path: string; title?: string}[] = []
+let mdFiles: {path: string; title?: string; hideInNav?: boolean}[] = []
 function updateWorkspacePlugin(telemetry?: CliTelemetry) {
   return {
     name: 'updateWorkspace',
@@ -286,20 +286,20 @@ function updateWorkspacePlugin(telemetry?: CliTelemetry) {
       // in tests, inject mock files into the nav.
       // we do this on `load` as each test doesn't always refresh the workspace
       // TODO, we should prob inject these into `loadWorkspace`, then we wouldn't need this block at all
-      let res = mdFiles.filter(file => !missingMockFiles.has(file.path))
+      let pages = mdFiles.filter(file => !missingMockFiles.has(file.path))
       if (process.env.NODE_ENV == 'test') {
         for (let [path, contents] of Object.entries(mockFileMap)) {
           if (missingMockFiles.has(path)) continue
-          let mockFile = {path, title: extractPageTitle(contents)}
-          let idx = res.findIndex(file => file.path == path)
-          if (idx >= 0) res.splice(idx, 1, mockFile)
-          else res.push(mockFile)
+          let mockFile = {path, ...extractFrontmatter(contents)}
+          let idx = pages.findIndex(file => file.path == path)
+          if (idx >= 0) pages.splice(idx, 1, mockFile)
+          else pages.push(mockFile)
         }
       }
 
       return `
         export const projectName = ${JSON.stringify(config.projectName)};
-        export default ${JSON.stringify(res)}
+        export default ${JSON.stringify(pages)}
       `
     },
     configureServer: (s: ViteDevServer) => {
@@ -314,8 +314,8 @@ function updateWorkspacePlugin(telemetry?: CliTelemetry) {
         })()
         await workspaceLoadPromise
 
-        // store md file path/title so we can serve it as virtual:nav for the sidebar
-        mdFiles = workspaceFiles.filter(file => file.path.endsWith('.md')).map(f => ({path: f.path, title: extractPageTitle(f.contents)}))
+        // Store every Markdown page and its navigation metadata for the app shell.
+        mdFiles = workspaceFiles.filter(file => file.path.endsWith('.md')).map(file => ({path: file.path, ...extractFrontmatter(file.contents)}))
 
         let mod = s.moduleGraph.getModuleById('\0virtual:nav')
         if (!mod) return

--- a/docs/base.md
+++ b/docs/base.md
@@ -93,6 +93,7 @@ Use a Markdown h1 to display a page title. Automatically sets the page's title i
 
 You can add YAML frontmatter at the top of a page. The following attributes are supported:
 - `title`: sets the title of the page in navigation. Used if the page has no h1, or to override the title used in the nav.
+- `hideInNav`: set to `true` to exclude the page from the sidebar. The page remains available at its normal URL, so other pages can link to it for detail or drill-down views.
 - `layout`: `notebook` is the default, good for prose interspersed with charts. `dashboard` has a wider max-width, for chart-heavy pages with lots of `<Row>`s.
 
 ## Viz and display components

--- a/ui/internal/PageNavGroup.svelte
+++ b/ui/internal/PageNavGroup.svelte
@@ -14,13 +14,14 @@
   let treeSignature = $state('')
   let lastCurrent = $state('')
 
-  let normalizedFiles = $derived((files || []).map(f => f.path))
-  let titlesByPath = $derived(Object.fromEntries((files || []).filter(f => !!f.title).map(f => [f.path, f.title])))
+  let visibleFiles = $derived((files || []).filter(f => !f.hideInNav))
+  let normalizedFiles = $derived(visibleFiles.map(f => f.path))
+  let titlesByPath = $derived(Object.fromEntries(visibleFiles.filter(f => !!f.title).map(f => [f.path, f.title])))
 
   let normalizedCurrent = $derived(normalizedFiles.find(f => pathToRoute(f) === ($route.replace(/\/+$/, '') || '/')) || '')
 
   $effect(() => {
-    let nextSignature = (files || []).map(f => `${f.path}:${f.title || ''}`).join('|')
+    let nextSignature = visibleFiles.map(f => `${f.path}:${f.title || ''}`).join('|')
     if (nextSignature !== treeSignature) {
       treeSignature = nextSignature
       tree = buildTree(normalizedFiles, titlesByPath)

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -20,6 +20,7 @@ test('loads markdown files', async ({server, page}) => {
   `,
   )
   server.mockFile('delays.md', '---\ntitle: Delay Deep-Dive\n---\n# Delays')
+  server.mockFile('flight-detail.md', '---\nhideInNav: true\n---\n# Flight Detail')
 
   await page.goto(server.url() + '/')
   await expect(page).toHaveTitle('Flight Delay Analysis - example-flights')
@@ -28,9 +29,17 @@ test('loads markdown files', async ({server, page}) => {
   await expect(nav).toBeVisible()
   await expect(nav.getByRole('link', {name: 'Flight Delay Analysis'})).toHaveAttribute('aria-current', 'page')
   await expect(nav.getByRole('link', {name: 'Delay Deep-Dive'})).toBeVisible()
+  await expect(nav.getByRole('link', {name: 'Flight Detail'})).toHaveCount(0)
   await expect(page.locator('main svg').first()).toBeVisible()
   await expect(page.locator('main#content')).toHaveCSS('max-width', '1200px')
   await expect(page).screenshot('loads-markdown-files')
+})
+
+test('routes pages hidden from navigation', async ({server, page}) => {
+  server.mockFile('flight-detail.md', '---\nhideInNav: true\n---\n# Flight Detail')
+
+  await page.goto(server.url() + '/flight-detail')
+  await expect(page.getByRole('heading', {level: 1, name: 'Flight Detail'})).toBeVisible()
 })
 
 test('serves the cloud CSP unless disabled', async ({server, page}) => {


### PR DESCRIPTION
Centralize supported page frontmatter parsing, include hidden pages in the frontend page list, and filter them only when building the sidebar. Document the new option.