### PR TITLE
Only use latin woff2 fonts

### DIFF
--- a/examples/flights/pages/delay_factors.md
+++ b/examples/flights/pages/delay_factors.md
@@ -6,7 +6,7 @@ layout: notebook
 
 Every frequent flyer has a pet theory. Pick the right airline. Avoid Chicago. Never fly a 20-year-old plane. These intuitions have just enough truth in them to survive, but they obscure which factors actually move the needle — and by how much.
 
-This is an analysis of FAA data covering roughly 345,000 U.S. commercial flights from 2000 to 2005. For each candidate factor — airline, origin airport, day of the week, and time of day — I measured how much of the variance in individual departure delays each one explains (η², or eta-squared). A high η² means knowing that factor genuinely helps predict whether _your_ flight will be late.
+This is an analysis of FAA data covering roughly 345,000 U.S. commercial flights from 2000 to 2005. For each candidate factor — airline, origin airport, day of the week, and time of day — I measured how much of the variance in individual departure delays each one explains. This statistic is called eta-squared. A high eta-squared value means knowing that factor genuinely helps predict whether _your_ flight will be late.
 
 ## One factor dwarfs the rest
 
@@ -51,7 +51,7 @@ order by eta_squared desc
   data=factor_importance
   x=eta_squared
   y=factor
-  title="Variance in departure delay explained by each factor (η²)"
+  title="Variance in departure delay explained by each factor (eta-squared)"
   height=240px
 />
 

--- a/ui/app.css
+++ b/ui/app.css
@@ -1,13 +1,18 @@
-@import '@fontsource/inter/400.css';
-@import '@fontsource/inter/600.css';
-@import '@fontsource/inter/700.css';
-@import '@fontsource/source-sans-3/400.css';
-@import '@fontsource/source-sans-3/600.css';
-@import '@fontsource/source-serif-4/400.css';
-@import '@fontsource/source-serif-4/400-italic.css';
-@import '@fontsource/source-serif-4/600.css';
-@import '@fontsource/source-serif-4/600-italic.css';
-@import '@fontsource/jetbrains-mono/400.css';
+@font-face { font-family: 'Inter'; font-style: normal; font-display: swap; font-weight: 400; src: url('@fontsource/inter/files/inter-latin-400-normal.woff2') format('woff2'); }
+@font-face { font-family: 'Inter'; font-style: italic; font-display: swap; font-weight: 400; src: url('@fontsource/inter/files/inter-latin-400-italic.woff2') format('woff2'); }
+@font-face { font-family: 'Inter'; font-style: normal; font-display: swap; font-weight: 600; src: url('@fontsource/inter/files/inter-latin-600-normal.woff2') format('woff2'); }
+@font-face { font-family: 'Inter'; font-style: italic; font-display: swap; font-weight: 600; src: url('@fontsource/inter/files/inter-latin-600-italic.woff2') format('woff2'); }
+@font-face { font-family: 'Inter'; font-style: normal; font-display: swap; font-weight: 700; src: url('@fontsource/inter/files/inter-latin-700-normal.woff2') format('woff2'); }
+@font-face { font-family: 'Inter'; font-style: italic; font-display: swap; font-weight: 700; src: url('@fontsource/inter/files/inter-latin-700-italic.woff2') format('woff2'); }
+@font-face { font-family: 'Source Sans 3'; font-style: normal; font-display: swap; font-weight: 400; src: url('@fontsource/source-sans-3/files/source-sans-3-latin-400-normal.woff2') format('woff2'); }
+@font-face { font-family: 'Source Sans 3'; font-style: italic; font-display: swap; font-weight: 400; src: url('@fontsource/source-sans-3/files/source-sans-3-latin-400-italic.woff2') format('woff2'); }
+@font-face { font-family: 'Source Sans 3'; font-style: normal; font-display: swap; font-weight: 600; src: url('@fontsource/source-sans-3/files/source-sans-3-latin-600-normal.woff2') format('woff2'); }
+@font-face { font-family: 'Source Sans 3'; font-style: italic; font-display: swap; font-weight: 600; src: url('@fontsource/source-sans-3/files/source-sans-3-latin-600-italic.woff2') format('woff2'); }
+@font-face { font-family: 'Source Serif 4'; font-style: normal; font-display: swap; font-weight: 400; src: url('@fontsource/source-serif-4/files/source-serif-4-latin-400-normal.woff2') format('woff2'); }
+@font-face { font-family: 'Source Serif 4'; font-style: italic; font-display: swap; font-weight: 400; src: url('@fontsource/source-serif-4/files/source-serif-4-latin-400-italic.woff2') format('woff2'); }
+@font-face { font-family: 'Source Serif 4'; font-style: normal; font-display: swap; font-weight: 600; src: url('@fontsource/source-serif-4/files/source-serif-4-latin-600-normal.woff2') format('woff2'); }
+@font-face { font-family: 'Source Serif 4'; font-style: italic; font-display: swap; font-weight: 600; src: url('@fontsource/source-serif-4/files/source-serif-4-latin-600-italic.woff2') format('woff2'); }
+@font-face { font-family: 'JetBrains Mono'; font-style: normal; font-display: swap; font-weight: 400; src: url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2') format('woff2'); }
 
 :root {
   --font-prose: 'Source Serif 4', Georgia, 'Times New Roman', serif;

--- a/ui/tests/snapshots/run-examples.test.ts/example-flights-pages-delay-factors.png
+++ b/ui/tests/snapshots/run-examples.test.ts/example-flights-pages-delay-factors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8936e8da030c57faf44fea1dff4d4cd7806c0ba29b51edfc6a21da574fe51c41
-size 111104
+oid sha256:c685fd8af2f2b6b142fe88700392663d3d4d7a51d827fd52f7ff61de4e74fb7c
+size 113467


### PR DESCRIPTION
Our standalone html files were ~4MB, mostly because of fonts. We have a 4 different fonts, and each was including the full range of characters and file formats.

This reduction takes us down to 1.67MB, only 278k of which is fonts.

We could avoid embedding fonts entirely, or reduce the number we use, but idk that it's worth it.

The next biggest contributor is echarts itself, which is 1.1MB