### PR TITLE
Expand ClickHouse function coverage

### DIFF
--- a/lang/clickHouseFunctions.ts
+++ b/lang/clickHouseFunctions.ts
@@ -1,6 +1,8 @@
 import type {FunctionDef} from './functionTypes.ts'
+import type {Overload} from './functions.ts'
 
 import {inferTimeOrdinal, inferGrain} from './temporalMetadata.ts'
+import {scalarType, type TypeKind} from './types.ts'
 import {trimIndentation} from './util.ts'
 
 const trim = trimIndentation
@@ -142,9 +144,83 @@ function nativeFunction(sqlName: string, docs: string, args: FunctionDef['args']
   }
 }
 
-// Keep the ClickHouse surface focused on analytics functions that map cleanly to
-// Graphene's expression grammar and type system. Parameterized and lambda calls
-// remain syntax features rather than ordinary function definitions.
+function snakeCaseFunctionName(name: string) {
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
+}
+
+// Defines ClickHouse's numeric conversion family, whose failure variants have distinct argument contracts but share a numeric result.
+function numericConversionFamily(target: string): FunctionDef[] {
+  let conversion = (suffix: string, args: FunctionDef['args'], summary: string) => {
+    let sqlName = `to${target}${suffix}`
+    return nativeFunction(sqlName, 'type-conversion-functions', args, 'number', summary, {aliases: [snakeCaseFunctionName(sqlName)]})
+  }
+  return [
+    conversion('', [{name: 'value', type: 'any'}], `Converts a numeric value or numeric string to ${target}.`),
+    conversion('OrZero', [{name: 'value', type: 'string'}], `Converts a string to ${target}, returning zero when parsing fails.`),
+    conversion('OrNull', [{name: 'value', type: 'string'}], `Converts a string to ${target}, returning null when parsing fails.`),
+    conversion('OrDefault', [{name: 'value', type: 'any'}, {name: 'default', type: 'number?'}], `Converts a value to ${target}, returning an optional default when parsing fails.`),
+  ]
+}
+
+// Decimal conversions additionally require a scale before the optional failure default.
+function decimalConversionFamily(bits: number): FunctionDef[] {
+  let target = `Decimal${bits}`
+  let conversion = (suffix: string, args: FunctionDef['args'], summary: string) => {
+    let sqlName = `to${target}${suffix}`
+    return nativeFunction(sqlName, 'type-conversion-functions', args, 'number', summary, {aliases: [snakeCaseFunctionName(sqlName)]})
+  }
+  return [
+    conversion('', [{name: 'value', type: 'any'}, {name: 'scale', type: 'number'}], `Converts a value to ${target} with the requested scale.`),
+    conversion('OrZero', [{name: 'value', type: 'string'}, {name: 'scale', type: 'number'}], `Converts a string to ${target}, returning zero when parsing fails.`),
+    conversion('OrNull', [{name: 'value', type: 'string'}, {name: 'scale', type: 'number'}], `Converts a string to ${target}, returning null when parsing fails.`),
+    conversion('OrDefault', [{name: 'value', type: 'string'}, {name: 'scale', type: 'number'}, {name: 'default', type: 'number?'}], `Converts a string to ${target}, returning an optional default when parsing fails.`),
+  ]
+}
+
+const clickHouseCombinators = ['SimpleState', 'OrDefault', 'Distinct', 'ForEach', 'ArgMax', 'ArgMin', 'OrNull', 'Array', 'Tuple', 'State', 'Merge', 'Map', 'If'] as const
+const clickHouseAnyTypes: TypeKind[] = ['string', 'number', 'boolean', 'date', 'time', 'timestamp', 'json', 'interval', 'record', 'map', 'array', 'sql native']
+
+// ClickHouse builds aggregate variants by recursively appending combinator suffixes instead of registering every resulting function name.
+export function findClickHouseCombinatorOverloads(name: string, map: Record<string, Overload[]>): Overload[] {
+  let direct = map[name]
+  if (direct) return direct
+
+  for (let suffix of clickHouseCombinators) {
+    if (!name.endsWith(suffix.toLowerCase())) continue
+    let nestedName = name.slice(0, -suffix.length)
+    let nested = findClickHouseCombinatorOverloads(nestedName, map).filter(overload => overload.returnType.expressionType == 'aggregate')
+    if (nested.length) return nested.map(overload => applyClickHouseCombinator(overload, suffix, overload.sqlName || nestedName))
+  }
+  return []
+}
+
+// Transforms the nested aggregate's signature while retaining the composed native SQL name.
+function applyClickHouseCombinator(overload: Overload, suffix: typeof clickHouseCombinators[number], nestedSqlName: string): Overload {
+  let transformed: Overload = {
+    ...overload,
+    params: overload.params.map(param => ({...param, allowedTypes: [...param.allowedTypes]})),
+    returnType: {...overload.returnType},
+    sqlName: `${nestedSqlName}${suffix}`,
+  }
+  let anyParam = (name: string) => ({name, allowedTypes: clickHouseAnyTypes.map(type => ({type}))})
+
+  if (suffix == 'If') transformed.params.push({name: 'condition', allowedTypes: [{type: 'boolean'}]})
+  if (suffix == 'ArgMax' || suffix == 'ArgMin') transformed.params.push(anyParam('key'))
+  if (suffix == 'Array' || suffix == 'ForEach') transformed.params = transformed.params.map(param => ({...param, allowedTypes: [{type: 'array'}, {type: 'sql native'}]}))
+  if (suffix == 'Map') transformed.params = transformed.params.map(param => ({...param, allowedTypes: [{type: 'map'}, {type: 'sql native'}]}))
+  if (suffix == 'Tuple') transformed.params = transformed.params.map(param => ({...param, allowedTypes: [{type: 'record'}, {type: 'sql native'}]}))
+
+  if (suffix == 'Array' && transformed.returnType.type == 'generic') transformed.returnType.type = 'array_element'
+  if (suffix == 'ForEach') transformed.returnType.type = 'array'
+  if (suffix == 'Map') transformed.returnType.type = scalarType('map')
+  if (suffix == 'Tuple') transformed.returnType.type = scalarType('record')
+  if (suffix == 'State' || suffix == 'SimpleState') transformed.returnType.type = scalarType('sql native')
+  if (suffix == 'Merge') transformed.params = [anyParam('state')]
+  if (suffix == 'Distinct') transformed.fanoutSafe = true
+  return transformed
+}
+
+// ClickHouse functions with ordinary call syntax. Parameterized double calls, lambda calls, internals, and native median remain unsupported.
 export const clickHouseFunctions: FunctionDef[] = [
   // ============================================================================
   // JSON and Dynamic Functions
@@ -283,6 +359,7 @@ export const clickHouseFunctions: FunctionDef[] = [
   nativeFunction('corr', '../aggregate-functions/reference/corr', [{name: 'x', type: 'number'}, {name: 'y', type: 'number'}], 'number', 'Computes the Pearson correlation coefficient.', {aggregate: true}),
   nativeFunction('covarPop', '../aggregate-functions/reference/covarpop', [{name: 'x', type: 'number'}, {name: 'y', type: 'number'}], 'number', 'Computes population covariance.', {aggregate: true, aliases: ['covar_pop']}),
   nativeFunction('covarSamp', '../aggregate-functions/reference/covarsamp', [{name: 'x', type: 'number'}, {name: 'y', type: 'number'}], 'number', 'Computes sample covariance.', {aggregate: true, aliases: ['covar_samp']}),
+  nativeFunction('countDistinct', '../aggregate-functions/reference/count', [{name: 'values', type: 'any...'}], 'number', 'Counts distinct values using ClickHouse\'s configured implementation.', {aggregate: true, fanoutSafe: true}),
   nativeFunction('groupUniqArray', '../aggregate-functions/reference/groupuniqarray', [{name: 'arg', type: 'T'}], 'array', 'Collects distinct input values into an array.', {aggregate: true, aliases: ['group_uniq_array']}),
   nativeFunction('retention', '../aggregate-functions/parametric-functions', [{name: 'conditions', type: 'boolean...'}], 'array<number>', 'Computes retention flags for a sequence of conditions.', {aggregate: true}),
   nativeFunction('stddevPop', '../aggregate-functions/reference/stddevpop', [{name: 'arg', type: 'number'}], 'number', 'Computes population standard deviation.', {aggregate: true, aliases: ['stddev_pop']}),
@@ -507,6 +584,15 @@ export const clickHouseFunctions: FunctionDef[] = [
   },
 
   // ============================================================================
+  // Type Conversion Functions
+  // ============================================================================
+  ...['Int8', 'Int16', 'Int32', 'Int64', 'Int128', 'Int256', 'UInt8', 'UInt16', 'UInt32', 'UInt64', 'UInt128', 'UInt256', 'Float32', 'Float64'].flatMap(numericConversionFamily),
+  ...[32, 64, 128, 256].flatMap(decimalConversionFamily),
+  nativeFunction('toBFloat16', 'type-conversion-functions', [{name: 'value', type: 'any'}], 'number', 'Converts a numeric value or numeric string to BFloat16.', {aliases: ['to_bfloat16']}),
+  nativeFunction('toBFloat16OrZero', 'type-conversion-functions', [{name: 'value', type: 'string'}], 'number', 'Converts a string to BFloat16, returning zero when parsing fails.', {aliases: ['to_bfloat16_or_zero']}),
+  nativeFunction('toBFloat16OrNull', 'type-conversion-functions', [{name: 'value', type: 'string'}], 'number', 'Converts a string to BFloat16, returning null when parsing fails.', {aliases: ['to_bfloat16_or_null']}),
+
+  // ============================================================================
   // Numeric Functions
   // ============================================================================
   nativeFunction('exp', 'math-functions', [{name: 'x', type: 'number'}], 'number', 'Returns e raised to x.'),
@@ -655,6 +741,8 @@ export const clickHouseFunctions: FunctionDef[] = [
   nativeFunction('arraySlice', 'array-functions', [{name: 'array', type: 'array'}, {name: 'offset', type: 'number'}, {name: 'length', type: 'number?'}], 'array', 'Returns a slice of an array.', {aliases: ['array_slice']}),
   nativeFunction('arraySort', 'array-functions', [{name: 'array', type: 'array'}], 'array', 'Sorts an array in ascending order.', {aliases: ['array_sort']}),
   nativeFunction('arrayUniq', 'array-functions', [{name: 'arrays', type: 'array...'}], 'number', 'Counts distinct array elements.', {aliases: ['array_uniq']}),
+  nativeFunction('arrayZip', 'array-functions', [{name: 'arrays', type: 'array...'}], 'array<record>', 'Combines corresponding array elements into tuples.', {aliases: ['array_zip']}),
+  nativeFunction('getSubcolumn', 'other-functions', [{name: 'value', type: 'any'}, {name: 'subcolumn', type: 'string'}], 'sql native', 'Extracts a named subcolumn from a nested value.', {aliases: ['get_subcolumn']}),
   nativeFunction('empty', 'array-functions', [{name: 'collection', type: ['array', 'map', 'string']}], 'boolean', 'Returns whether a collection or string is empty.'),
   nativeFunction('has', 'array-functions', [{name: 'array', type: 'array'}, {name: 'value', type: 'any'}], 'boolean', 'Returns whether an array contains a value.'),
   nativeFunction('indexOf', 'array-functions', [{name: 'array', type: 'array'}, {name: 'value', type: 'any'}], 'number', 'Returns the one-based position of a value in an array, or zero.', {aliases: ['index_of']}),
@@ -1255,6 +1343,20 @@ export const clickHouseFunctions: FunctionDef[] = [
     metadata: {timeGrain: 'day'},
     sqlName: 'toStartOfDay',
     aliases: ['to_start_of_day'],
+  },
+  {
+    name: 'tostartofminute',
+    description: trim(`
+      toStartOfMinute(datetime)
+
+      Truncates to the start of the minute.
+    `),
+    url: `${click}/functions/date-time-functions#tostartofminute`,
+    args: [{name: 'datetime', type: ['date', 'timestamp']}],
+    returns: 'timestamp',
+    metadata: {timeGrain: 'minute'},
+    sqlName: 'toStartOfMinute',
+    aliases: ['to_start_of_minute'],
   },
   {
     name: 'tostartofmonth',

--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -5,7 +5,7 @@ import type {FunctionDef, ArgDef} from './functionTypes.ts'
 
 import {athenaFunctions} from './athenaFunctions.ts'
 import {bigQueryFunctions} from './bigQueryFunctions.ts'
-import {clickHouseFunctions} from './clickHouseFunctions.ts'
+import {clickHouseFunctions, findClickHouseCombinatorOverloads} from './clickHouseFunctions.ts'
 import {duckDbFunctions} from './duckDbFunctions.ts'
 import {extendFanoutPath, mergeFanoutPaths, mergeSensitiveFanouts, normalizeExprFanout} from './fanout.ts'
 import {postgresFunctions} from './postgresFunctions.ts'
@@ -13,10 +13,10 @@ import {snowflakeFunctions} from './snowflakeFunctions.ts'
 import {arrayOf, normalizeScalarType, scalarType, type Expr, type FieldMeta, type FieldType, isArrayType, isScalarType, type Scope, type TypeKind} from './types.ts'
 import {txt} from './util.ts'
 
-const ANY_TYPES: TypeKind[] = ['string', 'number', 'boolean', 'date', 'time', 'timestamp', 'json', 'interval', 'record', 'map', 'array']
+const ANY_TYPES: TypeKind[] = ['string', 'number', 'boolean', 'date', 'time', 'timestamp', 'json', 'interval', 'record', 'map', 'array', 'sql native']
 
 // The shape that analyzeFunction works with. Converted from FunctionDef at startup.
-interface Overload {
+export interface Overload {
   params: {name: string; allowedTypes: {type: TypeKind; rawType?: string}[]; isVariadic?: boolean}[]
   returnType: {type: FieldType | 'generic' | 'array' | 'array_element'; expressionType?: 'aggregate' | 'scalar' | 'window'}
   fanoutSafe?: boolean
@@ -118,7 +118,10 @@ let dialectMaps: Record<string, Record<string, Overload[]>> = {
 
 function findOverloads(name: string, dialect: string): Overload[] {
   let map = dialectMaps[dialect] || dialectMaps['duckdb']
-  return map[name.toLowerCase()] || []
+  let normalizedName = name.toLowerCase()
+  let direct = map[normalizedName]
+  if (direct || dialect != 'clickhouse') return direct || []
+  return findClickHouseCombinatorOverloads(normalizedName, map)
 }
 
 // ============================================================================
@@ -159,11 +162,7 @@ function analyzeNamedFunction(analyzer: Analyzer, node: SyntaxNode, name: string
 
   // Analyze arguments and check types against overload
   let args = argNodes.map((argNode, idx) => {
-    let paramIdx = idx
-    if (overload && paramIdx >= overload.params.length) {
-      let lastParam = overload.params[overload.params.length - 1]
-      if (lastParam?.isVariadic) paramIdx = overload.params.length - 1
-    }
+    let paramIdx = overload ? parameterIndexForArgument(overload, idx, argNodes.length) : idx
     let firstType = overload?.params[paramIdx]?.allowedTypes[0]
     if (firstType?.type == 'sql native' && firstType?.rawType === 'kw') {
       return {sql: txt(argNode), type: scalarType('sql native')}
@@ -181,6 +180,16 @@ function analyzeNamedFunction(analyzer: Analyzer, node: SyntaxNode, name: string
   }
 
   return analyzeResolvedFunction(name, overload, args, scope, opts)
+}
+
+// Maps arguments around a variadic parameter, including ClickHouse combinators that append fixed arguments after it.
+function parameterIndexForArgument(overload: Overload, argumentIndex: number, argumentCount: number) {
+  let variadicIndex = overload.params.findIndex(param => param.isVariadic)
+  if (variadicIndex < 0 || argumentIndex < variadicIndex) return argumentIndex
+  let trailingCount = overload.params.length - variadicIndex - 1
+  let trailingStart = argumentCount - trailingCount
+  if (argumentIndex < trailingStart) return variadicIndex
+  return variadicIndex + 1 + argumentIndex - trailingStart
 }
 
 function analyzeResolvedFunction(name: string, overload: Overload, args: Expr[], scope: Scope, opts: {isWindow?: boolean; bare?: boolean} = {}): Expr {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -2285,6 +2285,34 @@ describe('lang', () => {
     }
   })
 
+  it('supports ClickHouse conversion families and aggregate combinators', () => {
+    setGlobalConfig({dialect: 'clickhouse', root: ''})
+    updateFile('table events (tags array<string>, values array<number>, properties map)', 'events.gsql')
+    try {
+      expect('from users select toInt8(name), toInt8OrZero(name), toInt8OrNull(name), toInt8OrDefault(name, 1), toDecimal64OrNull(name, 2)')
+        .toRenderSql('SELECT toInt8(users.name) as col_0, toInt8OrZero(users.name) as col_1, toInt8OrNull(users.name) as col_2, toInt8OrDefault(users.name,1) as col_3, toDecimal64OrNull(users.name,2) as col_4 FROM users as users')
+      expect('from users select toStartOfMinute(created_at), getSubcolumn(name, \'size0\')')
+        .toRenderSql('SELECT toStartOfMinute(users.created_at) as col_0, getSubcolumn(users.name,\'size0\') as col_1 FROM users as users')
+      expect('from events select arrayZip(tags, values)')
+        .toRenderSql('SELECT arrayZip(events.tags,events.values) as col_0 FROM events as events')
+      expect('from events select uniqArray(tags), sumForEach(values), sumMap(properties)')
+        .toRenderSql('SELECT uniqArray(events.tags) as col_0, sumForEach(events.values) as col_1, sumMap(events.properties) as col_2 FROM events as events')
+      expect('from users select countDistinctIf(name, age > 18), sumDistinctIf(age, age > 18), avgOrNull(age), maxArgMax(name, age)')
+        .toRenderSql('SELECT countDistinctIf(users.name,users.age>18) as col_0, sumDistinctIf(users.age,users.age>18) as col_1, avgOrNull(users.age) as col_2, maxArgMax(users.name,users.age) as col_3 FROM users as users')
+      expect('from users select toTypeName(uniqState(name)), toTypeName(sumSimpleState(age)), avgOrDefault(age), minArgMin(name, age)')
+        .toRenderSql('SELECT toTypeName(uniqState(users.name)) as col_0, toTypeName(sumSimpleState(users.age)) as col_1, avgOrDefault(users.age) as col_2, minArgMin(users.name,users.age) as col_3 FROM users as users')
+
+      expect('from users select unknownAggregateIf(age, age > 18)')
+        .toHaveDiagnostic(/Unknown function: unknownaggregateif/i)
+      for (let functionCall of ['median(age)', 'arrayMap(age)', 'topK(age)', '__applyFilter(age)']) {
+        expect(`from users select ${functionCall}`)
+          .toHaveDiagnostic(/Unknown function:/i)
+      }
+    } finally {
+      setGlobalConfig({root: ''})
+    }
+  })
+
   it('keeps column refs ahead of bare niladic functions', () => {
     let queries = analyze(`
       table t (

--- a/ui/tests/snapshots/viz.test.ts/area-chart-multiple-y-stacked100.png
+++ b/ui/tests/snapshots/viz.test.ts/area-chart-multiple-y-stacked100.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9bcacc2e3790f02b70b603f4f74bebe79e8ccc0c7466bde1cae916eed51afca
-size 17064
+oid sha256:b257cb683e65e2065816b229606772928a9160a0c57127113f4247be7b06d331
+size 17841

--- a/ui/tests/snapshots/viz.test.ts/bar-chart-multiple-y-stacked100.png
+++ b/ui/tests/snapshots/viz.test.ts/bar-chart-multiple-y-stacked100.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5505a18f764df6600949aca6f71556cd23958412aac130be930a2625a1dbf99c
-size 10203
+oid sha256:d886775ed7a41945aea46d0c5c489e82f56625a1409d34f8d902e1ab21837f4a
+size 10738


### PR DESCRIPTION
Add typed numeric and decimal conversion families, missing collection and temporal functions, and dynamic aggregate combinator resolution. Keep function definitions explicit and omit lambda, parameterized, internal, and native median functions.