### PR TITLE
Avoid button as tooltip anchor

### DIFF
--- a/ui/components/BigValue.svelte
+++ b/ui/components/BigValue.svelte
@@ -37,7 +37,7 @@
   {/snippet}
 
   {#if typeof description === 'string'}
-    <Tooltip text={description} label={`About ${title || value}`}>{@render content()}</Tooltip>
+    <Tooltip text={description}>{@render content()}</Tooltip>
   {:else}
     {@render content()}
   {/if}

--- a/ui/components/Tooltip.svelte
+++ b/ui/components/Tooltip.svelte
@@ -1,20 +1,17 @@
 <script lang="ts">
-  // Shared tooltip for compact contextual help. The popup uses viewport coordinates so
-  // scroll containers do not clip it, and mouse and keyboard users get the same content.
+  // Shared hover tooltip for compact contextual help. The popup uses viewport coordinates
+  // so scroll containers do not clip it.
   import {tick, type Snippet} from 'svelte'
 
-  let {text, children, label, placement = 'auto'}: {text: string; children: Snippet; label?: string; placement?: 'auto' | 'top'} = $props()
+  let {text, children, placement = 'auto'}: {text: string; children: Snippet; placement?: 'auto' | 'top'} = $props()
 
   let trigger: HTMLElement
   let popup = $state<HTMLElement>()
   let visible = $state(false)
-  let hovered = false
-  let focused = false
   let left = $state(0)
   let top = $state(0)
   let arrowLeft = $state(0)
   let renderedPlacement = $state<'top' | 'bottom'>('top')
-  let tooltipId = `tooltip-${Math.random().toString(36).slice(2)}`
 
   // Measure after rendering, then keep the popup above its trigger and inside the viewport.
   async function show() {
@@ -34,11 +31,6 @@
     top = Math.min(Math.max(8, preferredTop), maxTop)
   }
 
-  function updateVisibility() {
-    if (hovered || focused) void show()
-    else visible = false
-  }
-
   // Keep the shifted position valid while its anchor or viewport moves.
   $effect(() => {
     if (!visible) return
@@ -52,29 +44,18 @@
   })
 </script>
 
-<button
-  type="button"
-  class="tooltip-trigger"
-  bind:this={trigger}
-  aria-label={label}
-  aria-describedby={tooltipId}
-  onmouseenter={() => { hovered = true; updateVisibility() }}
-  onmouseleave={() => { hovered = false; updateVisibility() }}
-  onfocus={() => { focused = true; updateVisibility() }}
-  onblur={() => { focused = false; updateVisibility() }}
->
+<span class="tooltip-trigger" role="presentation" bind:this={trigger} onmouseenter={show} onmouseleave={() => visible = false}>
   {@render children()}
-</button>
+</span>
 
 {#if visible}
-  <span bind:this={popup} id={tooltipId} class={`tooltip-popup tooltip-popup--${renderedPlacement}`} role="tooltip" style={`left:${left}px;top:${top}px;--arrow-offset:${arrowLeft}px`}>
+  <span bind:this={popup} class={`tooltip-popup tooltip-popup--${renderedPlacement}`} role="tooltip" style={`left:${left}px;top:${top}px;--arrow-offset:${arrowLeft}px`}>
     {text}
   </span>
 {/if}
 
 <style>
-  .tooltip-trigger {display: inline-block; max-width: 100%; padding: 0; border: 0; background: transparent; color: inherit; font: inherit; letter-spacing: inherit; text-align: inherit; cursor: inherit;}
-  .tooltip-trigger:focus-visible {outline: 2px solid currentColor; outline-offset: 2px; border-radius: 2px;}
+  .tooltip-trigger {display: inline-block; max-width: 100%;}
   .tooltip-popup {position: fixed; z-index: 1000; box-sizing: border-box; width: max-content; max-width: min(280px, calc(100vw - 16px)); padding: 8px 10px; border-radius: 6px; background: #24292f; box-shadow: 0 3px 10px rgb(0 0 0 / 18%); color: white; font-size: 13px; font-weight: 400; line-height: 1.4; letter-spacing: normal; text-align: left; text-transform: none; white-space: normal; pointer-events: none;}
   .tooltip-popup::after {position: absolute; content: '';}
   .tooltip-popup--top::after {top: 100%; left: var(--arrow-offset); border: 5px solid transparent; border-top-color: #24292f; transform: translateX(-50%);}

--- a/ui/tests/bigValue.test.ts
+++ b/ui/tests/bigValue.test.ts
@@ -12,7 +12,7 @@ test('big value', async ({mount, sharedPage}) => {
   await component.evaluate(element => element.style.minHeight = '120px')
   await expect(sharedPage.getByText('Sales')).toBeVisible()
   await expect(sharedPage.getByText('$611.1k')).toBeVisible()
-  await sharedPage.getByRole('button', {name: 'About Sales'}).hover()
+  await sharedPage.getByText('Sales').hover()
   await expect(component).screenshot('big-value')
 })
 

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -474,7 +474,7 @@ test('hidden input applies URL values and defaults without rendering a control',
   await page.goto(server.url() + '/')
   await waitForGrapheneLoad(page)
   expect(queryBodies.some(body => body.params.carrier === 'AA')).toBe(true)
-  await expect(page.locator('main#content .input-block')).toHaveCount(0)
+  await expect(page.locator('main#content').locator('input, button, select')).toHaveCount(0)
 })
 
 test('inputs sync url state on load, change, and reload', {timeout: 20000}, async ({server, page}) => {

--- a/ui/tests/table.test.ts
+++ b/ui/tests/table.test.ts
@@ -304,7 +304,7 @@ test('table attributes render grouped headers, wrapped titles, and row styling o
   let table = component.locator('table')
   await table.locator('tr:has(td)').first().waitFor()
   await expect(table.locator('tr:has(td)')).toHaveCount(4)
-  await table.getByRole('button', {name: 'Carrier'}).hover()
+  await table.getByText('Carrier', {exact: true}).hover()
   await expect(component.locator('.table-container')).screenshot('attribute-groups-and-styling')
 })
 


### PR DESCRIPTION
Render tooltip triggers as hover-only spans instead of focusable buttons, and update tooltip screenshot tests to hover their visible text.