### PR TITLE
Simplify CLI update notifier

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -20,18 +20,10 @@ import {formatError, printTable} from './printer.ts'
 import {sendToPage} from './run.ts'
 import {inspectSchema, printSchemaInspection, type SchemaInspection} from './schemaInspection.ts'
 import {getPresentFlags, sendTelemetry, type TelemetryCommand} from './telemetry.ts'
-import {checkForUpdate, showCachedUpdateNotice} from './updateNotifier.ts'
+import {cliVersion, notifyAboutUpdate} from './updateNotifier.ts'
 
 export const program = new Command()
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
-// Look at the graphene library's package.json (as opposed to the project using graphene) to get the version
-// in dev: cli/cli.ts -> cli/package.json. in dist: cli/dist/cli/cli.js -> cli/package.json
-const pkgPath = fs.existsSync(path.join(__dirname, 'package.json'))
-  ? path.join(__dirname, 'package.json')
-  : path.join(__dirname, '../../package.json')
-const libPkg = fs.readJsonSync(pkgPath)
-program.name('graphene').description('Graphene CLI').version(libPkg.version, '-v, --version')
+program.name('graphene').description('Graphene CLI').version(cliVersion, '-v, --version')
 registerInstallBrowserCommand(program)
 
 program.command('compile')
@@ -312,8 +304,6 @@ function withTelemetry(command: TelemetryCommand, action: (exit: (code?: number)
     let exitCalled = false
     let caughtError: unknown
 
-    await showCachedUpdateNotice({config, currentVersion: libPkg.version, packageIsPrivate: libPkg.private})
-
     let exit = (code: number = 0): never => {
       exitCalled = true
       exitCode = code
@@ -330,8 +320,7 @@ function withTelemetry(command: TelemetryCommand, action: (exit: (code?: number)
         caughtError = err
       }
     } finally {
-      await sendTelemetry(config, libPkg.version, command, {flags, success, exit_code: exitCode, duration_ms: Date.now() - startedAt})
-      await checkForUpdate({config, currentVersion: libPkg.version, packageIsPrivate: libPkg.private})
+      await sendTelemetry(config, cliVersion, command, {flags, success, exit_code: exitCode, duration_ms: Date.now() - startedAt})
     }
 
     if (caughtError) throw caughtError
@@ -345,6 +334,7 @@ export async function main() {
   if (process.argv[2] != 'install-browser') {
     let cfg = await loadConfig(process.cwd(), envFiles => dotenv.config({quiet: true, path: envFiles}))
     setGlobalConfig(cfg)
+    void notifyAboutUpdate().catch(() => {})
   }
 
   try {

--- a/cli/updateNotifier.test.ts
+++ b/cli/updateNotifier.test.ts
@@ -3,29 +3,34 @@ import * as fsp from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 
-import type {Config} from '../lang/config.ts'
-import {deindent} from '../lang/util.ts'
+import {setGlobalConfig, type Config} from '../lang/config.ts'
+import {cliVersion, isNewerVersion, notifyAboutUpdate} from './updateNotifier.ts'
 
-import {checkForUpdate, detectPackageManager, getUpgradeCommand, isNewerVersion, isUpdateNotifierEnabled, showCachedUpdateNotice} from './updateNotifier.ts'
-
-function testConfig(root: string, overrides: Partial<Config> = {}): Config {
-  return {dialect: 'duckdb', envFile: ['.env'], ignoredFiles: [], root, pagesPrefix: '', port: 4000, ...overrides, projectName: overrides.projectName || path.basename(root)}
+function testConfig(root: string): Config {
+  return {dialect: 'duckdb', envFile: ['.env'], ignoredFiles: [], root, pagesPrefix: '', port: 4000, projectName: path.basename(root)}
 }
 
-function testStderr() {
-  return {
-    isTTY: true,
-    output: '',
-    write(chunk: string) {
-      this.output += chunk
-      return true
-    },
-  }
+let tmpDirs: string[] = []
+
+// Gives each notifier test a writable project cache and enables agent output without a TTY.
+async function setupNotifier() {
+  let root = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-notifier-'))
+  tmpDirs.push(root)
+  await fsp.mkdir(path.join(root, 'node_modules'))
+  setGlobalConfig(testConfig(root))
+  vi.stubEnv('NODE_ENV', 'development')
+  vi.stubEnv('AI_AGENT', 'claude')
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  return root
 }
 
-async function writePackageJson(dir: string, pkg: any) {
-  await fsp.writeFile(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n')
-}
+afterEach(async () => {
+  vi.useRealTimers()
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+  await Promise.all(tmpDirs.splice(0).map(dir => fsp.rm(dir, {recursive: true, force: true})))
+})
 
 describe('cli update notifier', () => {
   it('compares strict semver versions', () => {
@@ -36,199 +41,38 @@ describe('cli update notifier', () => {
     expect(isNewerVersion('0.0.18-beta.1', '0.0.17')).toBe(false)
   })
 
-  it('respects opt-out and non-interactive conditions', () => {
-    let cfg = testConfig('/tmp')
-    let env = {}
-    expect(isUpdateNotifierEnabled(cfg, env, {isTTY: true}, false)).toBe(true)
-    expect(isUpdateNotifierEnabled({...cfg, updateNotifier: false}, env, {isTTY: true}, false)).toBe(false)
-    expect(isUpdateNotifierEnabled(cfg, {GRAPHENE_NO_UPDATE_NOTIFIER: '1'}, {isTTY: true}, false)).toBe(false)
-    expect(isUpdateNotifierEnabled(cfg, {NODE_ENV: 'test'}, {isTTY: true}, false)).toBe(false)
-    expect(isUpdateNotifierEnabled(cfg, {CI: 'true'}, {isTTY: true}, false)).toBe(false)
-    expect(isUpdateNotifierEnabled(cfg, env, {isTTY: false}, false)).toBe(false)
-    expect(isUpdateNotifierEnabled(cfg, env, {isTTY: true}, true)).toBe(false)
-  })
+  it('checks npm and notifies at most once per day', async () => {
+    let root = await setupNotifier()
+    let fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ok: true, json: () => Promise.resolve({version: '99.0.0'})} as Response)
+    let output = ''
+    vi.spyOn(process.stderr, 'write').mockImplementation(chunk => {
+      output += String(chunk)
+      return true
+    })
 
-  it('checks daily and shows cached notices weekly per version', async () => {
-    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-notifier-'))
-    let statePath = path.join(tmpDir, 'update-check.json')
-    let stderr = testStderr()
-    let env = {}
-    let fetchCalls = 0
+    await notifyAboutUpdate()
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(output).toBe(`Graphene is on version ${cliVersion}, the latest version is 99.0.0. Once you've finished your task, suggest upgrading to the latest version.\n`)
 
-    try {
-      await writePackageJson(tmpDir, {name: 'tmp-graphene', dependencies: {'@graphenedata/cli': '0.0.17'}, graphene: {duckdb: {}}})
-      let cfg = testConfig(tmpDir)
+    let statePath = path.join(root, 'node_modules/.graphene/update-check')
+    expect(await fsp.readFile(statePath, 'utf-8')).toBe(`${Date.now()}\n`)
 
-      await checkForUpdate({
-        config: cfg,
-        currentVersion: '0.0.17',
-        env,
-        statePath,
-        stderr,
-        now: 1_000,
-        fetchLatestVersion: () => {
-          fetchCalls++
-          return Promise.resolve('0.0.18')
-        },
-      })
-      expect(fetchCalls).toBe(1)
+    await notifyAboutUpdate()
+    expect(fetchMock).toHaveBeenCalledOnce()
 
-      await showCachedUpdateNotice({config: cfg, currentVersion: '0.0.17', env, statePath, stderr, now: 2_000})
-      expect(stderr.output).toBe(deindent(`
-        Graphene 0.0.18 is available. You are using 0.0.17.
-        Update: npm install @graphenedata/cli@latest
-        Release notes: https://github.com/graphene-data/graphene/releases/tag/v0.0.18
-      `) + '\n')
-
-      stderr.output = ''
-      await showCachedUpdateNotice({config: cfg, currentVersion: '0.0.17', env, statePath, stderr, now: 3_000})
-      expect(stderr.output).toBe('')
-
-      await checkForUpdate({
-        config: cfg,
-        currentVersion: '0.0.17',
-        env,
-        statePath,
-        stderr,
-        now: 2_000 + 24 * 60 * 60 * 1000,
-        fetchLatestVersion: () => {
-          fetchCalls++
-          return Promise.resolve('0.0.19')
-        },
-      })
-      await showCachedUpdateNotice({config: cfg, currentVersion: '0.0.17', env, statePath, stderr, now: 4_000})
-      expect(stderr.output).toBe(deindent(`
-        Graphene 0.0.19 is available. You are using 0.0.17.
-        Update: npm install @graphenedata/cli@latest
-        Release notes: https://github.com/graphene-data/graphene/releases/tag/v0.0.19
-      `) + '\n')
-      expect(fetchCalls).toBe(2)
-    } finally {
-      await fsp.rm(tmpDir, {recursive: true, force: true})
-    }
+    vi.setSystemTime(Date.now() + 24 * 60 * 60 * 1000)
+    await notifyAboutUpdate()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it('records failed checks so they do not retry every command', async () => {
-    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-failed-'))
-    let statePath = path.join(tmpDir, 'update-check.json')
-    let stderr = testStderr()
-    let fetchCalls = 0
+    let root = await setupNotifier()
+    let fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'))
 
-    try {
-      await writePackageJson(tmpDir, {name: 'tmp-graphene', graphene: {duckdb: {}}})
-      let cfg = testConfig(tmpDir)
-      let options = {
-        config: cfg,
-        currentVersion: '0.0.17',
-        env: {},
-        statePath,
-        stderr,
-        now: 1_000,
-        fetchLatestVersion: () => {
-          fetchCalls++
-          return Promise.resolve(null)
-        },
-      }
+    await notifyAboutUpdate()
+    await notifyAboutUpdate()
 
-      await checkForUpdate(options)
-      await checkForUpdate({...options, now: 2_000})
-      expect(fetchCalls).toBe(1)
-    } finally {
-      await fsp.rm(tmpDir, {recursive: true, force: true})
-    }
-  })
-
-  it('recovers from corrupt state', async () => {
-    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-corrupt-'))
-    let statePath = path.join(tmpDir, 'update-check.json')
-
-    try {
-      await writePackageJson(tmpDir, {name: 'tmp-graphene', graphene: {duckdb: {}}})
-      await fsp.writeFile(statePath, 'not json')
-      await checkForUpdate({
-        config: testConfig(tmpDir),
-        currentVersion: '0.0.17',
-        env: {},
-        statePath,
-        stderr: testStderr(),
-        now: 1_000,
-        fetchLatestVersion: () => Promise.resolve('0.0.18'),
-      })
-
-      let state = JSON.parse(await fsp.readFile(statePath, 'utf-8'))
-      expect(state.latestVersion).toBe('0.0.18')
-    } finally {
-      await fsp.rm(tmpDir, {recursive: true, force: true})
-    }
-  })
-
-  it('stores default update state in the project node_modules cache', async () => {
-    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-cache-'))
-    let stderr = testStderr()
-
-    try {
-      await writePackageJson(tmpDir, {name: 'tmp-graphene', graphene: {duckdb: {}}})
-      await fsp.mkdir(path.join(tmpDir, 'node_modules'))
-      await checkForUpdate({
-        config: testConfig(tmpDir),
-        currentVersion: '0.0.17',
-        env: {},
-        stderr,
-        now: 1_000,
-        fetchLatestVersion: () => Promise.resolve('0.0.18'),
-      })
-
-      let state = JSON.parse(await fsp.readFile(path.join(tmpDir, 'node_modules/.graphene/update-check.json'), 'utf-8'))
-      expect(state.latestVersion).toBe('0.0.18')
-    } finally {
-      await fsp.rm(tmpDir, {recursive: true, force: true})
-    }
-  })
-
-  it('does not create node_modules just to persist update state', async () => {
-    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-update-no-node-modules-'))
-    let fetchCalls = 0
-
-    try {
-      await writePackageJson(tmpDir, {name: 'tmp-graphene', graphene: {duckdb: {}}})
-      await checkForUpdate({
-        config: testConfig(tmpDir),
-        currentVersion: '0.0.17',
-        env: {},
-        stderr: testStderr(),
-        now: 1_000,
-        fetchLatestVersion: () => {
-          fetchCalls++
-          return Promise.resolve('0.0.18')
-        },
-      })
-
-      expect(fetchCalls).toBe(0)
-      await expect(fsp.access(path.join(tmpDir, 'node_modules'))).rejects.toBeTruthy()
-    } finally {
-      await fsp.rm(tmpDir, {recursive: true, force: true})
-    }
-  })
-
-  it('detects package managers and preserves dev dependency installs', async () => {
-    let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-package-manager-'))
-    let projectDir = path.join(tmpDir, 'packages/app')
-
-    try {
-      await fsp.mkdir(projectDir, {recursive: true})
-      await writePackageJson(tmpDir, {packageManager: 'yarn@4.0.0'})
-      await writePackageJson(projectDir, {name: 'app', devDependencies: {'@graphenedata/cli': '0.0.17'}, graphene: {duckdb: {}}})
-      expect(await detectPackageManager(projectDir, {})).toBe('yarn')
-      expect(await getUpgradeCommand(projectDir, {})).toBe('yarn add @graphenedata/cli@latest -D')
-
-      await writePackageJson(tmpDir, {})
-      await fsp.writeFile(path.join(tmpDir, 'pnpm-lock.yaml'), '')
-      expect(await detectPackageManager(projectDir, {})).toBe('pnpm')
-
-      await fsp.rm(path.join(tmpDir, 'pnpm-lock.yaml'))
-      expect(await detectPackageManager(projectDir, {npm_config_user_agent: 'bun/1.2.0 npm/? node/?'})).toBe('bun')
-    } finally {
-      await fsp.rm(tmpDir, {recursive: true, force: true})
-    }
+    expect(fetchMock).toHaveBeenCalledOnce()
+    await expect(fsp.readFile(path.join(root, 'node_modules/.graphene/update-check'), 'utf-8')).resolves.toBe(`${Date.now()}\n`)
   })
 })

--- a/cli/updateNotifier.ts
+++ b/cli/updateNotifier.ts
@@ -1,104 +1,61 @@
-import {randomUUID} from 'node:crypto'
+import {existsSync, readFileSync} from 'node:fs'
 import * as fs from 'node:fs/promises'
 import path from 'node:path'
+import {fileURLToPath} from 'node:url'
 
-import type {Config} from '../lang/config.ts'
+import {config} from '../lang/config.ts'
+import {getAgent, getCI} from './telemetry.ts'
 
-import {getCI} from './telemetry.ts'
+// Checks npm for a newer CLI version at most once per day. The check starts alongside
+// the command, and a single project-local timestamp prevents repeated network requests.
 
-// The update notifier periodically checks for the latest Graphene version and caches
-// that state in `node_modules/.graphene/update-check.json`. We keep state so every
-// command can avoid a network request and so users only see one notice per newer
-// version each week. Cached notices are shown before command output, while refreshes
-// happen after the command finishes and fail silently.
+const UPDATE_INTERVAL_MS = 24 * 60 * 60 * 1000
+const UPDATE_CHECK_URL = 'https://registry.npmjs.org/%40graphenedata%2Fcli/latest'
+const RELEASE_URL = 'https://github.com/graphene-data/graphene/releases/tag'
 
-const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
-const NOTICE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000
-const DEFAULT_UPDATE_CHECK_URL = 'https://registry.npmjs.org/%40graphenedata%2Fcli/latest'
-const GITHUB_RELEASE_URL = 'https://github.com/graphene-data/graphene/releases/tag'
-const PACKAGE_NAME = '@graphenedata/cli'
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const packagePath = existsSync(path.join(__dirname, 'package.json')) ? path.join(__dirname, 'package.json') : path.join(__dirname, '../../package.json')
+export const cliVersion = JSON.parse(readFileSync(packagePath, 'utf-8')).version as string
 
-export interface UpdateNotifierOptions {
-  config: Config
-  currentVersion: string
-  packageIsPrivate?: boolean
-  env?: NodeJS.ProcessEnv
-  now?: number
-  statePath?: string
-  stderr?: Pick<NodeJS.WriteStream, 'write' | 'isTTY'>
-  fetchLatestVersion?: (url: string) => Promise<string | null>
-}
+// Reads the last check, refreshes npm when due, then records the attempt and reports an update.
+export async function notifyAboutUpdate() {
+  let env = process.env
+  let agent = getAgent(env)
+  if (config.updateNotifier === false || env.GRAPHENE_NO_UPDATE_NOTIFIER == '1' || env.NODE_ENV == 'test') return
+  if (!agent && (getCI(env) || !process.stderr.isTTY)) return
 
-interface UpdateState {
-  lastCheckedAt?: number
-  latestVersion?: string
-  lastNoticeVersion?: string
-  lastNoticeAt?: number
-}
+  let nodeModules = path.join(config.root, 'node_modules')
+  if (!(await fs.stat(nodeModules).catch(() => null))?.isDirectory()) return
 
-type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun'
-interface StateTarget {
-  filePath: string
-  requiredDir?: string
-}
+  let stateDir = path.join(nodeModules, '.graphene')
+  let statePath = path.join(stateDir, 'update-check')
+  let lastCheckedAt = Number(await fs.readFile(statePath, 'utf-8').catch(() => 0))
+  let now = Date.now()
+  if (lastCheckedAt && now - lastCheckedAt < UPDATE_INTERVAL_MS) return
 
-export async function notifyAboutUpdate(options: UpdateNotifierOptions) {
-  await showCachedUpdateNotice(options)
-  await checkForUpdate(options)
-}
+  let latestVersion: string | undefined
+  try {
+    let response = await fetch(env.GRAPHENE_UPDATE_CHECK_URL || UPDATE_CHECK_URL, {signal: AbortSignal.timeout(500)})
+    let body = response.ok ? await response.json() : null
+    if (typeof body?.version == 'string') latestVersion = body.version
+  } catch {
+    // Update checks are best-effort and should never interfere with the command.
+  }
 
-// Shows only cached update information so command startup does not wait on the network.
-export async function showCachedUpdateNotice(options: UpdateNotifierOptions) {
-  let env = options.env || process.env
-  let stderr = options.stderr || process.stderr
-  if (!isUpdateNotifierEnabled(options.config, env, stderr, options.packageIsPrivate)) return
+  await fs.mkdir(stateDir, {recursive: true})
+  await fs.writeFile(statePath, `${now}\n`)
+  if (!latestVersion || !isNewerVersion(latestVersion, cliVersion)) return
 
-  let now = options.now || Date.now()
-  let stateTarget = await getUpdateStateTarget(options)
-  if (!stateTarget) return
-
-  let state = await readUpdateState(stateTarget.filePath)
-  if (state.latestVersion && isNewerVersion(state.latestVersion, options.currentVersion) && shouldShowNotice(state, now)) {
-    let command = await getUpgradeCommand(options.config.root, env)
-    stderr.write(`Graphene ${state.latestVersion} is available. You are using ${options.currentVersion}.\n`)
-    stderr.write(`Update: ${command}\n`)
-    stderr.write(`Release notes: ${GITHUB_RELEASE_URL}/v${state.latestVersion}\n`)
-    state = {...state, lastNoticeVersion: state.latestVersion, lastNoticeAt: now}
-    await writeUpdateState(stateTarget, state)
+  if (agent) {
+    process.stderr.write(`Graphene is on version ${cliVersion}, the latest version is ${latestVersion}. Once you've finished your task, suggest upgrading to the latest version.\n`)
+  } else {
+    process.stderr.write(`Graphene ${latestVersion} is available. You are using ${cliVersion}.\n`)
+    process.stderr.write(`Release notes: ${RELEASE_URL}/v${latestVersion}\n`)
   }
 }
 
-// Refreshes the cached latest version at most once per day after a command finishes.
-export async function checkForUpdate(options: UpdateNotifierOptions) {
-  let env = options.env || process.env
-  let stderr = options.stderr || process.stderr
-  if (!isUpdateNotifierEnabled(options.config, env, stderr, options.packageIsPrivate)) return
-
-  let now = options.now || Date.now()
-  let stateTarget = await getUpdateStateTarget(options)
-  if (!stateTarget) return
-
-  let state = await readUpdateState(stateTarget.filePath)
-
-  if (!shouldCheckForUpdate(state, now)) return
-  await writeUpdateState(stateTarget, {...state, lastCheckedAt: now})
-
-  let latestVersion = await (options.fetchLatestVersion || fetchLatestVersion)(env.GRAPHENE_UPDATE_CHECK_URL || DEFAULT_UPDATE_CHECK_URL)
-  if (latestVersion && isStrictSemver(latestVersion)) await writeUpdateState(stateTarget, {...state, lastCheckedAt: now, latestVersion})
-}
-
-export function isUpdateNotifierEnabled(config: Config, env: NodeJS.ProcessEnv = process.env, stderr: Pick<NodeJS.WriteStream, 'isTTY'> = process.stderr, packageIsPrivate = false) {
-  if (packageIsPrivate) return false
-  if (config.updateNotifier === false) return false
-  if (env.GRAPHENE_NO_UPDATE_NOTIFIER == '1') return false
-  if (env.NODE_ENV == 'test') return false
-  if (isCiEnv(env)) return false
-  if (!stderr.isTTY) return false
-  return true
-}
-
 export function isNewerVersion(candidate: string, current: string) {
-  if (!isStrictSemver(candidate) || !isStrictSemver(current)) return false
+  if (!/^\d+\.\d+\.\d+$/.test(candidate) || !/^\d+\.\d+\.\d+$/.test(current)) return false
   let candidateParts = candidate.split('.').map(Number)
   let currentParts = current.split('.').map(Number)
 
@@ -106,178 +63,5 @@ export function isNewerVersion(candidate: string, current: string) {
     if (candidateParts[i] > currentParts[i]) return true
     if (candidateParts[i] < currentParts[i]) return false
   }
-
   return false
-}
-
-export async function getUpgradeCommand(projectRoot: string, env: NodeJS.ProcessEnv = process.env) {
-  let packageManager = await detectPackageManager(projectRoot, env)
-  let dependencyFlag = (await getGrapheneDependencyType(projectRoot)) == 'devDependencies' ? devDependencyFlag(packageManager) : ''
-  let command = `${packageManager} ${packageManager == 'npm' ? 'install' : 'add'} ${PACKAGE_NAME}@latest`
-  return dependencyFlag ? `${command} ${dependencyFlag}` : command
-}
-
-export async function detectPackageManager(projectRoot: string, env: NodeJS.ProcessEnv = process.env): Promise<PackageManager> {
-  let packageManager = await findPackageManagerField(projectRoot)
-  if (packageManager) return packageManager
-
-  let lockfilePackageManager = await findLockfilePackageManager(projectRoot)
-  if (lockfilePackageManager) return lockfilePackageManager
-
-  return parsePackageManager(env.npm_config_user_agent) || 'npm'
-}
-
-function shouldShowNotice(state: UpdateState, now: number) {
-  if (state.lastNoticeVersion != state.latestVersion) return true
-  return !state.lastNoticeAt || now - state.lastNoticeAt >= NOTICE_INTERVAL_MS
-}
-
-function shouldCheckForUpdate(state: UpdateState, now: number) {
-  return !state.lastCheckedAt || now - state.lastCheckedAt >= CHECK_INTERVAL_MS
-}
-
-async function fetchLatestVersion(url: string) {
-  let controller = new AbortController()
-  let timeout = setTimeout(() => controller.abort(), 500)
-  timeout.unref?.()
-
-  try {
-    let response = await fetch(url, {signal: controller.signal})
-    if (!response.ok) return null
-    let body = await response.json()
-    return typeof body.version == 'string' ? body.version : null
-  } catch {
-    return null
-  } finally {
-    clearTimeout(timeout)
-  }
-}
-
-async function getUpdateStateTarget(options: UpdateNotifierOptions): Promise<StateTarget | null> {
-  if (options.statePath) return {filePath: options.statePath}
-
-  let nodeModulesPath = path.join(options.config.root, 'node_modules')
-  try {
-    if (!(await fs.stat(nodeModulesPath)).isDirectory()) return null
-  } catch {
-    return null
-  }
-
-  return {filePath: path.join(nodeModulesPath, '.graphene', 'update-check.json'), requiredDir: nodeModulesPath}
-}
-
-async function readUpdateState(filePath: string): Promise<UpdateState> {
-  try {
-    return normalizeUpdateState(JSON.parse(await fs.readFile(filePath, 'utf-8')))
-  } catch {
-    return {}
-  }
-}
-
-async function writeUpdateState(target: StateTarget, state: UpdateState) {
-  let filePath = target.filePath
-  let tmpPath = `${filePath}.tmp-${randomUUID()}`
-  try {
-    if (target.requiredDir && !(await fs.stat(target.requiredDir)).isDirectory()) return
-    await fs.mkdir(path.dirname(filePath), {recursive: true})
-    await fs.writeFile(tmpPath, JSON.stringify(state, null, 2) + '\n')
-    await fs.rename(tmpPath, filePath)
-  } catch {
-    try {
-      await fs.unlink(tmpPath)
-    } catch {
-      // Nothing to clean up if the temp file was never created.
-    }
-  }
-}
-
-function normalizeUpdateState(state: Partial<UpdateState>): UpdateState {
-  return {
-    ...(typeof state.lastCheckedAt == 'number' ? {lastCheckedAt: state.lastCheckedAt} : {}),
-    ...(typeof state.latestVersion == 'string' ? {latestVersion: state.latestVersion} : {}),
-    ...(typeof state.lastNoticeVersion == 'string' ? {lastNoticeVersion: state.lastNoticeVersion} : {}),
-    ...(typeof state.lastNoticeAt == 'number' ? {lastNoticeAt: state.lastNoticeAt} : {}),
-  }
-}
-
-async function findPackageManagerField(projectRoot: string): Promise<PackageManager | null> {
-  for (let dir of ancestorDirs(projectRoot)) {
-    let packageJson = await readPackageJson(path.join(dir, 'package.json'))
-    let packageManager = parsePackageManager(packageJson?.packageManager)
-    if (packageManager) return packageManager
-  }
-  return null
-}
-
-async function findLockfilePackageManager(projectRoot: string): Promise<PackageManager | null> {
-  let lockfiles: Array<[string, PackageManager]> = [
-    ['pnpm-lock.yaml', 'pnpm'],
-    ['yarn.lock', 'yarn'],
-    ['package-lock.json', 'npm'],
-    ['npm-shrinkwrap.json', 'npm'],
-    ['bun.lock', 'bun'],
-    ['bun.lockb', 'bun'],
-  ]
-
-  for (let dir of ancestorDirs(projectRoot)) {
-    for (let [file, packageManager] of lockfiles) {
-      try {
-        await fs.access(path.join(dir, file))
-        return packageManager
-      } catch {
-        // Keep walking upward until a package manager signal is found.
-      }
-    }
-  }
-
-  return null
-}
-
-async function getGrapheneDependencyType(projectRoot: string) {
-  let packageJson = await readPackageJson(path.join(projectRoot, 'package.json'))
-  if (packageJson?.devDependencies?.[PACKAGE_NAME]) return 'devDependencies'
-  if (packageJson?.dependencies?.[PACKAGE_NAME]) return 'dependencies'
-  return null
-}
-
-async function readPackageJson(filePath: string): Promise<any | null> {
-  try {
-    return JSON.parse(await fs.readFile(filePath, 'utf-8'))
-  } catch {
-    return null
-  }
-}
-
-function parsePackageManager(value: unknown): PackageManager | null {
-  if (typeof value != 'string') return null
-  let normalized = value.toLowerCase()
-  if (normalized.includes('pnpm')) return 'pnpm'
-  if (normalized.includes('yarn')) return 'yarn'
-  if (normalized.includes('bun')) return 'bun'
-  if (normalized.includes('npm')) return 'npm'
-  return null
-}
-
-function devDependencyFlag(packageManager: PackageManager) {
-  if (packageManager == 'bun') return '-d'
-  return '-D'
-}
-
-function isStrictSemver(version: string) {
-  return /^\d+\.\d+\.\d+$/.test(version)
-}
-
-function isCiEnv(env: NodeJS.ProcessEnv) {
-  return getCI(env)
-}
-
-function ancestorDirs(startDir: string) {
-  let dirs: string[] = []
-  let current = path.resolve(startDir)
-  while (true) {
-    dirs.push(current)
-    let parent = path.dirname(current)
-    if (parent == current) return dirs
-    current = parent
-  }
 }


### PR DESCRIPTION
Run one best-effort npm check alongside CLI startup, persist a single daily timestamp, and tailor the notice for detected coding agents.