### PR TITLE
Authenticated telemetry for Graphene cloud users

### DIFF
--- a/cli/auth.ts
+++ b/cli/auth.ts
@@ -44,6 +44,15 @@ async function readEntry(): Promise<Cred | null> {
   return store[config.root]
 }
 
+// Returns existing Cloud credentials for telemetry without refreshing them or making telemetry affect CLI behavior.
+export async function getTelemetryAuthorization(): Promise<string | undefined> {
+  if (process.env.GRAPHENE_TOKEN) return `Bearer ${process.env.GRAPHENE_TOKEN}`
+
+  let entry = await readEntry()
+  if (!entry?.access_token || entry.expires_at < Date.now()) return
+  return `Bearer ${entry.access_token}`
+}
+
 async function updateEntry(cred: Cred) {
   let store = await readStore()
   cred.refresh_token ||= store[config.root]?.refresh_token

--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -287,22 +287,24 @@ test('cli check a single gsql file', async ({runCli}) => {
 })
 
 describe('cli telemetry', () => {
-  test('sends telemetry to the configured endpoint', async ({runCli}) => {
+  test('sends Cloud identity context to the configured endpoint', async ({runCli}) => {
     let tmpDir = await createTelemetryProject('graphene-cli-telemetry-')
     let batches: any[] = []
+    let authorizations: (string | undefined)[] = []
     let server = createServer(async (req: IncomingMessage, res: ServerResponse<IncomingMessage>) => {
       let body = await readRequestBody(req)
       batches.push(JSON.parse(body))
+      authorizations.push(req.headers.authorization)
       res.statusCode = 204
       res.end()
     })
 
     try {
       let endpoint = await listen(server)
-      let res = await runCli(['compile', 'from flights select carrier'], configFor(tmpDir, {telemetry: true}), {
+      let res = await runCli(['compile', 'from flights select carrier'], configFor(tmpDir, {telemetry: true, cloud: `${endpoint}/flights`}), {
         env: {
           GRAPHENE_TELEMETRY_DISABLED: '0',
-          GRAPHENE_TELEMETRY_ENDPOINT: endpoint,
+          GRAPHENE_TOKEN: 'telemetry-token',
         },
       })
 
@@ -322,6 +324,8 @@ describe('cli telemetry', () => {
       expect(completed.command).toBe('compile')
       expect(completed.success).toBe(true)
       expect(completed.exit_code).toBe(0)
+      expect(events.every(event => event.repo_slug == 'flights')).toBe(true)
+      expect(authorizations.every(authorization => authorization == 'Bearer telemetry-token')).toBe(true)
 
       for (let batch of batches) {
         expect(batch).toMatchObject({events: expect.any(Array)})

--- a/cli/telemetry/README.md
+++ b/cli/telemetry/README.md
@@ -8,7 +8,7 @@ Telemetry is enabled when:
 - `GRAPHENE_TELEMETRY_DISABLED` is not set to `1`
 - `graphene.telemetry` is not set to `false` in project config
 
-The default endpoint is `https://app.graphenedata.com/cli-telemetry`. Tests and local development can override it with `GRAPHENE_TELEMETRY_ENDPOINT`.
+The default endpoint is `https://app.graphenedata.com/cli-telemetry`. Cloud projects use `/cli-telemetry` on their configured Cloud origin so Cloud can attribute authenticated events. Tests and local development can override it with `GRAPHENE_TELEMETRY_ENDPOINT`.
 
 Telemetry state persistence is best-effort. State is stored in the current project's `node_modules/.graphene/telemetry.json` when `node_modules` already exists. If the project cache cannot be read or written, command behavior should not change and install or upgrade lifecycle events are skipped.
 
@@ -18,6 +18,7 @@ Every event includes these fields:
 
 - `install_id`: A random UUID generated once and persisted in the local Graphene project cache. It identifies a project-local CLI installation, not a user account or machine owner.
 - `project_hash`: A SHA-256 hash of the nearest `package.json` `name`, prefixed with `graphene:` before hashing. This lets us distinguish projects without sending the raw package name.
+- `repo_slug`: For Cloud projects, the repo slug configured in the Cloud URL. Cloud resolves it only within the authenticated organization.
 - `cli_version`: The Graphene CLI version.
 - `timestamp`: The event time in ISO-8601 format.
 - `ci`: Whether the CLI appears to be running in CI.
@@ -121,6 +122,8 @@ Events are sent as HTTP `POST` requests with a JSON batch envelope:
 ```
 
 The client currently sends one event per request as `{events: [event]}`.
+
+Cloud projects attach an existing, unexpired login token or `GRAPHENE_TOKEN`. Telemetry never refreshes credentials or prompts for login. Cloud derives the user and organization from that token; missing or invalid credentials remain anonymous.
 
 Telemetry is best-effort:
 

--- a/cli/telemetry/index.ts
+++ b/cli/telemetry/index.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 import type {Config} from '../../lang/config.ts'
 import type {WorkspaceFileInput} from '../../lang/core.ts'
+import {getTelemetryAuthorization} from '../auth.ts'
 import type {TelemetryBatch, TelemetryCommand, TelemetryEvent, TelemetryEventName, TelemetryPayloads} from './types.ts'
 
 import {TelemetryStorage} from './storage.ts'
@@ -26,7 +27,7 @@ export class CliTelemetry {
   private cliVersion: string
   private endpoint: string
 
-  constructor(cfg: Config, cliVersion: string, endpoint = process.env.GRAPHENE_TELEMETRY_ENDPOINT || DEFAULT_TELEMETRY_ENDPOINT) {
+  constructor(cfg: Config, cliVersion: string, endpoint = process.env.GRAPHENE_TELEMETRY_ENDPOINT || telemetryEndpoint(cfg)) {
     this.cfg = cfg
     this.cliVersion = cliVersion
     this.endpoint = endpoint
@@ -62,6 +63,7 @@ export class CliTelemetry {
     return {
       install_id: this.installId,
       project_hash: this.projectHash,
+      repo_slug: this.cfg.cloud ? new URL(this.cfg.cloud).pathname.replace(/^\/+|\/+$/g, '') || undefined : undefined,
       cli_version: this.cliVersion,
       timestamp: new Date().toISOString(),
       ci: ci.isCI,
@@ -71,20 +73,27 @@ export class CliTelemetry {
   }
 
   private send(event: TelemetryEvent) {
-    let batch: TelemetryBatch = {events: [event]}
-    let controller = new AbortController()
-    let timeout = setTimeout(() => controller.abort(), 500)
-    timeout.unref?.()
+    void (async () => {
+      let batch: TelemetryBatch = {events: [event]}
+      let controller = new AbortController()
+      let timeout = setTimeout(() => controller.abort(), 500)
+      timeout.unref?.()
 
-    void fetch(this.endpoint, {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify(batch),
-      signal: controller.signal,
-    })
-      .catch(() => {})
-      .finally(() => clearTimeout(timeout))
+      let headers = new Headers({'Content-Type': 'application/json'})
+      let authorization = this.cfg.cloud ? await getTelemetryAuthorization() : undefined
+      if (authorization) headers.set('Authorization', authorization)
+
+      await fetch(this.endpoint, {method: 'POST', headers, body: JSON.stringify(batch), signal: controller.signal})
+        .catch(() => {})
+        .finally(() => clearTimeout(timeout))
+    })().catch(() => {})
   }
+}
+
+// Cloud projects report to their Cloud origin so the server can validate their existing credentials.
+function telemetryEndpoint(cfg: Config) {
+  if (!cfg.cloud) return DEFAULT_TELEMETRY_ENDPOINT
+  return new URL('/cli-telemetry', cfg.cloud).toString()
 }
 
 export function isTelemetryEnabled(config: Config, endpoint: string) {

--- a/cli/telemetry/types.ts
+++ b/cli/telemetry/types.ts
@@ -9,6 +9,7 @@ export interface TelemetryState {
 export interface CommonEventFields {
   install_id: string
   project_hash?: string
+  repo_slug?: string
   cli_version: string
   timestamp: string
   ci: boolean


### PR DESCRIPTION
For all other users, telemetry remains anonymous