### PR TITLE
Fix pXX percentile shorthand for single-digit percentiles

### DIFF
--- a/lang/functions.ts
+++ b/lang/functions.ts
@@ -227,7 +227,9 @@ function renderFunctionSql(fnName: string, overload: Overload, args: Expr[]) {
 }
 
 function analyzePercentile(analyzer: Analyzer, node: SyntaxNode, args: Expr[], digits: string, scope: Scope, opts: {isWindow?: boolean} = {}): Expr {
-  let frac = Number(`0.${digits}`)
+  // Pad to at least 2 digits so single-digit shorthand (p1, p5) means the 1st/5th percentile
+  // (0.01, 0.05), not tenths (0.1, 0.5). Digits beyond 2 (e.g. p975) add sub-percentile precision.
+  let frac = Number(`0.${digits.padStart(2, '0')}`)
   if (Number(digits) == 100) return analyzer.diag(node, 'p100 is not allowed', {sql: 'NULL', type: scalarType('error')})
   if (Number(digits) == 0) return analyzer.diag(node, 'p0 is not allowed', {sql: 'NULL', type: scalarType('error')})
   if (analyzer.config.dialect == 'bigquery' && frac > 0.99) return analyzer.diag(node, 'BigQuery only supports up to p99', {sql: 'NULL', type: scalarType('error')})

--- a/lang/lang.test.ts
+++ b/lang/lang.test.ts
@@ -606,6 +606,13 @@ describe('lang', () => {
       .toReturnRows([24, 40, 40])
   })
 
+  it('parses single-digit pXX shorthand as the Nth percentile, not tenths', () => {
+    expect('from orders select p5(amount) as p5, p1(amount) as p1, p25(amount) as p25, p975(amount) as p975')
+      .toRenderSql(
+        'select quantile_cont(orders.amount, 0.05) as p5, quantile_cont(orders.amount, 0.01) as p1, quantile_cont(orders.amount, 0.25) as p25, quantile_cont(orders.amount, 0.975) as p975 from orders as orders',
+      )
+  })
+
   it('supports pXX over empty window', () => {
     expect('from orders select id, p50(amount) over () as p50_all order by id')
       .toRenderSql('select orders.id as id, quantile_cont(orders.amount, 0.5) OVER () as p50_all from orders as orders order by 1 asc nulls last')


### PR DESCRIPTION
`p5()` was being interpreted as `p50()`, `p1()` as `p10()`, etc. This maps single digit invocations to `p05()`, `p01()`, etc, while still mapping `p50()` to the median, `p975()` to 97.5th percentile, etc.