### PR TITLE
Allow stacked series w/ wide-format data

### DIFF
--- a/ui/components/AreaChart.svelte
+++ b/ui/components/AreaChart.svelte
@@ -50,7 +50,7 @@
       series = [{type: 'line' as const, areaStyle: {opacity: 0.2}, stack, stackPercentage, encode: {x, y: yFields[0], splitBy, ...sortHint}}]
     } else {
       // "wide" data, one area series per field listed in y
-      series = yFields.map(field => ({type: 'line' as const, name: formatTitle(field), areaStyle: {opacity: 0.2}, encode: {x, y: field, ...sortHint}}))
+      series = yFields.map(field => ({type: 'line' as const, name: formatTitle(field), areaStyle: {opacity: 0.2}, stack, stackPercentage, encode: {x, y: field, ...sortHint}}))
     }
 
     if (y2) series.push({type: 'line' as const, name: formatTitle(y2), yAxisIndex: 1, encode: {x, y: y2, ...sortHint}})

--- a/ui/components/BarChart.svelte
+++ b/ui/components/BarChart.svelte
@@ -62,9 +62,9 @@
     } else {
       // "wide" data, series are created for field listed in the y (or x, for horizontal) attribute
       if (horizontal) {
-        series = xFields.map(field => ({type: 'bar' as const, name: formatTitle(field), encode: {x: field, y, ...sortHint}, label: barLabel}))
+        series = xFields.map(field => ({type: 'bar' as const, name: formatTitle(field), encode: {x: field, y, ...sortHint}, stack, stackPercentage, label: barLabel}))
       } else {
-        series = yFields.map(field => ({type: 'bar' as const, name: formatTitle(field), encode: {x, y: field, ...sortHint}, label: barLabel}))
+        series = yFields.map(field => ({type: 'bar' as const, name: formatTitle(field), encode: {x, y: field, ...sortHint}, stack, stackPercentage, label: barLabel}))
       }
     }
 

--- a/ui/tests/snapshots/viz.test.ts/area-chart-multiple-y-stacked100.png
+++ b/ui/tests/snapshots/viz.test.ts/area-chart-multiple-y-stacked100.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9bcacc2e3790f02b70b603f4f74bebe79e8ccc0c7466bde1cae916eed51afca
+size 17064

--- a/ui/tests/snapshots/viz.test.ts/area-chart-multiple-y.png
+++ b/ui/tests/snapshots/viz.test.ts/area-chart-multiple-y.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1084303eff66b842b3bb4eb6f494d16e4ce30cc2bdb66a128c8ad69be6b5b94e
-size 25183
+oid sha256:bcd23afb4820849cfac60389c728cdae2845cf0eaec4467a89096c8ae83619d5
+size 25704

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-multiple-y-stacked100.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-multiple-y-stacked100.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5505a18f764df6600949aca6f71556cd23958412aac130be930a2625a1dbf99c
+size 10203

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-multiple-y.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-multiple-y.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb9339b9f2e4fae759cdc19a2a5a081a0ecdfd51a3bf0fe449a2ef57d1c218f1
-size 14515
+oid sha256:ea6707c5dd76ad69f9d74285167ec974f1f64af4067680d8a266a3a17ab6d926
+size 12754

--- a/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart-multi-x.png
+++ b/ui/tests/snapshots/viz.test.ts/horizontal-bar-chart-multi-x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5fcc93b0dee2fc1a802dfa0c95379d0206223400a04073efed4cc4d5eb4356bf
-size 5338
+oid sha256:ba932a769b9202bfce9b5335fbb4cc30727850a36866d479ef1838af1d9608b5
+size 5162

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -188,8 +188,13 @@ test('chart download button exports raw csv rows', async ({mount, chart, sharedP
 })
 
 test('bar chart supports multiple y fields', async ({mount, chart}) => {
-  await mount('components/BarChart.svelte', {data: timeseriesWithMultipleY(), x: 'month', y: 'sales_usd0k,profit_usd0k,cost_usd0k'})
+  let wide = {data: timeseriesWithMultipleY(), x: 'month', y: 'sales_usd0k,profit_usd0k,cost_usd0k'}
+
+  await mount('components/BarChart.svelte', wide)
   await expect(chart.el).screenshot('bar-chart-multiple-y')
+
+  await mount('components/BarChart.svelte', {...wide, arrange: 'stack100'})
+  await expect(chart.el).screenshot('bar-chart-multiple-y-stacked100')
 })
 
 test('stacked bar chart rounds positive and negative outer corners', async ({mount, chart}) => {
@@ -306,8 +311,9 @@ test('horizontal bar chart supports multiple x fields', async ({mount, chart}) =
     {name: 'current', type: scalarType('number')},
     {name: 'previous', type: scalarType('number')},
   ]
+  let wide = {data: {rows, fields}, x: 'current,previous', y: 'category'}
 
-  await mount('components/BarChart.svelte', {data: {rows, fields}, x: 'current,previous', y: 'category'})
+  await mount('components/BarChart.svelte', wide)
   await expect(chart.el).screenshot('horizontal-bar-chart-multi-x')
 })
 
@@ -336,8 +342,13 @@ test('stacked area chart', async ({mount, chart}) => {
 })
 
 test('area chart supports multiple y fields', async ({mount, chart}) => {
-  await mount('components/AreaChart.svelte', {data: timeseriesWithMultipleY(), x: 'month', y: 'sales_usd0k,profit_usd0k,cost_usd0k'})
+  let wide = {data: timeseriesWithMultipleY(), x: 'month', y: 'sales_usd0k,profit_usd0k,cost_usd0k'}
+
+  await mount('components/AreaChart.svelte', wide)
   await expect(chart.el).screenshot('area-chart-multiple-y')
+
+  await mount('components/AreaChart.svelte', {...wide, arrange: 'stack100'})
+  await expect(chart.el).screenshot('area-chart-multiple-y-stacked100')
 })
 
 test('area chart supports secondary y axis line', async ({mount, chart}) => {


### PR DESCRIPTION
Two notes:

- `AreaChart.arrange` has no `group` option, so every wide-format area chart changes appearance with no opt-out. The only wide-format charts in `examples/` are two NBA bar charts, both already passing `arrange="group"` explicitly, so nothing there regresses.
- Also fixes the `chart.config` test fixture, which read `$GRAPHENE.components` (Svelte constructors) and called `getModel()` on one, always throwing. Both existing callers were `test.skip`.

Repro page — drop into `examples/flights/pages/`:

````markdown
---
layout: dashboard
title: Wide stack repro
---

# Wide-format stacking

```gsql wide
from flights
where cancelled = 'N'
select extract(year from dep_time)::varchar as year,
  round(avg(dep_delay), 1) as dep_delay,
  round(avg(arr_delay), 1) as arr_delay,
  round(avg(taxi_out), 1) as taxi_out
```

<BarChart data=wide x=year y="dep_delay,arr_delay,taxi_out" sort="year asc" title="Wide, default (stack)" height=280px />
<BarChart data=wide x=year y="dep_delay,arr_delay,taxi_out" arrange=stack100 sort="year asc" title="Wide, stack100" height=280px />
<BarChart data=wide x=year y="dep_delay,arr_delay,taxi_out" arrange=group sort="year asc" title="Wide, group" height=280px />
<BarChart data=wide x="dep_delay,arr_delay,taxi_out" y=year sort="year asc" title="Horizontal wide, default (stack)" height=320px />
<AreaChart data=wide x=year y="dep_delay,arr_delay,taxi_out" sort="year asc" title="Wide area, default (stack)" height=280px />
<AreaChart data=wide x=year y="dep_delay,arr_delay,taxi_out" arrange=stack100 sort="year asc" title="Wide area, stack100" height=280px />
````

🤖 Generated with [Claude Code](https://claude.com/claude-code)
