### PR TITLE
Improve mobile report rendering

### DIFF
--- a/examples/flights/pages/index.md
+++ b/examples/flights/pages/index.md
@@ -247,6 +247,18 @@ layout: dashboard
   color: #78716c;
   text-align: center;
 }
+
+@media (max-width: 600px) {
+  .ed-masthead { padding: 24px 0 28px; }
+  .ed-masthead h1 { font-size: 42px; }
+  .ed-figures { grid-template-columns: repeat(2, 1fr); margin-bottom: 36px; }
+  .ed-figure { padding: 20px 8px; }
+  .ed-figure:nth-child(2) { border-right: none; }
+  .ed-figure:nth-child(-n + 2) { border-bottom: 1px solid #d6d3d1; }
+  .ed-figure-value { font-size: 34px; }
+  .ed-plates { grid-template-columns: 1fr; gap: 16px; margin-bottom: 40px; }
+  .ed-erd { overflow-x: auto; padding-bottom: 12px; }
+}
 </style>
 
 ```gsql totals

--- a/ui/app.css
+++ b/ui/app.css
@@ -351,3 +351,26 @@ main.pageContent > h1:first-child {
 .pageContent > div + :is(p, ul, ol, blockquote, hr, table, pre) {
   margin-top: 1rem;
 }
+
+/* Wide markdown tables scroll within the page instead of widening the mobile viewport. */
+.pageContent > table {
+  display: block;
+  overflow-x: auto;
+}
+
+/* Keep the reading measure useful on phones without changing desktop reports. */
+@media (max-width: 600px) {
+  body { font-size: 16px; }
+
+  main.pageContent {
+    padding: 56px 1.25rem 48px;
+  }
+
+  h1 { font-size: 1.625rem; }
+  h2 { font-size: 1.25rem; }
+  h1, h2 { overflow-wrap: anywhere; }
+
+  pre {
+    padding: 1rem;
+  }
+}

--- a/ui/components/DateRange.svelte
+++ b/ui/components/DateRange.svelte
@@ -386,4 +386,9 @@
     font-family: var(--font-ui);
     font-synthesis: none;
   }
+
+  @media (max-width: 600px) {
+    .range-row { flex-wrap: wrap; }
+    .date-input { flex: 1; min-width: 120px; }
+  }
 </style>

--- a/ui/components/ECharts.svelte
+++ b/ui/components/ECharts.svelte
@@ -198,6 +198,10 @@
     position: relative;
   }
 
+  @media (max-width: 600px) {
+    .echarts { max-width: 100%; }
+  }
+
   .empty-chart {
     width: 100%;
     height: 100%;

--- a/ui/components/Row.svelte
+++ b/ui/components/Row.svelte
@@ -13,4 +13,9 @@
     flex: 1 1 80px;
     min-width: 80px;
   }
+
+  /* Small charts and controls are more useful stacked than squeezed side-by-side on phones. */
+  @media (max-width: 600px) {
+    div > :global(*) { flex-basis: 100%; }
+  }
 </style>

--- a/ui/components/_Table.svelte
+++ b/ui/components/_Table.svelte
@@ -578,4 +578,10 @@
   .pagination__meta {
     margin-left: auto;
   }
+
+  @media (max-width: 600px) {
+    .pagination { flex-wrap: wrap; }
+    .pagination__status { margin: 0; }
+    .pagination__meta { flex-basis: 100%; margin-left: 0; }
+  }
 </style>

--- a/ui/internal/Sidebar.svelte
+++ b/ui/internal/Sidebar.svelte
@@ -15,9 +15,14 @@
     if (!sidebar.open || !navEl) return
     if (e.clientX > navEl.offsetLeft + navEl.offsetWidth) sidebar.leave()
   }
+
+  // Page navigation closes a click-pinned panel, which otherwise has no hover exit on touch screens.
+  function onDocClick(e) {
+    if (e.target instanceof Element && e.target.closest('#nav a')) sidebar.unpin()
+  }
 </script>
 
-<svelte:document onmousemove={onDocMouseMove} />
+<svelte:document onmousemove={onDocMouseMove} onclick={onDocClick} />
 
 <nav
   bind:this={navEl}
@@ -57,6 +62,14 @@
   .sb-panel[data-open='true'] {
     transform: translateX(0);
     pointer-events: auto;
+  }
+
+  @media (max-width: 600px) {
+    .sb-panel {
+      width: calc(100vw - 2 * var(--sb-inset, 0px));
+      max-width: var(--sb-w);
+      box-sizing: border-box;
+    }
   }
 
   .sb-panel :global(.sb-content) {

--- a/ui/internal/SidebarToggle.svelte
+++ b/ui/internal/SidebarToggle.svelte
@@ -1,7 +1,7 @@
 <script>
   // The persistent menu button: always fixed to the top-left corner of the viewport.
-  // Opens the sidebar on hover/click/focus. The sidebar stays open until the cursor
-  // crosses its right edge (onDocMouseMove in Sidebar.svelte), so no onmouseleave here.
+  // Opens the sidebar on hover/focus, while a click pins it for touch and keyboard use.
+  // The sidebar stays open until navigation or a second click when pinned.
   import Menu from '@lucide/svelte/icons/menu'
   import {sidebar} from './sidebar.svelte.ts'
 </script>
@@ -11,7 +11,7 @@
   type="button"
   aria-label="Open navigation"
   aria-expanded={sidebar.open}
-  onclick={sidebar.enter}
+  onclick={sidebar.togglePin}
   onmouseenter={sidebar.enter}
   onfocus={sidebar.enter}
   onblur={sidebar.leave}

--- a/ui/internal/sidebar.svelte.ts
+++ b/ui/internal/sidebar.svelte.ts
@@ -22,8 +22,14 @@ export const sidebar = {
     state.pinned = true
     state.open = true
   },
+  togglePin() {
+    clearTimeout(closeTimer)
+    state.pinned = !state.pinned
+    state.open = state.pinned
+  },
   unpin() {
+    clearTimeout(closeTimer)
     state.pinned = false
-    this.leave()
+    closeTimer = window.setTimeout(() => state.open = false, 60)
   },
 }

--- a/ui/tests/snapshots/inputs.test.ts/inputs-crowded-row-wrapped.png
+++ b/ui/tests/snapshots/inputs.test.ts/inputs-crowded-row-wrapped.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:621fc316bd5330983b0b03cea470c958db8c65c0a6b72f4eb90a4aa6a2537427
-size 15646
+oid sha256:7a921c84ff0753fa41e95a7982934976ccad7ddd794d4f561fec0e7cfac9fc94
+size 20937


### PR DESCRIPTION
Use responsive page spacing, stack report rows, and keep charts, tables, controls, and the example flights dashboard within narrow viewports. Make sidebar navigation usable on touch.