### PR TITLE
Better selectAllByDefault

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -168,7 +168,7 @@ Unsupported:
 Input values are referenced by their `name` as `$name` in Graphene SQL and sync into the page URL query string, preserving state across reloads and shared links.
 
 ### `<Dropdown>`
-Build options from a query using `data` and `value`; optionally use `label` as the displayed column. Other attributes are `title`, `description`, `defaultValue`, `multiple`, `selectAllByDefault`, `noDefault`, and `disableSelectAll`. `name` is required.
+`name` is required. Build options from a query with `data` and `value`; use `label` to display a different column. Optional attributes include `title`, `description`, `defaultValue`, `multiple`, `selectAllByDefault`, `noDefault`, and `disableSelectAll`.
 
 ````md
 ```sql statuses
@@ -181,7 +181,12 @@ select * from orders where status = $status
 ```
 ````
 
-For `multiple=true`, the input produces a list; filter with `where status in ($status)`. Pass multiple defaults as a JSON array string: `<Dropdown name=status multiple=true defaultValue="['Complete', 'Pending']" />`.
+Set `multiple=true` to select a list of values. Multiple defaults use a JSON array:
+
+```md
+<Dropdown name=status multiple=true defaultValue="['Complete', 'Pending']" />
+```
+Filter either kind of multiselect with `WHERE status IN ($status)`. Graphene sends whichever is shorter—the selected or unselected values—and applies `IN` or `NOT IN` automatically. The URL prefixes that compact list with `i:` or `e:`; URLs without a mode use `include`. `selectAllByDefault=true` only changes the initial selection. Empty lists are handled automatically.
 
 Static options can be nested inside the dropdown as `<DropdownOption value="complete" valueLabel="Complete" />`; `value` is required and `valueLabel` defaults to it.
 

--- a/examples/flights/pages/dropdown_defaults_test.md
+++ b/examples/flights/pages/dropdown_defaults_test.md
@@ -34,7 +34,7 @@ from flights
 where carrier = $carrier
   and origin = $origin
   and extract(year from dep_time) = cast($year as integer)
-  and destination not in ($excluded_invalid)
+  and destination in ($excluded_invalid)
 select destination, count() as flights
 order by flights desc, destination
 limit 10
@@ -45,7 +45,7 @@ from flights
 where carrier = $carrier
   and origin = $origin
   and extract(year from dep_time) = cast($year as integer)
-  and destination not in ($excluded_valid)
+  and destination in ($excluded_valid)
 select destination, count() as flights
 order by flights desc, destination
 limit 10

--- a/lang/analyze.ts
+++ b/lang/analyze.ts
@@ -84,6 +84,7 @@ class AnalysisSession implements Analyzer {
   config: AnalysisConfig
   files: FileInfo[]
   diagnostics: GrapheneError[] = []
+  paramTypes: Record<string, FieldType> = {}
   filesByPath: Record<string, FileInfo> = {}
   computedColumnStack = new Set<Column>() // Track computed columns being analyzed to detect cycles
   viewStack = new Set<Table>() // Also detect view cycles
@@ -398,7 +399,7 @@ class AnalysisSession implements Analyzer {
   }
 
   private analyzeSimpleQuery(simpleNode: SyntaxNode, queryNode: SyntaxNode, parentScope: Scope, ctes: Map<string, CteTable>, opts: {suppressImplicitOrderBy?: boolean} = {}): Query | void {
-    let query: Query = {sql: '', fields: [], joins: [], filters: [], groupBy: [], orderBy: []}
+    let query: Query = {sql: '', fields: [], dialect: this.config.dialect, paramTypes: this.paramTypes, joins: [], filters: [], groupBy: [], orderBy: []}
     let scope: Scope = {...parentScope, query}
     let isAgg = false
     let fanoutExprs: {node: SyntaxNode; expr: Expr}[] = []
@@ -604,6 +605,8 @@ class AnalysisSession implements Analyzer {
     let query: Query = {
       sql: '',
       fields,
+      dialect: this.config.dialect,
+      paramTypes: this.paramTypes,
       joins: [],
       filters: [],
       groupBy: [],
@@ -982,7 +985,8 @@ class AnalysisSession implements Analyzer {
           return {sql: `${expr.sql} ${not ? 'NOT IN' : 'IN'} (${subquery.sql})`, type: scalarType('boolean'), isAgg: expr.isAgg, fanout: expr.fanout}
         }
         if (!valueList) return this.diag(node, 'IN expression must provide either values or a subquery', {sql: 'NULL', type: scalarType('error')})
-        let values = valueList.getChildren('Expression').map(valueNode => {
+        let valueNodes = valueList.getChildren('Expression')
+        let values = valueNodes.map(valueNode => {
           let value = this.analyzeExpr(valueNode, scope)
           // Coerce string literals to temporal types if needed
           if ((isScalarType(expr.type, 'date') || isScalarType(expr.type, 'timestamp')) && isScalarType(value.type, 'string')) {
@@ -990,7 +994,17 @@ class AnalysisSession implements Analyzer {
           }
           return value.sql
         })
-        return {sql: `${expr.sql} ${not ? 'NOT IN' : 'IN'} (${values.join(',')})`, type: scalarType('boolean'), isAgg: expr.isAgg, fanout: expr.fanout}
+        let sql = `${expr.sql} ${not ? 'NOT IN' : 'IN'} (${values.join(',')})`
+
+        // A list param may contain either selected or unselected values. Emit both static branches so
+        // runtime filling only chooses a mode literal and never has to rewrite the generated SQL structure.
+        if (valueNodes.length == 1 && valueNodes[0].name == 'Param') {
+          let name = txt(valueNodes[0]).slice(1)
+          let mode = `$__graphene_list_mode_${name}`
+          this.paramTypes[name] = expr.type
+          sql = `((${mode}='include' AND ${sql}) OR (${mode}='exclude' AND ${expr.sql} ${not ? 'IN' : 'NOT IN'} (${values[0]})))`
+        }
+        return {sql, type: scalarType('boolean'), isAgg: expr.isAgg, fanout: expr.fanout}
       }
 
       case 'BetweenExpression': {

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -1952,6 +1952,19 @@ describe('lang', () => {
     expect(toSql(queries[0], {name: 'Alice'})).toMatch(/WHERE users\.name='Alice'/)
   })
 
+  it('renders adaptive list params with include mode by default', () => {
+    let included = analyze(`${testTables}\nfrom users select id where name in ($names)`)[0]
+    let excluded = analyze(`${testTables}\nfrom users select id where name not in ($names)`)[0]
+    expect(toSql(included, {names: ['Alice']})).toContain("(('include'='include' AND users.name IN ('Alice')) OR ('include'='exclude' AND users.name NOT IN ('Alice')))")
+    expect(toSql(included, {names: {values: ['Alice']}})).toContain("'include'='include'")
+    expect(toSql(included, {names: {mode: 'exclude', values: ['Alice']}})).toContain("(('exclude'='include' AND users.name IN ('Alice')) OR ('exclude'='exclude' AND users.name NOT IN ('Alice')))")
+    expect(toSql(excluded, {names: {mode: 'exclude', values: ['Alice']}})).toContain("(('exclude'='include' AND users.name NOT IN ('Alice')) OR ('exclude'='exclude' AND users.name IN ('Alice')))")
+
+    setGlobalConfig({dialect: 'bigquery', root: ''})
+    included = analyze(`${testTables}\nfrom users select id where name in ($names)`)[0]
+    expect(toSql(included, {names: []})).toContain('users.name IN (SELECT CAST(NULL AS STRING) WHERE FALSE)')
+  })
+
   it('does not treat $word inside single-quoted strings as params', () => {
     let queries = analyze(`${testTables}
       from users select id where name = '$test'

--- a/lang/params.ts
+++ b/lang/params.ts
@@ -1,24 +1,26 @@
-import type {Query} from './types.ts'
+import type {FieldType, Query} from './types.ts'
 
-// Fill in parameter values in a query's SQL strings
-// Params look like $paramName in the SQL
+// Converts analyzed $params into SQL literals without changing the generated query structure.
+// Adaptive list predicates already contain both mode branches; synthetic mode params select one at runtime.
 export function fillInParams(query: Query, params: Record<string, any>) {
-  query.sql = replaceParams(query.sql, params)
+  query.sql = replaceParams(query.sql, params, query.dialect, query.paramTypes)
 }
 
-function replaceParams(sql: string, params: Record<string, any>): string {
+// Replace scalar/list values and analyzer-generated mode params while leaving quoted SQL strings untouched.
+function replaceParams(sql: string, params: Record<string, any>, dialect?: string, paramTypes: Query['paramTypes'] = {}): string {
   // Alternation: match single-quoted strings (including escaped '') first, then $params.
-  // When we match a quoted string the capture group is undefined, so we return it unchanged.
+  // Synthetic mode params let analyzed IN expressions switch operators without rewriting SQL at runtime.
   return sql.replace(/'(?:[^']|'')*'|\$(\w+)/g, (match, name) => {
     if (!name) return match
-    let value = params[name]
+    if (name.startsWith('__graphene_list_mode_')) return `'${listParam(params[name.slice('__graphene_list_mode_'.length)]).mode}'`
+    let value = listParam(params[name]).values
     if (value === undefined) throw new Error(`Missing param $${name}`)
     if (value === null) return 'NULL'
     if (typeof value === 'string') return `'${value.replace(/'/g, "''")}'`
     if (typeof value === 'number') return value.toString()
     if (typeof value === 'boolean') return value ? 'true' : 'false'
     if (Array.isArray(value)) {
-      // For IN clauses with array params
+      if (!value.length) return emptyArraySql(dialect, paramTypes[name])
       return value
         .map(v => {
           if (typeof v === 'string') return `'${v.replace(/'/g, "''")}'`
@@ -28,4 +30,18 @@ function replaceParams(sql: string, params: Record<string, any>): string {
     }
     throw new Error(`Unsupported param type for $${name}: ${typeof value}`)
   })
+}
+
+// List params carry a compact-set mode; ordinary values remain include-mode params for compatibility.
+function listParam(value: any): {mode: 'include' | 'exclude'; values: any} {
+  if (!value || typeof value != 'object' || Array.isArray(value)) return {mode: 'include', values: value}
+  if ((value.mode && value.mode != 'include' && value.mode != 'exclude') || !Array.isArray(value.values)) throw new Error('List param requires include/exclude mode and array values')
+  return {mode: value.mode || 'include', values: value.values}
+}
+
+// Generate a typed zero-row subquery where the dialect requires one for IN comparisons.
+function emptyArraySql(dialect: string | undefined, type: FieldType | undefined) {
+  if (dialect != 'bigquery' || typeof type != 'string') return 'SELECT NULL WHERE FALSE'
+  let bigQueryType = {string: 'STRING', number: 'FLOAT64', boolean: 'BOOL', date: 'DATE', time: 'TIME', timestamp: 'TIMESTAMP'}[type]
+  return bigQueryType ? `SELECT CAST(NULL AS ${bigQueryType}) WHERE FALSE` : 'SELECT NULL WHERE FALSE'
 }

--- a/lang/types.ts
+++ b/lang/types.ts
@@ -279,6 +279,8 @@ export interface QueryJoin {
 export interface Query {
   sql: string // the complete SQL string
   fields: QueryField[] // SELECT columns
+  dialect?: string // dialect used to generate SQL and fill dialect-specific parameter values
+  paramTypes?: Record<string, FieldType> // types inferred where parameters are compared with fields
   joins: QueryJoin[] // JOINs needed for this query
   filters: Filter[] // WHERE/HAVING conditions
   groupBy: string[] // field names for GROUP BY

--- a/ui/components/Dropdown.svelte
+++ b/ui/components/Dropdown.svelte
@@ -44,9 +44,9 @@
   let queryOptions: Option[] = $state([])
   let manualOptions: Option[] = $state([])
   let selection: any[] = $state([])
-  let touched = false
+  // Multiselect params store whichever side of the selection is smaller; selection remains the full UI state.
+  let paramList: {mode: 'include' | 'exclude'; values: any[]} = $state({mode: 'include', values: []})
   let paramInitialized = false
-  let preserveInitialSelection = false
   let queryHandler: ((res: {rows?: any[]; error?: any}) => void) | null = null
   let queryKey = ''
 
@@ -302,15 +302,20 @@
     if (isOpen && activeIndex >= 0) void tick().then(scrollActiveIntoView)
   })
 
+  // Register the URL/query param and expand its compact list into the options displayed as selected.
   $effect(() => {
-    let defaultParam = !hasNoDefault && defaultValues.length ? writeSelection(defaultValues) : null
-    let unsub = window.$GRAPHENE.param(name, multi ? 'array' : 'scalar', defaultParam, value => {
-      if (!paramInitialized) {
-        preserveInitialSelection = value != null
-        paramInitialized = true
+    let listDefault = !hasNoDefault && defaultValues.length ? {mode: 'include', values: writeSelection(defaultValues)} : {mode: selectAllDefault ? 'exclude' : 'include', values: []}
+    let defaultParam = multi ? listDefault : (!hasNoDefault && defaultValues.length ? writeSelection(defaultValues) : null)
+    let unsub = window.$GRAPHENE.param(name, multi ? 'list' : 'scalar', defaultParam, value => {
+      paramInitialized = true
+      if (multi) {
+        paramList = value
+        let nextSelection = selectionFromList(value)
+        if (!sameSelection(selection, nextSelection)) setSelection(nextSelection, {persist: false})
+        return
       }
-      let nextSelection = readSelection(value)
-      if (!sameSelection(selection, nextSelection)) setSelection(nextSelection, {persist: false})
+      let paramSelection = readSelection(value)
+      if (!sameSelection(selection, paramSelection)) setSelection(paramSelection, {persist: false})
     })
     return unsub
   })
@@ -348,22 +353,18 @@
   })
 
   function syncSelection(fromUser: boolean) {
-    // Reconcile selection with the current option set. Query-derived defaults like
-    // select-all are applied once options are available and before the user interacts.
+    // Reconcile selection with the current option set. Multiselects retain their compact param
+    // while asynchronous or nested options register, then expand it against all available options.
     let opts = availableOptions
     if (!opts.length) {
-      // Keep the bound param initialized even before options load.
-      // This prevents $param references from throwing "Missing param" on first render.
-      updateInputPayload(selection)
+      if (!multi) updateInputPayload(selection)
       return
     }
-    let nextSelection = selection.filter(val => valueMap.has(optionKey(val)))
-    if (!fromUser) {
-      // Manual options register one at a time, so keep expanding a select-all default until the user interacts.
-      // An explicit default or URL value remains authoritative.
-      if (multi && selectAllDefault && !touched && !preserveInitialSelection) nextSelection = opts.map(o => o.value)
+    if (multi) {
+      setSelection(selectionFromList(paramList), {fromUser, persist: false})
+      return
     }
-    setSelection(nextSelection, {fromUser, persist: true})
+    setSelection(selection.filter(val => valueMap.has(optionKey(val))), {fromUser, persist: true})
   }
 
   // Multiple defaults use an array serialized as a string because Markdown attributes cannot safely pass Svelte values.
@@ -398,7 +399,7 @@
   }
 
   function writeSelection(values: any[]) {
-    if (multi) return values.length ? [...values] : null
+    if (multi) return [...values]
     return values.length ? values[0] : null
   }
 
@@ -408,12 +409,26 @@
       return
     }
     selection = values
-    if (fromUser) touched = true
     if (persist) updateInputPayload(selection)
   }
 
+  // Persist the smaller side of a multiselect so large select-all controls keep URLs and requests short.
   function updateInputPayload(values: any[]) {
+    if (!paramInitialized) return
+    if (multi) {
+      let excluded = availableOptions.filter(option => !values.some(selected => optionKey(selected) === optionKey(option.value))).map(option => option.value)
+      let nextList = values.length <= excluded.length ? {mode: 'include' as const, values: [...values]} : {mode: 'exclude' as const, values: excluded}
+      paramList = nextList
+      window.$GRAPHENE.updateParam(name, nextList)
+      return
+    }
     window.$GRAPHENE.updateParam(name, writeSelection(values))
+  }
+
+  // Convert the compact included/excluded set back into the selected options displayed by the control.
+  function selectionFromList(list: {mode: 'include' | 'exclude'; values: any[]}) {
+    if (list.mode == 'include') return list.values.filter(value => valueMap.has(optionKey(value)))
+    return availableOptions.filter(option => !list.values.some(excluded => optionKey(excluded) === optionKey(option.value))).map(option => option.value)
   }
 
   function selectAll() {

--- a/ui/internal/params.ts
+++ b/ui/internal/params.ts
@@ -1,15 +1,19 @@
-// API for keeping inputs in sync with url params, and query parameters
+// Keeps input values synchronized between the URL, rendered components, and query requests.
+// List params use the smaller included/excluded set in one escaped URL value.
 
-// the current values of all params, with defaults applied
 let paramValues: Record<string, any> = readUrlParams()
-
-// all listeners who have declared a param, and are awaiting new values
 let subscribers: Record<string, {type: ParamType; defaultValue: any; cb: ParamCallback}> = {}
 
 window.addEventListener('popstate', () => applyParams(readUrlParams(), false))
 
-type ParamType = 'scalar' | 'array'
+type ParamType = 'scalar' | 'array' | 'list'
 type ParamCallback = (value: any) => void
+
+// A list describes a selected set using either its included values or its excluded complement.
+interface ListParam {
+  mode: 'include' | 'exclude'
+  values: any[]
+}
 
 export function getParams() {
   return structuredClone(paramValues)
@@ -20,7 +24,7 @@ export function resetParams() {
   paramValues = readUrlParams()
 }
 
-// Subscribe to a param, providing a type and default (can be null). cb is called immediately with the current value, and when it changes
+// Subscribe to a param, providing a type and default (can be null). cb is called immediately with the current value, and when it changes.
 export function param(name: string, type: ParamType, defaultValue: any, cb: ParamCallback) {
   if (subscribers[name]) throw new Error(`Param named ${name} already in use`)
   subscribers[name] = {type, defaultValue, cb}
@@ -36,7 +40,7 @@ export function updateParam(name: string, value: any) {
   applyParams(next, true)
 }
 
-// Updates the values, notifies listeners, and (optionally) writes this back to the url
+// Update values, notify input components, optionally rewrite the URL, and rerun dependent queries.
 function applyParams(next: any, updateUrl = false) {
   Object.entries(subscribers).forEach(([name, sub]) => {
     next[name] = normalizeParamValue(sub.type, next[name] ?? sub.defaultValue ?? null)
@@ -49,7 +53,7 @@ function applyParams(next: any, updateUrl = false) {
   window.$GRAPHENE.rerunQueries()
 }
 
-// read the raw query params, and turn it into our params object
+// Read repeated legacy params as arrays; typed array subscribers also understand compact lists.
 function readUrlParams() {
   let next = {}
   for (let [name, value] of new URLSearchParams(window.location.search).entries()) {
@@ -61,14 +65,18 @@ function readUrlParams() {
   return next
 }
 
+// Serialize list mode and values together so a shared URL preserves which side of the set was stored.
 function writeUrlParams() {
   let search = new URLSearchParams()
   Object.entries(paramValues).forEach(([name, value]) => {
-    let def = subscribers[name]?.defaultValue
-    if (def && sameValue(value, def)) return // if a value is the default, don't write it to the url
-    if (value == null || value == undefined || value == '') return // dont write out empty/null values (though false is ok)
-    if (Array.isArray(value)) value.forEach(item => search.append(name, String(item)))
-    else search.append(name, String(value))
+    let subscriber = subscribers[name]
+    if (subscriber?.defaultValue && sameValue(value, subscriber.defaultValue)) return
+    if (value == null || value == '') return
+    if (subscriber?.type == 'list') {
+      search.append(name, `${value.mode == 'exclude' ? 'e' : 'i'}:${serializeList(value.values)}`)
+    } else if (Array.isArray(value)) {
+      if (value.length) search.append(name, serializeList(value))
+    } else search.append(name, String(value))
   })
 
   let nextSearch = search.toString()
@@ -77,13 +85,46 @@ function writeUrlParams() {
   window.history.replaceState(window.history.state, '', window.location.pathname + (nextSearch ? `?${nextSearch}` : '') + window.location.hash)
 }
 
+// Normalize legacy arrays as include lists; explicit i:/e: URLs preserve adaptive list mode.
 function normalizeParamValue(type: ParamType, value: any) {
+  if (type == 'list') {
+    if (value && !Array.isArray(value) && typeof value == 'object') return {mode: value.mode == 'exclude' ? 'exclude' : 'include', values: value.values} as ListParam
+    if (Array.isArray(value)) return {mode: 'include', values: value}
+    let encoded = String(value ?? '')
+    let hasMode = encoded.startsWith('i:') || encoded.startsWith('e:')
+    return {mode: encoded.startsWith('e:') ? 'exclude' : 'include', values: parseList(hasMode ? encoded.slice(2) : encoded).filter(item => item !== '')}
+  }
   if (type == 'array') {
-    if (value === undefined || value === null) return null
-    return Array.isArray(value) ? value : [value]
+    if (value === undefined || value === null) return []
+    if (Array.isArray(value)) return value
+    return parseList(String(value))
   }
   if (Array.isArray(value)) return value.length ? value[0] : null
   return value === undefined ? null : value
+}
+
+// Lists use commas for readability and backslashes to preserve commas or backslashes inside values.
+function serializeList(values: any[]) {
+  return values.map(value => String(value).replaceAll('\\', '\\\\').replaceAll(',', '\\,')).join(',')
+}
+
+function parseList(value: string) {
+  let values: string[] = []
+  let current = ''
+  let escaped = false
+  for (let char of value) {
+    if (escaped) {
+      current += char
+      escaped = false
+    } else if (char === '\\') escaped = true
+    else if (char === ',') {
+      values.push(current)
+      current = ''
+    } else current += char
+  }
+  if (escaped) current += '\\'
+  values.push(current)
+  return values
 }
 
 function changedKeys(before, after) {
@@ -97,6 +138,7 @@ function changedKeys(before, after) {
 
 function sameValue(left, right) {
   if (Array.isArray(left) || Array.isArray(right)) return Array.isArray(left) && Array.isArray(right) && left.length === right.length && left.every((value, index) => value === right[index])
+  if (left && right && typeof left == 'object' && typeof right == 'object') return left.mode == right.mode && sameValue(left.values, right.values)
   return left === right
 }
 

--- a/ui/tests/inputs.test.ts
+++ b/ui/tests/inputs.test.ts
@@ -124,12 +124,12 @@ test('dropdown selection supports single and bulk interactions', async ({server,
   expect(optionLabels).toEqual([...optionLabels].sort((a, b) => a.localeCompare(b, undefined, {numeric: true})))
   await page.getByRole('button', {name: 'Select all'}).click()
   await expect(menu.locator('.dropdown-option.is-selected')).toHaveCount(optionLabels.length)
-  expect(await lastParamUpdate(page, 'carrier_multi')).toEqual({name: 'carrier_multi', value: optionLabels})
+  expect(await lastParamUpdate(page, 'carrier_multi')).toEqual({name: 'carrier_multi', value: {mode: 'exclude', values: []}})
   await lockOpenDropdownWidth(page)
   await expect(menu).screenshot('dropdown-multi-select-all')
   await page.getByRole('button', {name: 'Clear selection'}).click()
   await expect(trigger).toContainText('Pick carriers')
-  expect(await lastParamUpdate(page, 'carrier_multi')).toEqual({name: 'carrier_multi', value: null})
+  expect(await lastParamUpdate(page, 'carrier_multi')).toEqual({name: 'carrier_multi', value: {mode: 'include', values: []}})
   await page.keyboard.press('Escape')
 })
 
@@ -295,6 +295,91 @@ test('static dropdown options apply select-all as each option registers', async 
   await expect(page.getByRole('listbox').locator('.dropdown-option.is-selected')).toHaveCount(3)
   await lockOpenDropdownWidth(page)
   await expect(page.getByRole('listbox')).screenshot('dropdown-manual-select-all-default')
+})
+
+test('multiselect URL state escapes commas inside values', async ({server, page}) => {
+  await loadDropdownPage(
+    server,
+    page,
+    `
+    <Dropdown name="markets" title="Markets" multiple=true>
+      <DropdownOption value="North, East" />
+      <DropdownOption value="South" />
+    </Dropdown>
+  `,
+  )
+
+  await page.getByRole('combobox', {name: 'Markets'}).click()
+  await page.getByRole('option', {name: 'North, East'}).click()
+  await expect.poll(() => readSearchParams(page)).toEqual({markets: 'i:North\\, East'})
+
+  await page.reload()
+  await waitForGrapheneLoad(page)
+  await page.getByRole('combobox', {name: 'Markets'}).click()
+  await expect(page.getByRole('option', {name: 'North, East'})).toHaveAttribute('aria-selected', 'true')
+})
+
+test('multiselects choose compact URL modes and apply them to query results', async ({server, page}) => {
+  let queryBodies: any[] = []
+  server.mockFile(
+    '/index.md',
+    `
+    # Multiselect filters
+
+    \`\`\`sql carrier_options
+    from flights select carrier as code group by 1 order by 1
+    \`\`\`
+
+    <Dropdown name=included_carriers data=carrier_options value=code title="Included carriers" multiple=true />
+    <Dropdown name=allowed_carriers data=carrier_options value=code title="Allowed carriers" multiple=true selectAllByDefault=true />
+
+    \`\`\`sql filtered_carriers
+    from flights
+    where carrier in ($included_carriers) and carrier in ($allowed_carriers)
+    select carrier, count() as flights group by 1 order by 1
+    \`\`\`
+
+    <BarChart title="Filtered carriers" data=filtered_carriers x=carrier y=flights />
+  `,
+  )
+  await page.route('**/_api/query', async route => {
+    queryBodies.push(route.request().postDataJSON())
+    await route.continue()
+  })
+
+  let filteredRequests = () => queryBodies.filter(body => body.gsql.includes('carrier in ($included_carriers)'))
+
+  await page.goto(server.url() + '/')
+  await waitForGrapheneLoad(page)
+  await expect.poll(() => filteredRequests().at(-1)?.params).toEqual({included_carriers: {mode: 'include', values: []}, allowed_carriers: {mode: 'exclude', values: []}})
+  await expect.poll(() => readSearchParams(page)).toEqual({})
+
+  await page.getByRole('combobox', {name: 'Included carriers'}).click()
+  await page.getByRole('option', {name: 'AA'}).click()
+  await page.keyboard.press('Escape')
+  await expect.poll(() => readSearchParams(page)).toEqual({included_carriers: 'i:AA'})
+  await expect.poll(() => filteredRequests().at(-1)?.params).toEqual({included_carriers: {mode: 'include', values: ['AA']}, allowed_carriers: {mode: 'exclude', values: []}})
+
+  await page.getByRole('combobox', {name: 'Included carriers'}).click()
+  await page.getByRole('option', {name: 'DL'}).click()
+  await page.keyboard.press('Escape')
+
+  await page.getByRole('combobox', {name: 'Allowed carriers'}).click()
+  await page.getByRole('option', {name: 'AA'}).click()
+  await page.keyboard.press('Escape')
+  await expect.poll(() => readSearchParams(page)).toEqual({included_carriers: 'i:AA,DL', allowed_carriers: 'e:AA'})
+  await expect.poll(() => filteredRequests().at(-1)?.params).toEqual({included_carriers: {mode: 'include', values: ['AA', 'DL']}, allowed_carriers: {mode: 'exclude', values: ['AA']}})
+  await expect(page.locator('.echarts')).screenshot('dropdown-multiselect-exclude-mode')
+
+  // Once only a few values remain selected, the select-all dropdown switches to the smaller inclusion list.
+  await page.getByRole('combobox', {name: 'Allowed carriers'}).click()
+  await page.getByRole('button', {name: 'Clear selection'}).click()
+  await expect.poll(() => filteredRequests().at(-1)?.params.allowed_carriers).toEqual({mode: 'include', values: []})
+  await page.getByRole('option', {name: 'AA'}).click()
+  await expect.poll(() => readSearchParams(page)).toEqual({included_carriers: 'i:AA,DL', allowed_carriers: 'i:AA'})
+  await expect.poll(() => filteredRequests().at(-1)?.params).toEqual({included_carriers: {mode: 'include', values: ['AA', 'DL']}, allowed_carriers: {mode: 'include', values: ['AA']}})
+  await page.getByRole('combobox', {name: 'Allowed carriers'}).click()
+  await expect(page.locator('.echarts')).screenshot('dropdown-multiselect-include-mode')
 })
 
 test('dropdown supports manual options and labelField mapping', async ({server, page}) => {
@@ -477,12 +562,14 @@ test('inputs sync url state on load, change, and reload', {timeout: 20000}, asyn
 
     <TextInput name="search_text" title="Search Text" defaultValue="alpha" />
     <Dropdown name="carrier_multi" data="carrier_options" value="code" label="label" title="Carriers" multiple=true />
+    <Dropdown name="carrier_all" data="carrier_options" value="code" label="label" title="All Carriers" multiple=true selectAllByDefault=true />
     <DateRange name="window" title="Window" start="2024-01-01" end="2024-01-31" />
 
     \`\`\`sql filtered_flights
     from flights select carrier
     where ($search_text is null or carrier = carrier)
       and ($carrier_multi is null or carrier in ($carrier_multi))
+      and carrier in ($carrier_all)
       and ($window_start is null or dep_time >= $window_start)
       and ($window_end is null or dep_time < $window_end)
     limit 5
@@ -501,37 +588,38 @@ test('inputs sync url state on load, change, and reload', {timeout: 20000}, asyn
   await waitForGrapheneLoad(page)
 
   await expect(page.getByLabel('Search Text')).toHaveValue('delta')
-  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('AA')
-  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('UA')
+  await expect(page.getByRole('combobox', {name: 'Carriers', exact: true})).toContainText('AA')
+  await expect(page.getByRole('combobox', {name: 'Carriers', exact: true})).toContainText('UA')
+  await expect(page.getByRole('combobox', {name: 'All Carriers'})).toContainText('selected')
+  expect(await page.evaluate(() => new URLSearchParams(location.search).has('carrier_all'))).toBe(false)
   await expect(page.locator('#daterange-window-start')).toHaveValue('2024-01-05')
   await expect(page.locator('#daterange-window-end')).toHaveValue('2024-01-12')
   await expect(page.locator('.preset-select')).toHaveValue('Last 7 Days')
   expect(
-    queryBodies.some(
-      body =>
-        JSON.stringify(body.params) ===
-        JSON.stringify({
-          search_text: 'delta',
-          carrier_multi: ['AA', 'UA'],
-          window_start: '2024-01-05',
-          window_end: '2024-01-12',
-        }),
-    ),
+    queryBodies.some(body =>
+      body.params.search_text == 'delta' && body.params.carrier_multi?.mode == 'include' && body.params.carrier_multi?.values.join(',') == 'AA,UA' &&
+      body.params.carrier_all?.mode == 'exclude' && body.params.carrier_all?.values.length == 0 &&
+      body.params.window_start == '2024-01-05' && body.params.window_end == '2024-01-12'),
   ).toBe(true)
 
   await page.getByLabel('Search Text').fill('omega')
   await expect.poll(() => queryBodies.some(body => body.params.search_text === 'omega')).toBe(true)
-  await page.getByRole('combobox', {name: 'Carriers'}).click()
+  await page.getByRole('combobox', {name: 'Carriers', exact: true}).click()
   await page.getByRole('option', {name: 'DL'}).click()
+  await page.keyboard.press('Escape')
+  await page.getByRole('combobox', {name: 'All Carriers'}).click()
+  await page.getByRole('option', {name: 'AA'}).click()
   await page.locator('#daterange-window-start').evaluate((el: HTMLInputElement) => {
     el.value = '2024-01-08'
     el.dispatchEvent(new Event('change', {bubbles: true}))
   })
+  await expect.poll(() => queryBodies.some(body => JSON.stringify(body.params.carrier_all) === JSON.stringify({mode: 'exclude', values: ['AA']}))).toBe(true)
   await expect
     .poll(() => readSearchParams(page))
     .toEqual({
       search_text: 'omega',
-      carrier_multi: ['AA', 'UA', 'DL'],
+      carrier_multi: 'i:AA,UA,DL',
+      carrier_all: 'e:AA',
       window_start: '2024-01-08',
       window_end: '2024-01-12',
     })
@@ -539,9 +627,12 @@ test('inputs sync url state on load, change, and reload', {timeout: 20000}, asyn
   await page.reload()
   await waitForGrapheneLoad(page)
   await expect(page.getByLabel('Search Text')).toHaveValue('omega')
-  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('AA')
-  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('UA')
-  await expect(page.getByRole('combobox', {name: 'Carriers'})).toContainText('DL')
+  await expect(page.getByRole('combobox', {name: 'Carriers', exact: true})).toContainText('AA')
+  await expect(page.getByRole('combobox', {name: 'Carriers', exact: true})).toContainText('UA')
+  await expect(page.getByRole('combobox', {name: 'Carriers', exact: true})).toContainText('DL')
+  await page.getByRole('combobox', {name: 'All Carriers'}).click()
+  await expect(page.getByRole('option', {name: 'AA'})).toHaveAttribute('aria-selected', 'false')
+  await expect(page.getByRole('option', {name: 'UA'})).toHaveAttribute('aria-selected', 'true')
   await expect(page.locator('#daterange-window-start')).toHaveValue('2024-01-08')
   await expect(page.locator('#daterange-window-end')).toHaveValue('2024-01-12')
 })
@@ -595,7 +686,7 @@ test('inputs resync from url changes after navigation events', async ({server, p
     .poll(() => queryBodies[queryBodies.length - 1]?.params)
     .toEqual({
       search_text: 'sigma',
-      carrier_multi: ['DL'],
+      carrier_multi: {mode: 'include', values: ['DL']},
       window_start: '2024-01-10',
       window_end: '2024-01-20',
     })

--- a/ui/tests/snapshots/inputs.test.ts/dropdown-multiselect-exclude-mode.png
+++ b/ui/tests/snapshots/inputs.test.ts/dropdown-multiselect-exclude-mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35cac36857ea992b46abd4cf90dfe86a9318a3b9b59cc25a8afe5b6090619a2c
+size 5444

--- a/ui/tests/snapshots/inputs.test.ts/dropdown-multiselect-include-mode.png
+++ b/ui/tests/snapshots/inputs.test.ts/dropdown-multiselect-include-mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11ebc6690c1615f8028a688ca49246cefe88ddd77c52340482c8f56984647c23
+size 5537

--- a/ui/tests/snapshots/run-examples.test.ts/example-flights-pages-dropdown-defaults-test.png
+++ b/ui/tests/snapshots/run-examples.test.ts/example-flights-pages-dropdown-defaults-test.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94dd3bce4a4c5b2b68f27c6a61bcd519d05a1bcb0f0ae81e6c419343c4507006
-size 33868
+oid sha256:c5c44dffdbe45cd43afcd84e23556ac2c42b32ff9c6a56c7c9c1a6525c4a137a
+size 34059


### PR DESCRIPTION
If a multiselect has a ton of values, selectAllByDefault can mean the url gets enormous, potentially getting blocked by the browser or WAF.

I think that if you use selectAllByDefault, we should invert the logic so the params only show the values you're excluding, and your query would be a `NOT IN ($param)`.

We can even enforce this by analyzing queries using dropdown params and ensuring that they use either IN or NOT IN as appropriate.

This is a breaking change in that queries using a selectAllByDefault will need to be changed, though `graphene check` should catch them. It also means saved urls might behave differently now.

I also fixed the empty-set handling, so selecting all/none won't generate invalid sql like `not in ()`