### PR TITLE
Fix and test Windows CLI login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,20 @@ jobs:
           name: UI test diffs
           path: ui/tests/results/**
 
+  windows-smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with: {lfs: true, persist-credentials: false}
+      - uses: ./.github/actions/setup
+      - name: Local dev server
+        run: pnpm test cli/cli.test.ts -t "starts and stops the server in the background"
+      - name: Cloud browser login
+        if: always() # Keep the independent login signal when local server coverage finds a Windows-specific failure.
+        run: pnpm test cli/auth.windows.test.ts
+        env:
+          XDG_CONFIG_HOME: ${{ runner.temp }}/graphene-config
+
   test-vscode:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:

--- a/cli/auth.test.ts
+++ b/cli/auth.test.ts
@@ -1,12 +1,29 @@
 /// <reference types="vitest/globals" />
 // Covers CLI requests with delegated tokens and renewable credentials saved by `graphene login`.
 
+import {spawn} from 'child_process'
 import fs from 'node:fs/promises'
 import {createServer} from 'node:http'
 
 import {config, normalizeConfig, setGlobalConfig} from '../lang/config.ts'
 import {gFetch} from '../utils/index.ts'
-import {authenticatedFetch} from './auth.ts'
+import {authenticatedFetch, openInBrowser} from './auth.ts'
+
+vi.mock('child_process', () => ({spawn: vi.fn()}))
+
+// Windows OAuth URLs must bypass cmd.exe, which treats each `&`-delimited parameter as a separate command.
+test('openInBrowser preserves the complete OAuth URL on Windows', () => {
+  let url = 'https://app.graphenedata.com/authenticate?redirect_uri=http%3A%2F%2F127.0.0.1%3A5054%2Fcallback&client_id=connected-app-live&state=login-state'
+  let unref = vi.fn()
+  vi.mocked(spawn).mockReturnValue({unref} as any)
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+  openInBrowser(url)
+
+  expect(spawn).toHaveBeenCalledWith('rundll32', ['url.dll,FileProtocolHandler', url], {stdio: 'ignore'})
+  expect(unref).toHaveBeenCalled()
+  vi.restoreAllMocks()
+})
 
 test('gFetch decodes JSON and plain-text error responses', async () => {
   let server = createServer((req, res) => {

--- a/cli/auth.ts
+++ b/cli/auth.ts
@@ -66,13 +66,17 @@ async function updateEntry(cred: Cred) {
   }
 }
 
+// Opens an authentication URL with the operating system's browser without passing OAuth parameters through a shell.
 export function openInBrowser(url: string) {
   try {
-    let plat = process.platform
     let cmd = 'xdg-open'
-    if (plat == 'darwin') cmd = 'open'
-    if (plat == 'win32') cmd = 'start'
-    let p = spawn(cmd, [url], {stdio: 'ignore', shell: plat === 'win32'})
+    let args = [url]
+    if (process.platform == 'darwin') cmd = 'open'
+    if (process.platform == 'win32') {
+      cmd = 'rundll32'
+      args = ['url.dll,FileProtocolHandler', url]
+    }
+    let p = spawn(cmd, args, {stdio: 'ignore'})
     p.unref()
   } catch {
     console.log(`Open this URL to authenticate:\n${url}`)

--- a/cli/auth.windows.test.ts
+++ b/cli/auth.windows.test.ts
@@ -1,0 +1,60 @@
+/// <reference types="vitest/globals" />
+// Exercises the complete CLI browser login through Windows' real URL handler and a local OAuth stand-in.
+
+import {createServer} from 'node:http'
+
+import {config, normalizeConfig, setGlobalConfig} from '../lang/config.ts'
+import {authClientId, loginPkce} from './auth.ts'
+
+const windowsCi = process.platform == 'win32' && !!process.env.CI
+
+// Verify Windows passes every OAuth parameter through the browser, loopback callback, and token exchange unchanged.
+test.runIf(windowsCi)('completes browser login through the Windows URL handler', async () => {
+  let originalConfig = structuredClone(config)
+  let authorizeRequest = Promise.withResolvers<URL>()
+  let tokenRequest = Promise.withResolvers<Record<string, string>>()
+  let server = createServer(async (req, res) => {
+    let requestUrl = new URL(req.url || '/', 'http://127.0.0.1')
+
+    if (req.method == 'GET' && requestUrl.pathname == '/authenticate') {
+      authorizeRequest.resolve(requestUrl)
+      let callback = new URL(requestUrl.searchParams.get('redirect_uri')!)
+      callback.searchParams.set('code', 'windows-login-code')
+      callback.searchParams.set('state', requestUrl.searchParams.get('state')!)
+      res.writeHead(302, {location: callback.toString()})
+      res.end()
+      return
+    }
+
+    if (req.method == 'POST' && requestUrl.pathname == '/_api/oauth2/token') {
+      let chunks: Buffer[] = []
+      for await (let chunk of req) chunks.push(chunk)
+      tokenRequest.resolve(JSON.parse(Buffer.concat(chunks).toString()))
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({access_token: 'windows-access-token', refresh_token: 'windows-refresh-token', token_type: 'Bearer', expires_in: 3600}))
+      return
+    }
+
+    res.statusCode = 404
+    res.end('Not found')
+  })
+
+  try {
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    let address = server.address()
+    if (!address || typeof address == 'string') throw new Error('Failed to start Windows auth test server')
+    setGlobalConfig(normalizeConfig({root: 'windows-login-test', clickhouse: {}, cloud: `http://127.0.0.1:${address.port}`}))
+
+    await loginPkce()
+
+    let authorizeUrl = await authorizeRequest.promise
+    expect(authorizeUrl.searchParams.get('client_id')).toBe(authClientId())
+    expect(authorizeUrl.searchParams.get('redirect_uri')).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/)
+    expect(authorizeUrl.searchParams.get('code_challenge')).toBeTruthy()
+    expect(authorizeUrl.searchParams.get('state')).toBeTruthy()
+    expect(await tokenRequest.promise).toMatchObject({code: 'windows-login-code', client_id: authClientId(), redirect_uri: authorizeUrl.searchParams.get('redirect_uri')})
+  } finally {
+    setGlobalConfig(originalConfig)
+    await new Promise(resolve => server.close(resolve))
+  }
+})

--- a/cli/background.ts
+++ b/cli/background.ts
@@ -95,8 +95,9 @@ function sendSignal(pid: number, signal: NodeJS.Signals): boolean {
   return true
 }
 
-export async function stopGrapheneIfRunning(): Promise<void> {
-  let port = config.port
+// Stops the background server listening on the configured or explicitly supplied port.
+export async function stopGrapheneIfRunning(portOverride?: number): Promise<void> {
+  let port = portOverride ?? config.port
   let pid = await getPidOnPort(port)
   if (!pid) return
 

--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -3,13 +3,14 @@ import * as fsp from 'node:fs/promises'
 import {createServer, type IncomingMessage, type ServerResponse} from 'node:http'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import {fileURLToPath} from 'node:url'
 
 import {loadConfig, normalizeConfig, type Config, type ConfigInput} from '../lang/config.ts'
 import {isServerRunning, stopGrapheneIfRunning} from './background.ts'
 import {normalizePageUrl} from './run.ts'
 import {expect, test} from './testFixtures.ts'
 
-const dir = path.resolve(import.meta.url.replace('file://', ''), '../')
+const dir = path.dirname(fileURLToPath(import.meta.url))
 const flightDir = path.resolve(dir, '../examples/flights')
 const TEST_PORT = 4163
 const flightConfig = configFor(flightDir, {port: TEST_PORT})
@@ -112,7 +113,7 @@ describe('cli compile', () => {
 
 describe('cli serve', () => {
   test('starts and stops the server in the background', async ({runCli}) => {
-    await stopGrapheneIfRunning()
+    await stopGrapheneIfRunning(TEST_PORT)
 
     try {
       let start = await runCli(['serve', '--bg'], flightConfig)
@@ -124,7 +125,7 @@ describe('cli serve', () => {
       expectCliSuccess(stop, 'serve stop')
       expect(await isServerRunning(TEST_PORT)).toBe(false)
     } finally {
-      await stopGrapheneIfRunning()
+      await stopGrapheneIfRunning(TEST_PORT)
     }
   })
 


### PR DESCRIPTION
Open authentication URLs through Windows' URL handler without cmd.exe so
ampersand-delimited OAuth parameters reach the browser intact. Add a Windows
CI smoke job covering local serve and the full browser login loopback flow.