### PR TITLE
Various formatting -> ECharts bugfixes

### DIFF
--- a/docs/references/echarts.md
+++ b/docs/references/echarts.md
@@ -36,8 +36,16 @@ You don't need to configure these — Graphene applies them by default:
 - Axes: created if missing, types inferred from field metadata (time, category, value), tick formatting applied
 - Layout: grid padding computed to prevent title/legend overlap
 - Style: color palette, fonts, axis borders, split lines, and series marker defaults (via the Graphene theme)
+- Values: axis ticks, tooltips, and bar labels formatted from the column's metadata (`#currency`, `#unit`, `#ratio`, `#pct`, `#precision`, `#timeGrain`, `#timeOrdinal`)
 
 Your config typically only needs to specify the series `type`, `encode` mappings, and any explicit overrides to the above.
+
+Metadata formatting follows the `encode` mapping, so it needs the value column named there - `y` for a vertical
+cartesian series, `x` for a horizontal one, and `value` for the types that use it (pie, funnel, treemap, sankey,
+themeRiver). A series that carries its numbers in a literal `series.data` array, or encodes them by dataset
+dimension index (`encode: {y: 1}`), has no column to read metadata from, so those values render unformatted.
+Anything you set yourself wins over the default, so `axisLabel.formatter`, `series.tooltip.valueFormatter`,
+`tooltip.formatter`, and `label.formatter` are all still yours to override.
 
 ## Encode fields by series type
 
@@ -45,7 +53,7 @@ Each series type maps columns via `encode`. Graphene accepts:
 
 | Series type | Encode fields |
 |-------------|---------------|
-| `bar`, `line`, `scatter`, `candlestick`, `heatmap`, `effectScatter` | `x`, `y`, `splitBy` |
+| `bar`, `pictorialBar`, `line`, `scatter`, `candlestick`, `heatmap`, `effectScatter` | `x`, `y`, `splitBy` |
 | `pie`, `funnel` | `itemName`, `value` |
 | `treemap` | `itemName`, `value` |
 | `sankey`, `chord` | `source`, `target`, `value` |

--- a/docs/references/echarts.md
+++ b/docs/references/echarts.md
@@ -40,13 +40,6 @@ You don't need to configure these — Graphene applies them by default:
 
 Your config typically only needs to specify the series `type`, `encode` mappings, and any explicit overrides to the above.
 
-Metadata formatting follows the `encode` mapping, so it needs the value column named there - `y` for a vertical
-cartesian series, `x` for a horizontal one, and `value` for the types that use it (pie, funnel, treemap, sankey,
-themeRiver). A series that carries its numbers in a literal `series.data` array, or encodes them by dataset
-dimension index (`encode: {y: 1}`), has no column to read metadata from, so those values render unformatted.
-Anything you set yourself wins over the default, so `axisLabel.formatter`, `series.tooltip.valueFormatter`,
-`tooltip.formatter`, and `label.formatter` are all still yours to override.
-
 ## Encode fields by series type
 
 Each series type maps columns via `encode`. Graphene accepts:

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -2439,6 +2439,23 @@ describe('lang', () => {
     expect(errors[0].to?.col).toBe(27)
   })
 
+  it('attaches metadata comments inside markdown fences to the right column', () => {
+    analyze(
+      trimIndentation(`## My analysis
+      \`\`\`gsql ages
+        from users select
+          name,
+          -- Average age #unit=years
+          avg(age) as avg_age
+      \`\`\`
+    `),
+      'md',
+    )
+    let columns = getTable('ages')!.columns
+    expect(columns.find(c => c.name === 'avg_age')!.metadata).toMatchObject({unit: 'years', description: 'Average age'})
+    expect(columns.find(c => c.name === 'name')!.metadata?.unit).toBeUndefined()
+  })
+
   it('marks markdown component attribute errors across the attribute value', () => {
     analyze('<BarChart data="users" x="code" y="age" />', 'md')
     let errors = getDiagnostics().filter(d => d.severity === 'error')

--- a/lang/metadata.ts
+++ b/lang/metadata.ts
@@ -48,7 +48,10 @@ export function extractLeadingMetadata(node: SyntaxNode): Record<string, string>
 }
 
 export function extractLeadingMetadataDetails(node: SyntaxNode): {metadata: Record<string, string>; entries: MetadataEntry[]} {
-  let src = getFile(node).contents
+  // Node offsets are in the file's parsed document, which for Markdown pages is the virtual gsql we build
+  // from its fences and components - not the Markdown itself.
+  let file = getFile(node)
+  let src = file.virtualContents ?? file.contents
   if (!src) return {metadata: {}, entries: []}
 
   let pos = node.from

--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -16,6 +16,7 @@ import {paletteForPath} from './theme.ts'
 // Run enrichment in a fixed order so defaults stay predictable.
 export function enrich(config: EChartsConfig, rows: Record<string, any>[], fields: Field[]) {
   let normalized = normalize(config)
+  nameEncodedDimensions(normalized, fields)
   ensureAxes(normalized)
   ensureTooltip(normalized)
   ensureColors(normalized)
@@ -244,6 +245,37 @@ function buildSplitSeries(template: SeriesWithGroupingHint, datasetId: string, n
     delete next.encode.splitBy
   }
   return next
+}
+
+// ECharts lets a series encode a column either by name or by its position in the dataset's dimensions, so
+// `encode: {y: 1}` and `encode: {y: 'revenue'}` mean the same thing to it. Every enrichment that reads metadata
+// looks columns up by name, so rewrite the positional form into the name it refers to and they all keep working.
+// Indices we can't place - no dimensions to read, or a position outside them - are left alone for ECharts to
+// resolve as it normally would.
+function nameEncodedDimensions(config: NormalConfig, fields: Field[]) {
+  for (let series of config.series) {
+    if (!series?.encode) continue
+    let dimensions = datasetDimensions(config, series) ?? fields.map(field => field.name)
+    let encode = series.encode as Record<string, unknown>
+
+    for (let [prop, value] of Object.entries(encode)) {
+      encode[prop] = Array.isArray(value) ? value.map(entry => dimensionName(entry, dimensions)) : dimensionName(value, dimensions)
+    }
+  }
+}
+
+// The dimension names a series reads through its dataset. Undefined when the config didn't declare any, since
+// the dataset we build ourselves doesn't exist yet at this point in enrichment.
+function datasetDimensions(config: NormalConfig, series: SeriesWithGroupingHint) {
+  let dataset = series.datasetId != null ? config.dataset.find(entry => entry?.id === series.datasetId) : config.dataset.find(entry => entry?.source != null)
+  let dimensions = dataset?.dimensions
+  if (!Array.isArray(dimensions)) return undefined
+  return dimensions.map(dimension => (typeof dimension === 'string' ? dimension : (dimension as {name?: string})?.name))
+}
+
+function dimensionName(value: unknown, dimensions: (string | undefined)[]) {
+  if (typeof value !== 'number' || !Number.isInteger(value)) return value
+  return dimensions[value] ?? value
 }
 
 // Ensure cartesian series always have at least one x/y axis object.

--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -250,7 +250,7 @@ function buildSplitSeries(template: SeriesWithGroupingHint, datasetId: string, n
 // This gives later enrichments an axis target to infer into, and avoids
 // ECharts runtime errors like `xAxis "0" not found`.
 function ensureAxes(config: NormalConfig) {
-  let cartesianSeriesTypes = new Set(['line', 'bar', 'scatter', 'candlestick', 'heatmap', 'boxplot', 'effectScatter'])
+  let cartesianSeriesTypes = new Set(['line', 'bar', 'pictorialBar', 'scatter', 'candlestick', 'heatmap', 'boxplot', 'effectScatter'])
   let needsCartesianAxes = config.series.some(series => series?.type != null && cartesianSeriesTypes.has(series.type))
   if (!needsCartesianAxes) return
 
@@ -647,13 +647,16 @@ function addPieTooltips(config: NormalConfig, fields: Field[]) {
 
   tooltip.trigger = 'item'
   tooltip.formatter = (params: any) => {
+    let series = config.series[Number(params?.seriesIndex ?? 0)]
+    let valueField = getSeriesValueField(series, fields)
     let value = params?.value
     if (value && typeof value === 'object' && !Array.isArray(value)) {
-      let series = config.series[Number(params?.seriesIndex ?? 0)]
-      let yField = getSeriesValueField(series, fields)?.name
-      value = yField && value[yField] != null ? value[yField] : value.value
+      value = valueField && value[valueField.name] != null ? value[valueField.name] : value.value
     }
-    return `${params?.name ?? ''}: ${value ?? ''} (${params?.percent ?? 0}%)`
+
+    // Reuse the series' own formatter so slices read the same as the rest of the chart's values.
+    let formatted = series?.tooltip?.valueFormatter ? series.tooltip.valueFormatter(value, params?.dataIndex) : formatFromField(valueField, value)
+    return `${escapeHtml(params?.name ?? '')}: ${escapeHtml(formatted)} (${params?.percent ?? 0}%)`
   }
 }
 
@@ -882,21 +885,21 @@ function getSeriesValueField(series: SeriesWithGroupingHint | undefined, fields:
   return getEncodeField(series, fields, 'y') ?? getEncodeField(series, fields, 'value')
 }
 
-// The field(s) to format in a series' tooltip. Depends on series type since scatter/bar put the numeric value in different encode props.
+// The field(s) to format in a series' tooltip. Depends on series type since series put the numeric value in different encode props.
 function getSeriesValueFields(series: SeriesWithGroupingHint, fields: Field[]) {
   switch (series.type) {
     case 'scatter':
     case 'effectScatter':
       return [getEncodeField(series, fields, 'x'), getEncodeField(series, fields, 'y')].filter((f): f is Field => !!f)
-    case 'bar': {
-      let xField = getEncodeField(series, fields, 'x')
-      let yField = getEncodeField(series, fields, 'y')
-      return xField?.type == 'number' ? [xField] : [yField].filter((f): f is Field => !!f)
-    }
     case 'heatmap':
       return [getEncodeField(series, fields, 'value')].filter((f): f is Field => !!f)
-    default:
-      return [getEncodeField(series, fields, 'y')].filter((f): f is Field => !!f)
+    default: {
+      // Everything else names its value `y`, `value` (pie, funnel, treemap, sankey), or - when it runs horizontally,
+      // like a bar or pictorialBar on a category y-axis - `x`. Prefer whichever of those is numeric, since that is
+      // the one carrying the metadata worth formatting.
+      let candidates = [getEncodeField(series, fields, 'y'), getEncodeField(series, fields, 'value'), getEncodeField(series, fields, 'x')]
+      return [candidates.find(field => field?.type === 'number') ?? candidates.find(Boolean)].filter((f): f is Field => !!f)
+    }
   }
 }
 

--- a/ui/component-utilities/enrich.ts
+++ b/ui/component-utilities/enrich.ts
@@ -264,13 +264,18 @@ function nameEncodedDimensions(config: NormalConfig, fields: Field[]) {
   }
 }
 
-// The dimension names a series reads through its dataset. Undefined when the config didn't declare any, since
-// the dataset we build ourselves doesn't exist yet at this point in enrichment.
+// The dimension names a series reads through its dataset. Follow the same id/index selection ECharts uses, then
+// walk through transforms because filtered and sorted datasets inherit their source dataset's dimensions.
 function datasetDimensions(config: NormalConfig, series: SeriesWithGroupingHint) {
-  let dataset = series.datasetId != null ? config.dataset.find(entry => entry?.id === series.datasetId) : config.dataset.find(entry => entry?.source != null)
-  let dimensions = dataset?.dimensions
-  if (!Array.isArray(dimensions)) return undefined
-  return dimensions.map(dimension => (typeof dimension === 'string' ? dimension : (dimension as {name?: string})?.name))
+  let dataset = series.datasetId != null ? config.dataset.find(entry => entry?.id === series.datasetId) : config.dataset[Number(series.datasetIndex ?? 0)]
+
+  while (dataset) {
+    if (Array.isArray(dataset.dimensions)) return dataset.dimensions.map(dimension => (typeof dimension === 'string' ? dimension : (dimension as {name?: string})?.name))
+    let sourceId = dataset.fromDatasetId
+    if (sourceId != null) dataset = config.dataset.find(entry => entry?.id === sourceId)
+    else if (dataset.fromDatasetIndex != null) dataset = config.dataset[Number(dataset.fromDatasetIndex)]
+    else return undefined
+  }
 }
 
 function dimensionName(value: unknown, dimensions: (string | undefined)[]) {

--- a/ui/component-utilities/types.ts
+++ b/ui/component-utilities/types.ts
@@ -26,6 +26,7 @@ type CommonSeriesFields = {
   color?: string
   stack?: string
   datasetId?: string
+  datasetIndex?: number
   data?: unknown
   links?: unknown
   layout?: string

--- a/ui/tests/snapshots/viz.test.ts/pie-chart-tooltip.png
+++ b/ui/tests/snapshots/viz.test.ts/pie-chart-tooltip.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8ae30e87426b389abf7b9ddf6df9a1fff1bb3f8cd354434625caf3e99edb1f3
-size 21590
+oid sha256:378c3a90ac4165fe77ea6a75d1be3b7271abf05ac6760b55ca4efdc1536f3739
+size 21109

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -682,6 +682,47 @@ test('pie chart', async ({mount, chart}) => {
   await expect(chart.el).screenshot('pie-chart-tooltip')
 })
 
+test('value-encoded series format their values from field metadata', async ({mount, chart}) => {
+  // pie/funnel/treemap name their value `value` rather than `y`, so this checks that metadata still reaches them.
+  let data = singleDim() // `value` carries currency: USD
+
+  await mount('components/ECharts.svelte', {data, config: {series: [{type: 'pie', encode: {itemName: 'category', value: 'value'}}]}})
+  let pie = await chart.config(option => {
+    let series = Array.isArray(option.series) ? option.series[0] : option.series
+    let tooltip = Array.isArray(option.tooltip) ? option.tooltip[0] : option.tooltip
+    return {value: series.tooltip.valueFormatter(4200), tooltip: tooltip.formatter({seriesIndex: 0, dataIndex: 0, name: 'Bikes', percent: 33, value: {category: 'Bikes', value: 4200}})}
+  })
+  expect(pie).toEqual({value: '$4.2k', tooltip: 'Bikes: $4.2k (33%)'})
+
+  await mount('components/ECharts.svelte', {data, config: {series: [{type: 'funnel', encode: {itemName: 'category', value: 'value'}}]}})
+  let funnel = await chart.config(option => {
+    let series = Array.isArray(option.series) ? option.series[0] : option.series
+    return series.tooltip.valueFormatter(4200)
+  })
+  expect(funnel).toBe('$4.2k')
+})
+
+test('horizontal bar-like series format the value on their x axis', async ({mount, chart}) => {
+  let rows = [
+    {carrier: 'AA', delay: 42},
+    {carrier: 'DL', delay: 58},
+  ]
+  let fields = [
+    {name: 'carrier', type: scalarType('string')},
+    {name: 'delay', type: scalarType('number'), metadata: {unit: 'minutes'}},
+  ]
+
+  // pictorialBar isn't a type we special-case, but it still carries its value on x when the y axis is categorical.
+  await mount('components/ECharts.svelte', {data: {rows, fields}, config: {yAxis: {type: 'category'}, series: [{type: 'pictorialBar', symbol: 'rect', symbolRepeat: false, encode: {x: 'delay', y: 'carrier'}}]}})
+  let formatted = await chart.config(option => {
+    let series = Array.isArray(option.series) ? option.series[0] : option.series
+    let xAxis = Array.isArray(option.xAxis) ? option.xAxis[0] : option.xAxis
+    return {axis: xAxis.axisLabel.formatter(42), tooltip: series.tooltip.valueFormatter(42)}
+  })
+
+  expect(formatted).toEqual({axis: '42m', tooltip: '42m'})
+})
+
 test.skip('can provide a list of colors for different series', async () => {})
 
 test.skip('line chart seriesLabelFmt formats date series names', async ({mount, chart}) => {

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -723,6 +723,53 @@ test('horizontal bar-like series format the value on their x axis', async ({moun
   expect(formatted).toEqual({axis: '42m', tooltip: '42m'})
 })
 
+test('encoding a column by dimension index formats like encoding it by name', async ({mount, chart}) => {
+  let rows = [
+    {carrier: 'AA', delay: 42},
+    {carrier: 'DL', delay: 58},
+  ]
+  let fields = [
+    {name: 'carrier', type: scalarType('string')},
+    {name: 'delay', type: scalarType('number'), metadata: {unit: 'minutes'}},
+  ]
+
+  await mount('components/ECharts.svelte', {data: {rows, fields}, config: {series: [{type: 'bar', encode: {x: 0, y: 1}}]}})
+  let byIndex = await chart.config(option => {
+    let xAxis = Array.isArray(option.xAxis) ? option.xAxis[0] : option.xAxis
+    let yAxis = Array.isArray(option.yAxis) ? option.yAxis[0] : option.yAxis
+    let series = Array.isArray(option.series) ? option.series[0] : option.series
+    return {x: xAxis.type, y: yAxis.type, axis: yAxis.axisLabel.formatter(42), tooltip: series.tooltip.valueFormatter(42)}
+  })
+
+  expect(byIndex).toEqual({x: 'category', y: 'value', axis: '42m', tooltip: '42m'})
+})
+
+test('dimension indexes resolve against the dataset the config declared', async ({mount, chart}) => {
+  let rows = [
+    {carrier: 'AA', delay: 42},
+    {carrier: 'DL', delay: 58},
+  ]
+  let fields = [
+    {name: 'carrier', type: scalarType('string')},
+    {name: 'delay', type: scalarType('number'), metadata: {unit: 'minutes'}},
+  ]
+
+  // Dimensions here are the reverse of the field order, so an index read off the fields would pick the wrong column.
+  await mount('components/ECharts.svelte', {
+    data: {rows, fields},
+    config: {dataset: [{source: rows, dimensions: ['delay', 'carrier']}], series: [{type: 'bar', encode: {x: 1, y: 0}}]},
+  })
+  let encode = (await chart.config(option => {
+    let series = Array.isArray(option.series) ? option.series[0] : option.series
+    let yAxis = Array.isArray(option.yAxis) ? option.yAxis[0] : option.yAxis
+    return {encode: series.encode, axis: yAxis.axisLabel.formatter(42)}
+  }))!
+
+  expect(encode.encode.x).toBe('carrier')
+  expect(encode.encode.y).toBe('delay')
+  expect(encode.axis).toBe('42m')
+})
+
 test.skip('can provide a list of colors for different series', async () => {})
 
 test.skip('line chart seriesLabelFmt formats date series names', async ({mount, chart}) => {

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -770,6 +770,37 @@ test('dimension indexes resolve against the dataset the config declared', async 
   expect(encode.axis).toBe('42m')
 })
 
+test('dimension indexes use the series datasetIndex and inherited dimensions', async ({mount, chart}) => {
+  let rows = [
+    {carrier: 'AA', delay: 42},
+    {carrier: 'DL', delay: 58},
+  ]
+  let fields = [
+    {name: 'carrier', type: scalarType('string')},
+    {name: 'delay', type: scalarType('number'), metadata: {unit: 'minutes'}},
+  ]
+
+  // Dataset 2 inherits dataset 1's reversed dimensions. Falling back to dataset 0 or field order swaps x and y.
+  await mount('components/ECharts.svelte', {
+    data: {rows, fields},
+    config: {
+      dataset: [
+        {id: 'other', source: rows, dimensions: ['carrier', 'delay']},
+        {id: 'source', source: rows, dimensions: ['delay', 'carrier']},
+        {fromDatasetId: 'source', transform: {type: 'filter', config: {dimension: 'carrier', '=': 'AA'}}},
+      ],
+      series: [{type: 'bar', datasetIndex: 2, encode: {x: 1, y: 0}}],
+    },
+  })
+  let formatted = await chart.config(option => {
+    let series = Array.isArray(option.series) ? option.series[0] : option.series
+    let yAxis = Array.isArray(option.yAxis) ? option.yAxis[0] : option.yAxis
+    return {encode: series.encode, axis: yAxis.axisLabel.formatter(42), tooltip: series.tooltip.valueFormatter(42)}
+  })
+
+  expect(formatted).toEqual({encode: {x: 'carrier', y: 'delay'}, axis: '42m', tooltip: '42m'})
+})
+
 test.skip('can provide a list of colors for different series', async () => {})
 
 test.skip('line chart seriesLabelFmt formats date series names', async ({mount, chart}) => {


### PR DESCRIPTION
Seven bugs:

1. Formatting did not fully carry into tooltips on series that use `encode.value` instead of `encode.x`/`encode.y`. $25m rendered as 25M, 73% as 0.734, 12.3M mi as 12.3M. Its singular sibling getSeriesValueField already did `y ?? value`, which is why the same pie chart had correct labels and a wrong tooltip.
2. Pie tooltips ignored formatting entirely. `addPieTooltips` installs a whole-tooltip formatter, which overrides `valueFormatter`, and it interpolated the number raw: `Southwest: 24983102.88 (18.4%)`. Now formats through the series' own formatter.
3. Bar tooltips picked the x column whenever x was numeric. Right for horizontal bars, wrong for a vertical bar over a numeric x — a flight count came out as 1.23k mi because the x axis was in miles. Now prefers the numeric candidate among y, value, x in that order, which also covers series types the old switch never listed (pictorialBar, boxplot).
4. Pie tooltip text wasn't HTML-escaped. ECharts renders formatter output as HTML, and this string is built from query data. The cartesian item tooltip alongside it already escaped.
5. pictorialBar got no axes. It wasn't in ensureAxes' cartesian list, so a config declaring only its categorical axis died with xAxis "0" not found — no chart, just a red box. The missing axis object was also where metadata formatting gets written, so it lost tick formatting too. This is the lollipop pattern in our own docs, which is why that example declares both axes by hand.
6. `#` metadata comments in md fences attached to the wrong column. `extractLeadingMetadataDetails` scanned `file.contents` at node offsets, but a Markdown page is parsed as a virtual gsql document built from its fences and components — so it read Markdown prose at gsql offsets. A `#currency=USD` above a fence's `sum(...)` landed on the neighboring carrier column. Page rendering is unaffected ([cli/serve2.ts:157](https://github.com/graphene-data/graphene/blob/claude/echarts-metadata-formatting-fynopq/cli/serve2.ts#L157) excludes .md and analyzes fence text as plain gsql); this is what the editor, language server, and `graphene check` see. 
7. Positional `encode` indexes a la `encode: {y: 1}` resolved to nothing. The lookup was name-only and filtered numbers out, even though ECharts treats index and name as equivalent. Beyond losing metadata, axis inference had no field to work from and defaulted both axes to category, so a numeric axis rendered as discrete buckets. Indexes are now rewritten to names up front, resolved against the dimensions the config's own dataset declares.