### PR TITLE
Flip bar corner rounding for negative values

### DIFF
--- a/ui/component-utilities/dataShaping.ts
+++ b/ui/component-utilities/dataShaping.ts
@@ -16,7 +16,9 @@ export function applyMissingPointDefaults(config: NormalConfig, rows: Record<str
   let series = config.series
   if (series.length === 0 || rows.length === 0) return
 
-  let groups = new Map<string, {xField: string; splitFields: string[]; fills: Map<string, any>}>()
+  // Horizontal bars put the categories on y and the values on x, so the roles below are swapped.
+  let horizontal = isHorizontalBar(config)
+  let groups = new Map<string, {categoryField: string; splitFields: string[]; fills: Map<string, any>}>()
 
   for (let entry of series) {
     let splitFields = getSplitFields(entry)
@@ -24,38 +26,40 @@ export function applyMissingPointDefaults(config: NormalConfig, rows: Record<str
     let yField = getSeriesYField(entry)
     if (splitFields.length === 0 || !xField || !yField) continue
 
-    let key = `${xField}::${splitFields.join('::')}`
-    if (!groups.has(key)) groups.set(key, {xField, splitFields, fills: new Map()})
+    let categoryField = horizontal ? yField : xField
+    let valueField = horizontal ? xField : yField
+    let key = `${categoryField}::${splitFields.join('::')}`
+    if (!groups.has(key)) groups.set(key, {categoryField, splitFields, fills: new Map()})
 
     // This line is where chart-specific missing-value behavior is chosen.
     // See getMissingFillValueForSeries() below for the type mapping.
     let fillValue = getMissingFillValueForSeries(entry)
     let fills = groups.get(key)!.fills
 
-    // If multiple templates target the same y field, prefer zero over null.
+    // If multiple templates target the same value field, prefer zero over null.
     // (bar/area should win over plain line when mixed configs exist.)
-    if (!fills.has(yField) || fillValue === 0) fills.set(yField, fillValue)
+    if (!fills.has(valueField) || fillValue === 0) fills.set(valueField, fillValue)
   }
 
   for (let group of groups.values()) {
-    let xValues = distinctValues(rows, group.xField)
+    let categories = distinctValues(rows, group.categoryField)
     let splitValues = group.splitFields.map(field => distinctValues(rows, field))
-    if (xValues.length === 0 || splitValues.some(values => values.length === 0)) continue
+    if (categories.length === 0 || splitValues.some(values => values.length === 0)) continue
 
     let existing = new Set<string>()
     for (let row of rows) {
-      existing.add(compositeKey([row?.[group.xField], ...group.splitFields.map(field => row?.[field])]))
+      existing.add(compositeKey([row?.[group.categoryField], ...group.splitFields.map(field => row?.[field])]))
     }
 
-    for (let xValue of xValues) {
+    for (let category of categories) {
       for (let splitCombination of cartesianValues(splitValues)) {
-        if (existing.has(compositeKey([xValue, ...splitCombination]))) continue
+        if (existing.has(compositeKey([category, ...splitCombination]))) continue
 
-        let row: Record<string, any> = {[group.xField]: xValue}
+        let row: Record<string, any> = {[group.categoryField]: category}
         group.splitFields.forEach((field, index) => {
           row[field] = splitCombination[index]
         })
-        for (let [yField, fillValue] of group.fills.entries()) row[yField] = fillValue
+        for (let [valueField, fillValue] of group.fills.entries()) row[valueField] = fillValue
         rows.push(row)
       }
     }
@@ -200,7 +204,7 @@ export function inlineDataIntoSeries(config: NormalConfig, rows: Record<string, 
   }
 
   for (let series of config.series) {
-    if (series?.type !== 'bar' || !series?.stack || series?.data != null) continue
+    if (series?.type !== 'bar' || series?.data != null) continue
 
     let xField = getSeriesXField(series)
     let yField = getSeriesYField(series)
@@ -209,6 +213,13 @@ export function inlineDataIntoSeries(config: NormalConfig, rows: Record<string, 
 
     let seriesRows = datasetRows(series.datasetId)
     if (!seriesRows) continue
+
+    // Unstacked bars stand alone, so their rows map straight through without aligning to shared categories.
+    if (!series.stack) {
+      series.data = seriesRows.map(row => ({...row, value: [row[xField], row[yField]]}))
+      delete series.datasetId
+      continue
+    }
 
     let rowByCategory = new Map<string, Record<string, any>>()
     for (let row of seriesRows) {

--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -614,50 +614,48 @@ function addPieTooltips(config: NormalConfig, fields: Field[]) {
   }
 }
 
-// Round only the topmost (or rightmost for horizontal) visible non-zero bar in each stack slot.
+// Round the outermost visible non-zero bar in each stack slot, on both sides of the value axis.
+// Negative bars grow away from the baseline in the opposite direction, so their rounded corners flip too.
 function stackedBarCornerRadius(config: NormalConfig) {
   let horizontal = isHorizontalBar(config)
-  let cornerRadius = horizontal ? [0, 3, 3, 0] : [3, 3, 0, 0]
+  let positiveRadius = horizontal ? [0, 3, 3, 0] : [3, 3, 0, 0]
+  let negativeRadius = horizontal ? [3, 0, 0, 3] : [0, 0, 3, 3]
   let valueIndex = horizontal ? 0 : 1
   let selected = config.legend[0]?.selected || {}
   let stacks = new Map<string, SeriesWithGroupingHint[]>()
-
-  // Unstacked bars can use a single series-level radius.
-  for (let series of config.series) {
-    if (series?.type !== 'bar' || series?.stack || series?.itemStyle?.borderRadius != null) continue
-    series.itemStyle = {...series.itemStyle, borderRadius: cornerRadius}
-  }
 
   for (let [index, series] of config.series.entries()) {
     if (series?.type !== 'bar' || series?.itemStyle?.borderRadius != null || !Array.isArray(series.data)) continue
 
     let axisKey = `${Number(series.xAxisIndex ?? 0)}:${Number(series.yAxisIndex ?? 0)}`
-    let stackKey = series.stack ?? `__  graphene_unstacked_${index}`
+    let stackKey = series.stack ?? `__graphene_unstacked_${index}`
     let key = `${axisKey}::${stackKey}`
     let group = stacks.get(key) ?? []
     group.push(series)
     stacks.set(key, group)
   }
 
-  // For each stack slot, scan top-down and round the first visible non-zero segment.
+  // Positive and negative segments stack in opposite directions, so each side gets its own outermost segment.
+  // Scanning from the last series backwards finds it, since later series sit further from the baseline.
   for (let stackSeries of stacks.values()) {
     let maxPoints = Math.max(...stackSeries.map(series => (series.data as unknown[]).length), 0)
 
     for (let pointIndex = 0; pointIndex < maxPoints; pointIndex++) {
-      for (let seriesIndex = stackSeries.length - 1; seriesIndex >= 0; seriesIndex--) {
-        let series = stackSeries[seriesIndex]
-        if (selected[series.name || ''] === false) continue
+      let candidates = stackSeries
+        .map(series => ({series, point: (series.data as Record<string, any>[])[pointIndex]}))
+        .filter(({series, point}) => selected[series.name || ''] !== false && point && typeof point === 'object')
+        .map(entry => ({...entry, value: Number(entry.point?.value?.[valueIndex])}))
+        .filter(entry => Number.isFinite(entry.value) && entry.value !== 0)
+        .reverse()
 
-        let point = (series.data as unknown[])[pointIndex]
-        if (!point || typeof point !== 'object') continue
+      for (let sign of [1, -1]) {
+        let outermost = candidates.find(entry => Math.sign(entry.value) === sign)
+        if (!outermost) continue
 
-        let value = Number((point as Record<string, any>)?.value?.[valueIndex])
-        if (!Number.isFinite(value) || value === 0) continue
-
-        let typed = point as Record<string, any>
-        let existingItemStyle = typed.itemStyle && typeof typed.itemStyle === 'object' ? typed.itemStyle : {}
-        ;(series.data as Record<string, any>[])[pointIndex] = {...typed, itemStyle: {...existingItemStyle, borderRadius: cornerRadius}}
-        break
+        let {series, point} = outermost
+        let existingItemStyle = point.itemStyle && typeof point.itemStyle === 'object' ? point.itemStyle : {}
+        let borderRadius = sign > 0 ? positiveRadius : negativeRadius
+        ;(series.data as Record<string, any>[])[pointIndex] = {...point, itemStyle: {...existingItemStyle, borderRadius}}
       }
     }
   }

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-negative-stack-corners.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-negative-stack-corners.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4186c1c28c8c502fa8c3cfcf44b290461ae8755ea3c24b1299201e250db45336
+size 6688

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -192,6 +192,25 @@ test('bar chart supports multiple y fields', async ({mount, chart}) => {
   await expect(chart.el).screenshot('bar-chart-multiple-y')
 })
 
+test('stacked bar chart rounds positive and negative outer corners', async ({mount, chart}) => {
+  let rows = [
+    {category: 'Positive', segment: 'Base', value: 12},
+    {category: 'Positive', segment: 'Outer', value: 5},
+    {category: 'Negative', segment: 'Base', value: -12},
+    {category: 'Negative', segment: 'Outer', value: -5},
+    {category: 'Both', segment: 'Base', value: 10},
+    {category: 'Both', segment: 'Outer', value: -6},
+  ]
+  let fields = [
+    {name: 'category', type: scalarType('string')},
+    {name: 'segment', type: scalarType('string')},
+    {name: 'value', type: scalarType('number')},
+  ]
+
+  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'category', y: 'value', splitBy: 'segment', arrange: 'stack'})
+  await expect(chart.el).screenshot('bar-chart-negative-stack-corners')
+})
+
 test('bar chart supports expression fields with commas', async ({mount, chart}) => {
   let data = {
     rows: [


### PR DESCRIPTION
Bar corners were always rounded on the top (or right, for horizontal bars) regardless of sign. Each stack slot now rounds its outermost segment on both sides of the baseline, flipping the corners for the negative side.

Also fixes `applyMissingPointDefaults` treating `encode.x` as the category axis unconditionally, which crashed horizontal split bars with sparse data.

<details>
<summary>Test page — drop into <code>examples/flights/pages/</code> to review all permutations</summary>

````md
---
layout: dashboard
title: Bar corner radius test
---

# Bar corner radius permutations

Every bar's rounded corners should sit on the end **away from the zero baseline**: top for positive vertical bars, bottom for negative ones, right for positive horizontal bars, left for negative ones. In a stack, only the outermost segment on each side of the baseline is rounded.

```gsql carrier_delay
from flights where cancelled = 'N'
select carriers.nickname as carrier, round(avg(dep_delay), 1) as avg_delay
order by avg_delay desc
limit 8
```

```gsql carrier_net
from flights
where cancelled = 'N' and carriers.nickname in ('Southwest', 'Comair', 'American', 'Alaska', 'United', 'Delta', 'ATA', 'Continental Express')
select carriers.nickname as carrier, round(avg(dep_delay - arr_delay), 1) as time_made_up
order by time_made_up desc
```

```gsql carrier_taxi
from flights where cancelled = 'N'
select carriers.nickname as carrier, round(avg(taxi_in - taxi_out), 1) as taxi_net
having avg(taxi_in - taxi_out) < 0
order by taxi_net desc
limit 8
```

ATA and Continental Express only flew in the last three years of the data, so the queries below that include them exercise sparse splits, where the missing year/carrier combinations are filled with zeros.

```gsql year_carrier_positive
from flights
where cancelled = 'N' and carriers.nickname in ('Southwest', 'American', 'ATA', 'Continental Express')
select extract(year from dep_time)::varchar as year, carriers.nickname as carrier, round(avg(dep_delay), 1) as avg_delay
```

```gsql year_carrier_negative
from flights
where cancelled = 'N' and carriers.nickname in ('Southwest', 'American', 'ATA', 'Continental Express')
select extract(year from dep_time)::varchar as year, carriers.nickname as carrier, round(avg(taxi_in - taxi_out), 1) as taxi_net
```

```gsql year_carrier_mixed
with by_carrier as (
  from flights
  where cancelled = 'N' and carriers.nickname in ('Southwest', 'American', 'United', 'Delta')
  select extract(year from dep_time)::varchar as year, carriers.nickname as carrier, avg(dep_delay) as avg_delay
)
select year, carrier, round(avg_delay - avg(avg_delay) over (partition by year), 1) as vs_year_avg
from by_carrier
```

```gsql year_carrier_phase
from flights where cancelled = 'N' and carriers.nickname in ('Southwest', 'American')
select extract(year from dep_time)::varchar as year, carriers.nickname as carrier, 'Airborne' as phase, round(avg(dep_delay - arr_delay), 1) as minutes
union all
from flights where cancelled = 'N' and carriers.nickname in ('Southwest', 'American')
select extract(year from dep_time)::varchar as year, carriers.nickname as carrier, 'Taxi' as phase, round(avg(taxi_in - taxi_out), 1) as minutes
```

## Single series

<Row>
  <BarChart data=carrier_delay x=carrier y=avg_delay title="Vertical, all positive" height=260px />
  <BarChart data=carrier_taxi x=carrier y=taxi_net title="Vertical, all negative" height=260px />
</Row>

<Row>
  <BarChart data=carrier_net x=carrier y=time_made_up title="Vertical, mixed sign" height=260px />
  <BarChart data=carrier_net x=carrier y=time_made_up label=true title="Vertical, mixed sign, with labels" height=260px />
</Row>

<Row>
  <BarChart data=carrier_delay x=avg_delay y=carrier title="Horizontal, all positive" height=260px />
  <BarChart data=carrier_taxi x=taxi_net y=carrier title="Horizontal, all negative" height=260px />
</Row>

<Row>
  <BarChart data=carrier_net x=time_made_up y=carrier title="Horizontal, mixed sign" height=260px />
  <BarChart data=carrier_net x=time_made_up y=carrier label=true title="Horizontal, mixed sign, with labels" height=260px />
</Row>

## Grouped

<Row>
  <BarChart data=year_carrier_positive x=year y=avg_delay splitBy=carrier arrange=group sort="year asc" title="Grouped, all positive" height=260px />
  <BarChart data=year_carrier_negative x=year y=taxi_net splitBy=carrier arrange=group sort="year asc" title="Grouped, all negative" height=260px />
</Row>

<Row>
  <BarChart data=year_carrier_mixed x=year y=vs_year_avg splitBy=carrier arrange=group sort="year asc" title="Grouped, mixed sign" height=260px />
  <BarChart data=year_carrier_mixed x=vs_year_avg y=year splitBy=carrier arrange=group sort="year asc" title="Grouped horizontal, mixed sign" height=300px />
</Row>

<Row>
  <BarChart data=year_carrier_positive x=avg_delay y=year splitBy=carrier arrange=group sort="year asc" title="Grouped horizontal, all positive" height=300px />
  <BarChart data=year_carrier_negative x=taxi_net y=year splitBy=carrier arrange=group sort="year asc" title="Grouped horizontal, all negative" height=300px />
</Row>

## Stacked

<Row>
  <BarChart data=year_carrier_positive x=year y=avg_delay splitBy=carrier sort="year asc" title="Stacked, all positive" height=260px />
  <BarChart data=year_carrier_negative x=year y=taxi_net splitBy=carrier sort="year asc" title="Stacked, all negative" height=260px />
</Row>

<Row>
  <BarChart data=year_carrier_mixed x=year y=vs_year_avg splitBy=carrier sort="year asc" title="Stacked, mixed sign" height=260px />
  <BarChart data=year_carrier_mixed x=vs_year_avg y=year splitBy=carrier sort="year asc" title="Stacked horizontal, mixed sign" height=300px />
</Row>

<Row>
  <BarChart data=year_carrier_positive x=avg_delay y=year splitBy=carrier sort="year asc" title="Stacked horizontal, all positive" height=300px />
  <BarChart data=year_carrier_negative x=taxi_net y=year splitBy=carrier sort="year asc" title="Stacked horizontal, all negative" height=300px />
</Row>

`arrange=stack100` is vertical-only today — the horizontal form throws "Horizontal charts do not support a value or time-based x-axis".

<Row>
  <BarChart data=year_carrier_positive x=year y=avg_delay splitBy=carrier arrange=stack100 sort="year asc" title="Stacked 100%" height=260px />
</Row>

## Grouped and stacked together

Each year has one bar per carrier, and each bar stacks an airborne and a taxi segment. Airborne minutes are positive and taxi minutes are negative, so every stack straddles the baseline.

<Row>
  <ECharts data=year_carrier_phase height=320px>
    title: {text: 'Grouped + stacked, mixed sign'},
    series: [{type: 'bar', stack: 'phase', encode: {x: 'year', y: 'minutes', splitBy: ['carrier', 'phase']}}],
  </ECharts>
  <ECharts data=year_carrier_phase height=360px>
    title: {text: 'Grouped + stacked horizontal, mixed sign'},
    series: [{type: 'bar', stack: 'phase', encode: {x: 'minutes', y: 'year', splitBy: ['carrier', 'phase']}}],
  </ECharts>
</Row>
````

</details>

Note: `arrange=stack100` throws on horizontal bars for the same x/y reason, fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
