### PR TITLE
Table title font size bump

### DIFF
--- a/ui/components/_Table.svelte
+++ b/ui/components/_Table.svelte
@@ -526,8 +526,8 @@
   }
 
   .table-title__headline {
-    font-weight: 600;
-    font-size: 14px;
+    font-weight: bold;
+    font-size: 15px;
     line-height: 1.3;
   }
 

--- a/ui/tests/snapshots/table.test.ts/attribute-groups-and-styling.png
+++ b/ui/tests/snapshots/table.test.ts/attribute-groups-and-styling.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f6aa12dc5705ae2de37d8830e493bf66bb8d03d67fb49e56457a743426fd1b0c
-size 16106
+oid sha256:74c65e975441925d252b69fd501f12a5a0683a208a298b21f0f06a04a9e9b83c
+size 16419

--- a/ui/tests/snapshots/table.test.ts/delta-columns.png
+++ b/ui/tests/snapshots/table.test.ts/delta-columns.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b59aa8e85e1ce4d200653ae9755b15261136f1520d40f77445ad816f6b37264
-size 10095
+oid sha256:9e1070aad78a5f78050689e2a7ceed37e1ec9dd6b5b2b9a3ef408da5b14c6299
+size 10104

--- a/ui/tests/snapshots/table.test.ts/headers-align-with-cells.png
+++ b/ui/tests/snapshots/table.test.ts/headers-align-with-cells.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75a5054168bdda8a7bdada723614f02ac4cea2d0bb23b4877624e5c36f9518da
-size 21240
+oid sha256:32a05eb185ea5868ff85edd1b83320937b942a0931f74dd544839da70549ef1b
+size 21621

--- a/ui/tests/snapshots/table.test.ts/row-numbers-sort-asc-page-2.png
+++ b/ui/tests/snapshots/table.test.ts/row-numbers-sort-asc-page-2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82615352b6fbad6d67fbea0b5123ed85b4c1ccbc79171ebca43227c428df57ff
-size 13534
+oid sha256:1586cfd41d0e620a589dd2e6a6cae0391256e8bc44dd93153519030e551a1cf2
+size 13535

--- a/ui/tests/snapshots/table.test.ts/table-renders-data.png
+++ b/ui/tests/snapshots/table.test.ts/table-renders-data.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9338498c9243552654dd44b9f0c548c6b01b8e9337e27c4c5e01aaa2fe798a57
-size 51140
+oid sha256:9d792aef765826ff32d96cb7673af9d0a0efcd40e12543f0ca888142f8c796ba
+size 51275


### PR DESCRIPTION
Table titles were 14px whereas all other chart component titles were 15px. Now everything is 15px.