### PR TITLE
Put negative bar labels on the bottom/left of the bar

### DIFF
--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -48,11 +48,13 @@ export function enrich(config: EChartsConfig, rows: Record<string, any>[], field
   addCartesianItemTooltips(normalized, fields)
   styleSecondaryAxisForSimpleBarLineLayout(normalized, fields)
   applyIntegerYAxisTicks(normalized, rows, fields)
-  barLabelPositioning(normalized)
   labelsUseYAxisFormat(normalized, fields)
   addPieTooltips(normalized, fields)
   inlineDataIntoSeries(normalized, rows)
   stackedBarCornerRadius(normalized)
+
+  // Runs last because it reads point values to place labels, which only exist once data is inlined.
+  barLabelPositioning(normalized)
   return normalized
 }
 
@@ -548,18 +550,41 @@ function applyIntegerYAxisTicks(config: NormalConfig, rows: Record<string, any>[
   if (values.every(value => Number.isInteger(value))) yAxis.minInterval = 1
 }
 
+// A negative bar's label sits past the end of the bar, which is where the category axis labels are.
+// Padding that end of the value axis keeps the two apart without moving the axis labels themselves.
+const NEGATIVE_LABEL_AXIS_GAP = '12%'
+
 // Keep bar labels readable by default: place them outside bars and avoid overlap when possible.
+// Negative bars extend the other way, so their labels move to the opposite side to stay outside the bar.
 function barLabelPositioning(config: NormalConfig) {
   let horizontal = isHorizontalBar(config)
+  let valueIndex = horizontal ? 0 : 1
+  let negativePosition = horizontal ? 'left' : 'bottom'
+  let axesNeedingRoom = new Set<number>()
 
   for (let series of config.series) {
     if (series?.type !== 'bar' || !series.label || series.label.show !== true) continue
 
-    if (series.label.position == null) series.label.position = horizontal ? 'right' : 'top'
+    let hasExplicitPosition = series.label.position != null
+    if (!hasExplicitPosition) series.label.position = horizontal ? 'right' : 'top'
     if (series.label.distance == null) series.label.distance = 4
     if (series.labelLayout == null || typeof series.labelLayout === 'function') series.labelLayout = {}
     let labelLayout = series.labelLayout as Record<string, any>
     if (labelLayout.hideOverlap == null) labelLayout.hideOverlap = true
+
+    // Position only varies by sign through point-level labels, so negative points override the series default.
+    if (hasExplicitPosition || !Array.isArray(series.data)) continue
+    for (let [pointIndex, point] of (series.data as Record<string, any>[]).entries()) {
+      if (!point || typeof point !== 'object' || !(Number(point.value?.[valueIndex]) < 0)) continue
+      series.data[pointIndex] = {...point, label: {...point.label, position: negativePosition}}
+      axesNeedingRoom.add(Number((horizontal ? series.xAxisIndex : series.yAxisIndex) ?? 0))
+    }
+  }
+
+  for (let axisIndex of axesNeedingRoom) {
+    let axis = (horizontal ? config.xAxis : config.yAxis)[axisIndex] as Record<string, any> | undefined
+    if (axis?.type !== 'value' || axis.min != null || axis.boundaryGap != null) continue
+    axis.boundaryGap = [NEGATIVE_LABEL_AXIS_GAP, 0]
   }
 }
 
@@ -567,14 +592,18 @@ function barLabelPositioning(config: NormalConfig) {
 // This keeps label formatting in sync with tooltips without asking callers to repeat it.
 // labelsUseYAxisFormat depends on valueFormatting running first so labels inherit axis formatting.
 function labelsUseYAxisFormat(config: NormalConfig, fields: Field[]) {
+  let horizontalChart = isHorizontalBar(config)
+
   for (let series of config.series) {
     // No-op when labels are off or already explicitly formatted.
     if (!series?.label || series.label.show !== true || series.label.formatter != null) continue
 
-    let valueField = getSeriesValueField(series, fields)
+    // Horizontal bars carry their values on x, so labels read and format that axis instead.
+    let horizontal = horizontalChart && series.type === 'bar'
+    let valueField = horizontal ? getEncodeField(series, fields, 'x') : getSeriesValueField(series, fields)
     let yField = valueField?.name
-    let axisIndex = Number(series.yAxisIndex ?? 0)
-    let axisFormatter = config.yAxis[axisIndex]?.axisLabel?.formatter
+    let axisIndex = Number((horizontal ? series.xAxisIndex : series.yAxisIndex) ?? 0)
+    let axisFormatter = (horizontal ? config.xAxis : config.yAxis)[axisIndex]?.axisLabel?.formatter
     let labelFormatter = valueField ? makeValueFormatter([valueField]) : axisFormatter
     if (typeof labelFormatter !== 'function') continue
 

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-positive-negative-labels.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-positive-negative-labels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0c1c02254efdec091bbd8575f2c106b481cd56c5d0e34329469657cbb22c7b4
+size 5456

--- a/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart-positive-negative-labels.png
+++ b/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart-positive-negative-labels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc88b0540d9e765ca5b39f869de53731e9f36885af6001acb0c6c532567ea562
+size 4914

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -192,6 +192,20 @@ test('bar chart supports multiple y fields', async ({mount, chart}) => {
   await expect(chart.el).screenshot('bar-chart-multiple-y')
 })
 
+test('bar chart places positive and negative labels outside their bars', async ({mount, chart}) => {
+  let rows = [
+    {category: 'Growth', amount: 42},
+    {category: 'Decline', amount: -28},
+  ]
+  let fields = [
+    {name: 'category', type: scalarType('string')},
+    {name: 'amount', type: scalarType('number')},
+  ]
+
+  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'category', y: 'amount', label: true})
+  await expect(chart.el).screenshot('bar-chart-positive-negative-labels')
+})
+
 test('stacked bar chart rounds positive and negative outer corners', async ({mount, chart}) => {
   let rows = [
     {category: 'Positive', segment: 'Base', value: 12},
@@ -282,6 +296,20 @@ test('bar chart bounds numeric year x axis from metadata', async ({mount, chart}
 test('horizontal bar chart', async ({mount, chart}) => {
   await mount('components/BarChart.svelte', {data: singleDim(), x: 'value', y: 'category'})
   await expect(chart.el).screenshot('horizontal-bar-chart')
+})
+
+test('horizontal bar chart places and formats positive and negative labels outside their bars', async ({mount, chart}) => {
+  let rows = [
+    {category: 'Growth', amount: 42},
+    {category: 'Decline', amount: -28},
+  ]
+  let fields = [
+    {name: 'category', type: scalarType('string')},
+    {name: 'amount', type: scalarType('number')},
+  ]
+
+  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'amount', y: 'category', label: true})
+  await expect(chart.el).screenshot('horizontal-bar-chart-positive-negative-labels')
 })
 
 test('horizontal bar chart auto-expands height for many categories', async ({mount, chart}) => {


### PR DESCRIPTION
Bar labels sat on the top (or right, for horizontal bars) regardless of sign, so labels on negative bars landed on the wrong side. This fixes it by moving the labels to the opposite side of the bar when it's negative.

One wrinkle is that the negative label could sometimes collide with the axis line/labels, so domain padding was needed in this case.

Also fixes a problem where horizontal bar labels were reading the y encode, which is the category on those charts, so they printed the category name instead of the value.

<details>
<summary>Test page — drop into <code>examples/flights/pages/</code> to see the permutations</summary>

````md
---
layout: dashboard
title: Label padding test
---

# Negative label padding stress test

A negative bar's label sits past the end of the bar, which is where the category axis labels are. To keep them apart we pad that end of the value axis by a percentage of its range, but only on charts that actually place a negative label.

The percentage is measured in **data units** while a label's width is measured in **pixels**, so this page varies the two things that decouple them: how many characters the label has, and how many pixels the chart gets. Every chart here is a plain `<BarChart>`, so what you see is what the defaults produce.

```gsql base
from flights
where cancelled = 'N' and carriers.nickname in ('Southwest', 'Comair', 'American', 'Alaska', 'United', 'Delta', 'ATA', 'Continental Express')
select
  carriers.nickname as carrier,
  round(avg(dep_delay - arr_delay), 1) as short_v,
  round(avg(dep_delay - arr_delay) * 1000000, 0) as long_v
order by short_v desc
```

```gsql mostly_negative
from flights
where cancelled = 'N' and carriers.nickname in ('Southwest', 'Comair', 'American', 'Alaska', 'United', 'Delta', 'ATA', 'Continental Express')
select carriers.nickname as carrier, round(avg(taxi_in - taxi_out) + 6, 1) as v
order by v desc
```

```gsql all_negative
from flights where cancelled = 'N'
select carriers.nickname as carrier, round(avg(taxi_in - taxi_out), 1) as v
having avg(taxi_in - taxi_out) < 0
order by v desc
limit 8
```

```gsql tiny_negative
from flights
where cancelled = 'N' and carriers.nickname in ('Southwest', 'Comair', 'American', 'Alaska', 'United', 'Delta', 'ATA')
select carriers.nickname as carrier, round(avg(dep_delay - arr_delay) - 0.4, 1) as v
order by v desc
```

```gsql long_categories
from flights where cancelled = 'N'
select origin_airport.city || ', ' || origin as airport, round(avg(dep_delay - arr_delay), 1) as v
having count() > 5000
order by v
limit 7
```

## Horizontal: how negatives sit against the range

<Row>
  <BarChart data=base x=short_v y=carrier label=true title="Mixed sign" height=300px />
  <BarChart data=base x=long_v y=carrier label=true title="Mixed sign, abbreviated values" height=300px />
</Row>

<Row>
  <BarChart data=tiny_negative x=v y=carrier label=true title="One tiny negative" height=300px />
  <BarChart data=mostly_negative x=v y=carrier label=true title="Mostly negative" height=300px />
</Row>

<Row>
  <BarChart data=all_negative x=v y=carrier label=true title="All negative" height=300px />
  <BarChart data=long_categories x=v y=airport label=true title="Long category names" height=300px />
</Row>

## Horizontal: the same chart, less width

Fewer pixels per data unit is where a percentage of the range buys the least room.

<Row>
  <BarChart data=base x=short_v y=carrier label=true title="Half" height=300px />
  <BarChart data=base x=short_v y=carrier label=true title="Half" height=300px />
</Row>

<Row>
  <BarChart data=base x=long_v y=carrier label=true title="Third" height=300px />
  <BarChart data=base x=long_v y=carrier label=true title="Third" height=300px />
  <BarChart data=base x=long_v y=carrier label=true title="Third" height=300px />
</Row>

## Vertical: the same chart, more height

The label needs one line of text either way, so a percentage of the range buys more and more room as the chart grows.

<Row>
  <BarChart data=base x=carrier y=short_v label=true title="Short" height=240px />
</Row>

<Row>
  <BarChart data=base x=carrier y=short_v label=true title="Tall" height=640px />
</Row>

## Vertical: ratio of negative to positive

<Row>
  <BarChart data=base x=carrier y=short_v label=true title="Vertical mixed sign" height=280px />
  <BarChart data=base x=carrier y=long_v label=true title="Vertical abbreviated values" height=280px />
</Row>

<Row>
  <BarChart data=all_negative x=carrier y=v label=true title="Vertical all negative" height=280px />
  <BarChart data=tiny_negative x=carrier y=v label=true title="Vertical one tiny negative" height=280px />
</Row>
````

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
