### PR TITLE
Run zizmor in core CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,11 +4,11 @@ description: Checkout install dependencies
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       with:
         version: 10
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 24.14.1
         cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ permissions:
   contents: read
 
 jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with: {persist-credentials: false}
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          inputs: .github
+          version: v1.29.0
+
   check-commit-authors:
     if: github.event_name == 'pull_request' && github.repository == 'graphene-data/graphene'
     runs-on: ubuntu-latest
@@ -20,7 +31,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check commit authors
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const APPROVED_FILE = '.github/APPROVED_CONTRIBUTORS';
@@ -100,11 +111,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with: {persist-credentials: false}
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.14.1
           cache: pnpm
@@ -117,13 +129,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with: {lfs: true, persist-credentials: false}
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.14.1
           cache: pnpm
@@ -143,7 +154,7 @@ jobs:
         run: pnpm -C ui test
       - name: Upload failures
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: UI test diffs
           path: ui/tests/results/**
@@ -151,11 +162,12 @@ jobs:
   test-vscode:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with: {persist-credentials: false}
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.14.1
           cache: pnpm
@@ -170,14 +182,14 @@ jobs:
   test-install:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with: {lfs: true}
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with: { lfs: true, persist-credentials: false }
       - uses: ./.github/actions/setup
       - run: pnpm test ui/tests/install.test.ts
         env: {SLOW_TEST: '1'}
       - name: Upload failures
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: UI test diffs
           path: ui/tests/results/**
@@ -187,8 +199,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: test
     steps:
-      - uses: actions/checkout@v4
-        with: {lfs: true}
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with: { lfs: true, persist-credentials: false }
       - uses: ./.github/actions/setup
       - run: pnpm test cli/schema.test.ts
         env:
@@ -203,7 +215,7 @@ jobs:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
       - name: Upload failures
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: UI test diffs
           path: ui/tests/results/**
@@ -213,8 +225,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: test
     steps:
-      - uses: actions/checkout@v4
-        with: {lfs: true}
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with: { lfs: true, persist-credentials: false }
       - uses: ./.github/actions/setup
       - run: pnpm test ui/tests/run-examples.test.ts
         env:
@@ -228,7 +240,7 @@ jobs:
           AWS_REGION: us-east-1
       - name: Upload failures
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: UI test diffs
           path: ui/tests/results/**

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Detect release commit and merged PR
         id: detect
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             let mergeSha = context.payload.after
@@ -114,16 +114,15 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - name: Checkout merged PR head
-        uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ needs.detect.outputs.pr_number }}/head
+      - name: Checkout merged PR head # zizmor: ignore[artipacked] The release script uses checkout's credential to push the version tag.
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with: {ref: "refs/pull/${{ needs.detect.outputs.pr_number }}/head"}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.14.1
           cache: pnpm


### PR DESCRIPTION
Audit GitHub Actions on every CI run and resolve the existing findings by pinning third-party actions and disabling unnecessary checkout credential persistence.