### PR TITLE
Tighten horizontal bar chart title spacing

### DIFF
--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -395,7 +395,8 @@ function computeTitleLegendAndGridPadding(config: NormalConfig) {
 
   if (title?.text) {
     legend.top = numericOffset(legend.top, 18)
-    grid.top = numericOffset(grid.top, 28)
+    // Horizontal bars are already inset from the grid boundary, so the standard title offset leaves a large visual gap.
+    grid.top = numericOffset(grid.top, isHorizontalBar(config) ? 12 : 28)
   }
 
   if (legend?.show) {

--- a/ui/tests/snapshots/run-examples.test.ts/example-flights-pages-delay-factors.png
+++ b/ui/tests/snapshots/run-examples.test.ts/example-flights-pages-delay-factors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d8783bd43f947a777718777d711d0ddaf9267c7a31a4e995fcf07fa9cf0a99d
-size 111258
+oid sha256:8936e8da030c57faf44fea1dff4d4cd7806c0ba29b51edfc6a21da574fe51c41
+size 111104

--- a/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart-auto-height.png
+++ b/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart-auto-height.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc644401070252a488ce809b0469b5912fbc1399f80c53bee7ce8ee67d6aad76
-size 19856
+oid sha256:5f58539caa66aac46cdd98881e07a84db77aa3c25cc15d4e679bab9114c76d09
+size 22737

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -272,7 +272,7 @@ test('horizontal bar chart auto-expands height for many categories', async ({mou
     {name: 'value', type: scalarType('number')},
   ]
 
-  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'value', y: 'category'})
+  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'value', y: 'category', title: 'Values by Category'})
   await expect(chart.el).screenshot('horizontal-bar-chart-auto-height')
 })
 


### PR DESCRIPTION
Use the category-axis inset to reduce unnecessary top grid padding on horizontal bar charts. Cover titled, auto-height charts with a screenshot regression test.