### PR TITLE
Fix mocked Markdown CSS cache races

### DIFF
--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -391,13 +391,13 @@ function mockFilesForTests() {
     resolveId(id: any) {
       let key = toMockKey(id)
       if (!mockFileMap[key]) return
-      // Always resolve to the absolute path so the module graph key matches
-      // what updateMockFile emits via server.watcher (needed for HMR to work).
-      return path.join(config.root, key) + '?mock'
+      // Keep mocks and real files under the same module ID. Svelte's virtual CSS lookup uses the
+      // filename without query parameters, so a `?mock` ID can lose its compiled CSS metadata.
+      return path.join(config.root, key)
     },
     load(id: any) {
-      if (!id.endsWith('?mock')) return null
-      let key = toMockKey(id.replace(/\?mock$/, ''))
+      let key = toMockKey(id)
+      if (!mockFileMap[key]) return null
       if (missingMockFiles.has(key)) throw new Error('Mock file not found')
       return mockFileMap[key]
     },

--- a/ui/tests/markdown.test.ts
+++ b/ui/tests/markdown.test.ts
@@ -44,9 +44,11 @@ test('routes pages hidden from navigation', async ({server, page}) => {
 
 test('serves the cloud CSP unless disabled', async ({server, page}) => {
   let response = await page.goto(server.url())
+  await waitForGrapheneLoad(page)
   expect(response!.headers()['content-security-policy']).toBe(grapheneCsp)
 
   response = await page.goto(server.url({csp: false}))
+  await waitForGrapheneLoad(page)
   expect(response!.headers()['content-security-policy']).toBeUndefined()
 })
 


### PR DESCRIPTION
Keep mocked and real Markdown files under the same Vite module ID so Svelte can find compiled CSS metadata after test cleanup. Wait for each CSP test page to finish loading before navigating again.