### PR TITLE
Support arrange=stack100 on horizontal bars

### DIFF
--- a/ui/component-utilities/dataShaping.ts
+++ b/ui/component-utilities/dataShaping.ts
@@ -1,10 +1,10 @@
 import type {Field, NormalConfig, SeriesWithGroupingHint} from './types.ts'
 
-// Fill sparse grouped data so each split series has a value for each x bucket.
+// Fill sparse grouped data so each split series has a value for each category.
 //
 // This only applies to split templates (`encode.splitBy`).
-// We do not attempt to fabricate x values here; we only ensure a full Cartesian
-// product of existing x values and split values.
+// We do not attempt to fabricate category values here; we only ensure a full Cartesian
+// product of existing category and split values.
 //
 // Missing-value behavior by chart type (Evidence defaults):
 // - line (no area): null  -> visible line gaps
@@ -16,46 +16,47 @@ export function applyMissingPointDefaults(config: NormalConfig, rows: Record<str
   let series = config.series
   if (series.length === 0 || rows.length === 0) return
 
-  let groups = new Map<string, {xField: string; splitFields: string[]; fills: Map<string, any>}>()
+  let horizontal = isHorizontalBar(config)
+  let groups = new Map<string, {categoryField: string; splitFields: string[]; fills: Map<string, any>}>()
 
   for (let entry of series) {
     let splitFields = getSplitFields(entry)
-    let xField = getSeriesXField(entry)
-    let yField = getSeriesYField(entry)
-    if (splitFields.length === 0 || !xField || !yField) continue
+    let categoryField = horizontal ? getSeriesYField(entry) : getSeriesXField(entry)
+    let valueField = horizontal ? getSeriesXField(entry) : getSeriesYField(entry)
+    if (splitFields.length === 0 || !categoryField || !valueField) continue
 
-    let key = `${xField}::${splitFields.join('::')}`
-    if (!groups.has(key)) groups.set(key, {xField, splitFields, fills: new Map()})
+    let key = `${categoryField}::${splitFields.join('::')}`
+    if (!groups.has(key)) groups.set(key, {categoryField, splitFields, fills: new Map()})
 
     // This line is where chart-specific missing-value behavior is chosen.
     // See getMissingFillValueForSeries() below for the type mapping.
     let fillValue = getMissingFillValueForSeries(entry)
     let fills = groups.get(key)!.fills
 
-    // If multiple templates target the same y field, prefer zero over null.
+    // If multiple templates target the same value field, prefer zero over null.
     // (bar/area should win over plain line when mixed configs exist.)
-    if (!fills.has(yField) || fillValue === 0) fills.set(yField, fillValue)
+    if (!fills.has(valueField) || fillValue === 0) fills.set(valueField, fillValue)
   }
 
   for (let group of groups.values()) {
-    let xValues = distinctValues(rows, group.xField)
+    let categoryValues = distinctValues(rows, group.categoryField)
     let splitValues = group.splitFields.map(field => distinctValues(rows, field))
-    if (xValues.length === 0 || splitValues.some(values => values.length === 0)) continue
+    if (categoryValues.length === 0 || splitValues.some(values => values.length === 0)) continue
 
     let existing = new Set<string>()
     for (let row of rows) {
-      existing.add(compositeKey([row?.[group.xField], ...group.splitFields.map(field => row?.[field])]))
+      existing.add(compositeKey([row?.[group.categoryField], ...group.splitFields.map(field => row?.[field])]))
     }
 
-    for (let xValue of xValues) {
+    for (let categoryValue of categoryValues) {
       for (let splitCombination of cartesianValues(splitValues)) {
-        if (existing.has(compositeKey([xValue, ...splitCombination]))) continue
+        if (existing.has(compositeKey([categoryValue, ...splitCombination]))) continue
 
-        let row: Record<string, any> = {[group.xField]: xValue}
+        let row: Record<string, any> = {[group.categoryField]: categoryValue}
         group.splitFields.forEach((field, index) => {
           row[field] = splitCombination[index]
         })
-        for (let [yField, fillValue] of group.fills.entries()) row[yField] = fillValue
+        for (let [valueField, fillValue] of group.fills.entries()) row[valueField] = fillValue
         rows.push(row)
       }
     }

--- a/ui/component-utilities/dataShaping.ts
+++ b/ui/component-utilities/dataShaping.ts
@@ -62,45 +62,48 @@ export function applyMissingPointDefaults(config: NormalConfig, rows: Record<str
   }
 }
 
-// Evidence stacked100 behavior: compute percentages per x-domain and rewrite series to synthetic pct fields.
+// Evidence stacked100 behavior: compute percentages per category and rewrite series to synthetic pct fields.
 export function applyStackPercentage(config: NormalConfig, rows: Record<string, any>[], fields: Field[]) {
   let series = config.series
   if (series.length === 0 || rows.length === 0) return
 
+  // Horizontal bars put the categories on y and the values on x, so the roles below are swapped.
+  let horizontal = isHorizontalBar(config)
+  let categoryOf = (entry?: SeriesWithGroupingHint) => (horizontal ? getSeriesYField(entry) : getSeriesXField(entry))
+  let valueOf = (entry?: SeriesWithGroupingHint) => (horizontal ? getSeriesXField(entry) : getSeriesYField(entry))
   let groupIndex = 0
 
   for (let entry of series) {
-    let xField = getSeriesXField(entry)
-    let yField = getSeriesYField(entry)
-    if (entry?.stackPercentage !== true || !entry?.stack || !xField || !yField || entry?.datasetId != null) continue
+    let categoryField = categoryOf(entry)
+    let valueField = valueOf(entry)
+    if (entry?.stackPercentage !== true || !entry?.stack || !categoryField || !valueField || entry?.datasetId != null) continue
 
     let stackGroup = series.filter(candidate => {
-      return candidate?.stack === entry.stack && getSeriesXField(candidate) === xField && getSeriesYField(candidate)
+      return candidate?.stack === entry.stack && categoryOf(candidate) === categoryField && valueOf(candidate)
     })
     if (stackGroup[0] !== entry) continue
 
-    let yFields = Array.from(new Set(stackGroup.map(candidate => getSeriesYField(candidate)).filter(Boolean))) as string[]
-    let pctFieldByY = Object.fromEntries(yFields.map((y, index) => [y, `__graphene_stack_pct_${groupIndex}_${index}`])) as Record<string, string>
+    let valueFields = Array.from(new Set(stackGroup.map(candidate => valueOf(candidate)).filter(Boolean))) as string[]
+    let pctFieldByValue = Object.fromEntries(valueFields.map((field, index) => [field, `__graphene_stack_pct_${groupIndex}_${index}`])) as Record<string, string>
 
-    let totalsByX = new Map<string, number>()
+    let totalsByCategory = new Map<string, number>()
     for (let row of rows) {
-      let xKey = valueKey(row?.[xField])
-      let rowTotal = yFields.reduce((sum, y) => sum + (Number(row?.[y]) || 0), 0)
-      totalsByX.set(xKey, (totalsByX.get(xKey) ?? 0) + rowTotal)
+      let categoryKey = valueKey(row?.[categoryField])
+      let rowTotal = valueFields.reduce((sum, field) => sum + (Number(row?.[field]) || 0), 0)
+      totalsByCategory.set(categoryKey, (totalsByCategory.get(categoryKey) ?? 0) + rowTotal)
     }
 
     for (let row of rows) {
-      let xKey = valueKey(row?.[xField])
-      let total = totalsByX.get(xKey) ?? 0
-      for (let y of yFields) row[pctFieldByY[y]] = total <= 0 ? 0 : (Number(row?.[y]) || 0) / total
+      let total = totalsByCategory.get(valueKey(row?.[categoryField])) ?? 0
+      for (let field of valueFields) row[pctFieldByValue[field]] = total <= 0 ? 0 : (Number(row?.[field]) || 0) / total
     }
 
-    for (let y of yFields) ensureField(fields, pctFieldByY[y], {metadata: {ratio: true}})
+    for (let field of valueFields) ensureField(fields, pctFieldByValue[field], {metadata: {ratio: true}})
 
     for (let candidate of stackGroup) {
-      let y = getSeriesYField(candidate)
-      if (!y) continue
-      candidate.encode = {...candidate.encode, y: pctFieldByY[y]}
+      let field = valueOf(candidate)
+      if (!field) continue
+      candidate.encode = {...candidate.encode, [horizontal ? 'x' : 'y']: pctFieldByValue[field]}
       delete candidate.stackPercentage
     }
 

--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -41,7 +41,7 @@ export function enrich(config: EChartsConfig, rows: Record<string, any>[], field
   horizontalBarGuard(normalized, fields)
   computeTitleLegendAndGridPadding(normalized)
   applyLegendSelection(normalized)
-  hideStackPercentageValueAxis(normalized, fields)
+  stackPercentageValueAxis(normalized, fields)
   removeHiddenValueAxisPadding(normalized)
   valueFormatting(normalized, fields)
   timeFormatting(normalized)
@@ -468,18 +468,21 @@ function addCartesianItemTooltips(config: NormalConfig, fields: Field[]) {
   }
 }
 
-// Hide value y-axes for stacked-100 charts, since values are percentages and labels are usually redundant.
-function hideStackPercentageValueAxis(config: NormalConfig, fields: Field[]) {
-  for (let [axisIndex, axis] of config.yAxis.entries()) {
-    if (!axis || axis.type !== 'value' || axis.show != null) continue
+// Stacked-100 charts always span 0-1, so pin the value axis domain and hide it, since percentage labels are usually redundant.
+// The value axis is x for horizontal bars and y everywhere else.
+function stackPercentageValueAxis(config: NormalConfig, fields: Field[]) {
+  let horizontal = isHorizontalBar(config)
 
-    let seriesOnAxis = config.series.filter(entry => Number(entry?.yAxisIndex ?? 0) === axisIndex)
-    if (seriesOnAxis.length === 0) continue
+  for (let [axisIndex, axis] of (horizontal ? config.xAxis : config.yAxis).entries()) {
+    if (!axis || axis.type !== 'value') continue
 
-    let yFields = seriesOnAxis.map(entry => getSeriesValueField(entry, fields)).filter((f): f is Field => !!f)
-    if (yFields.length === 0) continue
+    let seriesOnAxis = config.series.filter(entry => Number((horizontal ? entry?.xAxisIndex : entry?.yAxisIndex) ?? 0) === axisIndex)
+    let valueFields = seriesOnAxis.map(entry => getEncodeField(entry, fields, horizontal ? 'x' : 'y')).filter((f): f is Field => !!f)
+    if (valueFields.length === 0) continue
 
-    if (yFields.every(field => field.name.startsWith('__graphene_stack_pct_'))) axis.show = false
+    if (!valueFields.every(field => field.name.startsWith('__graphene_stack_pct_'))) continue
+    axis.max ??= 1
+    axis.show ??= false
   }
 }
 

--- a/ui/components/BarChart.svelte
+++ b/ui/components/BarChart.svelte
@@ -76,7 +76,8 @@
       tooltip: {trigger: 'item'},
       legend: {show: Boolean(splitBy || y2 || (!horizontal && yFields.length > 1) || (horizontal && xFields.length > 1))},
       xAxis: {},
-      yAxis: [{max: stackPercentage ? 1 : undefined}, ...(y2 ? [{alignTicks: true}] : [])],
+      // The stack100 domain is pinned by an enrichment, since only it knows whether x or y holds the values.
+      yAxis: [{}, ...(y2 ? [{alignTicks: true}] : [])],
       series,
     }
   }

--- a/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart-stacked100.png
+++ b/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart-stacked100.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28e890131ba32f18afc625ad3b5d92ce559d9049a183bf8b4d5d25eb4812c877
+size 11414

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -292,6 +292,25 @@ test('horizontal bar chart supports multiple x fields', async ({mount, chart}) =
   await expect(chart.el).screenshot('horizontal-bar-chart-multi-x')
 })
 
+test('horizontal bar chart stacked100', async ({mount, chart}) => {
+  let rows = [
+    {category: 'Alpha', segment: 'Current', value: 30},
+    {category: 'Alpha', segment: 'Previous', value: 70},
+    {category: 'Beta', segment: 'Current', value: 20},
+    {category: 'Gamma', segment: 'Current', value: 25},
+    {category: 'Gamma', segment: 'Previous', value: 75},
+  ]
+  let fields = [
+    {name: 'category', type: scalarType('string')},
+    {name: 'segment', type: scalarType('string')},
+    {name: 'value', type: scalarType('number')},
+  ]
+
+  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'value', y: 'category', splitBy: 'segment', arrange: 'stack100', title: 'Share by Category'})
+  await chart.chartDispatchAction({type: 'showTip', seriesIndex: 1, dataIndex: 2})
+  await expect(chart.el).screenshot('horizontal-bar-chart-stacked100')
+})
+
 test('stacked area chart', async ({mount, chart}) => {
   await mount('components/AreaChart.svelte', {data: timeseriesGrouped(), x: 'month', y: 'sales_usd0k', splitBy: 'category', arrange: 'stack'})
   await expect(chart.el).screenshot('area-chart-stacked')


### PR DESCRIPTION
`arrange=stack100` threw "Horizontal charts do not support a value or time-based x-axis" on horizontal bars — `applyStackPercentage` assumed categories on x and values on y, so it totalled by value and rewrote the wrong encode key.

The 0–1 domain also moves from `BarChart` to the enrichment that hides the value axis, since only it knows which axis holds the values. On horizontal charts `BarChart` was pinning `max` on the *category* axis, which clips it to two categories.

<details>
<summary>Repro — drop into <code>examples/flights/pages/</code></summary>

````md
```gsql q
from flights
where cancelled = 'N' and carriers.nickname in ('Southwest', 'American', 'United', 'Delta')
select extract(year from dep_time)::varchar as year, carriers.nickname as carrier, round(avg(dep_delay), 1) as avg_delay
```

<BarChart data=q x=year y=avg_delay splitBy=carrier arrange=stack100 sort="year asc" title="Vertical stack100" height=280px />
<BarChart data=q x=avg_delay y=year splitBy=carrier arrange=stack100 sort="year asc" title="Horizontal stack100" height=320px />
````

</details>

Branched off `main`, independent of #566. Both were cherry-picked together to confirm they compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
