### PR TITLE
Use valid YAML for scheduled report frontmatter

### DIFF
--- a/cli/check.ts
+++ b/cli/check.ts
@@ -4,7 +4,8 @@ import path from 'path'
 import type {WorkspaceFileInput} from '../lang/types.ts'
 
 import {config} from '../lang/config.ts'
-import {analyzeWorkspace, loadWorkspace} from '../lang/core.ts'
+import {analyzeWorkspace, GrapheneError, loadWorkspace} from '../lang/core.ts'
+import {extractFrontmatter} from './mdCompile.ts'
 import {mockFileMap} from './mockFiles.ts'
 import {normalizeFile} from './normalizeFile.ts'
 import {formatError} from './printer.ts'
@@ -41,6 +42,16 @@ export async function check(options: CheckOptions): Promise<boolean> {
   }
 
   let result = analyzeWorkspace({config, files})
+
+  // Markdown analysis handles embedded queries; validate page frontmatter separately so metadata errors include the source file.
+  for (let file of files.filter(file => file.path.toLowerCase().endsWith('.md'))) {
+    try {
+      extractFrontmatter(file.contents)
+    } catch (err:any) {
+      result.diagnostics.push(new GrapheneError({file: file.path, message: err.message}))
+    }
+  }
+
   if (result.diagnostics.length > 0) {
     log(formatError(result.diagnostics, {style: true}))
     return false

--- a/cli/cli.test.ts
+++ b/cli/cli.test.ts
@@ -326,6 +326,17 @@ describe('cli run', () => {
   })
 })
 
+test('cli check surfaces invalid Markdown frontmatter with its filename', async ({runCli}) => {
+  let tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'graphene-check-frontmatter-'))
+  try {
+    await fsp.writeFile(path.join(tmpDir, 'report.md'), '---\nscheduled: "0 4 * *"\n---\n# Report')
+    let res = await runCli(['check'], configFor(tmpDir))
+    expectCliOutput(res, {code: 1, stdout: 'ERROR: report.md: Invalid scheduled report: expected a five-field cron'})
+  } finally {
+    await fsp.rm(tmpDir, {recursive: true, force: true})
+  }
+})
+
 test('cli check a single gsql file', async ({runCli}) => {
   let res = await runCli(['check', 'tables/flights.gsql'], flightConfig)
   expectCliOutput(res, 'No errors found 💎')

--- a/cli/mdCompile.test.ts
+++ b/cli/mdCompile.test.ts
@@ -2,10 +2,10 @@
 import {compile} from 'mdsvex'
 import {compile as compileSvelte} from 'svelte/compiler'
 
-import {extractFrontmatter, injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
+import {extractFrontmatter, frontmatterOptions, injectComponentImports, parseScheduledFrontmatter, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 
 async function compileMarkdownPage(src: string) {
-  let out = await compile(src, {extensions: ['.md'], remarkPlugins, rehypePlugins, filename: '/tmp/repro.md'})
+  let out = await compile(src, {extensions: ['.md'], frontmatter: frontmatterOptions, remarkPlugins, rehypePlugins, filename: '/tmp/repro.md'})
   if (!out) throw new Error('Expected mdsvex compile output')
   let preprocessed = injectComponentImports().markup({content: String(out.code), filename: '/tmp/repro.md'})
   if (!preprocessed) throw new Error('Expected preprocess output')
@@ -29,13 +29,36 @@ describe('extractFrontmatter', () => {
     expect(extractFrontmatter('Intro\n\n# Page title\n\nContent')).toEqual({title: 'Page title'})
   })
 
-  it('extracts a scheduled value outside YAML parsing', () => {
-    let metadata = extractFrontmatter('---\nscheduled: "0 9 * * 1-5" @grant\n---\n# Report')
-    expect(metadata).toEqual({title: 'Report', scheduled: '"0 9 * * 1-5" @grant'})
+  it('extracts and validates a one-line scheduled report', () => {
+    let contents = '---\nscheduled: "0 9 * * 1-5 @grant"\n---\n# Report'
+    expect(extractFrontmatter(contents)).toEqual({title: 'Report', scheduled: '0 9 * * 1-5 @grant'})
+    expect(parseScheduledFrontmatter(contents)).toEqual([{cron: '0 9 * * 1-5', remainder: '@grant'}])
   })
 
-  it('rejects duplicate scheduled fields', () => {
-    expect(() => extractFrontmatter('---\nscheduled: "0 9 * * 1-5" @grant\nscheduled: "30 16 * * *" #operations\n---')).toThrow('Multiple scheduled fields are not supported')
+  it('leaves delivery syntax to the schedule consumer', () => {
+    let contents = '---\nscheduled: "0 9 * * 1-5 deliver however Cloud likes"\n---'
+    expect(parseScheduledFrontmatter(contents)).toEqual([{cron: '0 9 * * 1-5', remainder: 'deliver however Cloud likes'}])
+  })
+
+  it('supports a YAML list of delivery times', () => {
+    let contents = '---\nscheduled:\n  - "0 9 * * 1-5 @grant"\n  - "30 16 * * * #operations"\n---'
+    expect(extractFrontmatter(contents)).toEqual({scheduled: '0 9 * * 1-5 @grant'})
+    expect(parseScheduledFrontmatter(contents)).toEqual([
+      {cron: '0 9 * * 1-5', remainder: '@grant'},
+      {cron: '30 16 * * *', remainder: '#operations'},
+    ])
+  })
+
+  it('rewrites repeated legacy scheduled fields before parsing YAML', () => {
+    let contents = '---\nscheduled: "0 9 * * 1-5" @grant\nscheduled: "30 16 * * *" #operations\n---'
+    expect(parseScheduledFrontmatter(contents)).toEqual([
+      {cron: '0 9 * * 1-5', remainder: '@grant'},
+      {cron: '30 16 * * *', remainder: '#operations'},
+    ])
+  })
+
+  it('rejects invalid scheduled fields', () => {
+    expect(() => extractFrontmatter('---\nscheduled: "0 9 * *"\n---')).toThrow('expected a five-field cron')
   })
 
   it('handles leading whitespace', () => {
@@ -49,6 +72,11 @@ describe('extractFrontmatter', () => {
 })
 
 describe('markdown compilation', () => {
+  it('compiles legacy scheduled frontmatter through the shared YAML parser', async () => {
+    let code = await compileMarkdownPage('---\nscheduled: "0 9 * * 1-5" @grant\n---\n# Report')
+    expect(code).toContain('>Report</h1>')
+  })
+
   it('keeps query code braces inside string literals', async () => {
     let src = `
 \`\`\`sql repro
@@ -58,7 +86,7 @@ from flights
 \`\`\`
 `
 
-    let out = await compile(src, {extensions: ['.md'], remarkPlugins, rehypePlugins, filename: '/tmp/repro.md'})
+    let out = await compile(src, {extensions: ['.md'], frontmatter: frontmatterOptions, remarkPlugins, rehypePlugins, filename: '/tmp/repro.md'})
     if (!out) throw new Error('Expected mdsvex compile output')
     let code = String(out.code)
 
@@ -74,7 +102,7 @@ where created_at >= coalesce($daterange_start, created_at)
 \`\`\`
 `
 
-    let out = await compile(src, {extensions: ['.md'], remarkPlugins, rehypePlugins, filename: '/tmp/repro.md'})
+    let out = await compile(src, {extensions: ['.md'], frontmatter: frontmatterOptions, remarkPlugins, rehypePlugins, filename: '/tmp/repro.md'})
     if (!out) throw new Error('Expected mdsvex compile output')
     let code = String(out.code)
 

--- a/cli/mdCompile.ts
+++ b/cli/mdCompile.ts
@@ -88,28 +88,107 @@ export function componentNames() {
 }
 
 export type PageFrontmatter = {title?: string; hideInNav?: boolean; layout?: string; scheduled?: string}
+export interface ScheduledFrontmatter {cron: string; remainder: string}
+
+const frontmatterRe = /^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/
+const legacyScheduleRe = /^scheduled\s*:\s*"([^"\r\n]+)"\s+([^\r\n]+)$/gim
+
+// Load standard YAML after rewriting the former `scheduled: "<cron>" <delivery>` extension into its valid YAML equivalent.
+function parseFrontmatterYaml(frontmatter: string): Record<string, any> {
+  let legacySchedules = [...frontmatter.matchAll(legacyScheduleRe)].map(match => `${match[1]} ${match[2].trim()}`)
+  if (legacySchedules.length) {
+    let replacement = legacySchedules.length === 1
+      ? `scheduled: ${JSON.stringify(legacySchedules[0])}`
+      : `scheduled:\n${legacySchedules.map(value => `  - ${JSON.stringify(value)}`).join('\n')}`
+    let replacedFirst = false
+    frontmatter = frontmatter.replace(legacyScheduleRe, () => {
+      if (replacedFirst) return ''
+      replacedFirst = true
+      return replacement
+    })
+  }
+
+  let raw = yaml.safeLoad(frontmatter)
+  if (raw === undefined) return {}
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('Frontmatter must be a YAML object')
+  return raw as Record<string, any>
+}
+
+function parseFrontmatter(contents: string): Record<string, any> {
+  let frontmatter = contents.trimStart().match(frontmatterRe)?.[1]
+  return frontmatter ? parseFrontmatterYaml(frontmatter) : {}
+}
+
+// mdsvex uses the same parser so legacy schedules remain renderable while all other frontmatter follows YAML.
+export const frontmatterOptions = {type: 'yaml', marker: '-', parse: parseFrontmatterYaml}
+
+// Parse all schedules from a page after normalizing its frontmatter.
+export function parseScheduledFrontmatter(contents: string): ScheduledFrontmatter[] {
+  return parseScheduledValue(parseFrontmatter(contents).scheduled)
+}
+
+// Parse one schedule string or a YAML list. Core validates the five-field cron and leaves any trailing syntax to Cloud.
+function parseScheduledValue(scheduled: unknown): ScheduledFrontmatter[] {
+  if (scheduled === undefined) return []
+  let values: unknown[] = Array.isArray(scheduled) ? scheduled : [scheduled]
+  if (!values.every((value): value is string => typeof value === 'string')) throw new Error('Scheduled reports must be strings')
+
+  return values.map(value => {
+    let parts = value.trim().split(/\s+/)
+    if (parts.length < 5) throw new Error('Invalid scheduled report: expected a five-field cron')
+    let cron = parts.slice(0, 5).join(' ')
+    parseCronFieldSet(cron)
+    return {cron, remainder: parts.slice(5).join(' ')}
+  })
+}
+
+// Parse cron fields once for both frontmatter validation and Cloud's UTC schedule matching.
+export function parseCronFieldSet(cron: string) {
+  let fields = cron.trim().split(/\s+/)
+  if (fields.length !== 5) throw new Error(`Invalid cron "${cron}": expected five fields`)
+  return [
+    parseCronField(fields[0], 0, 59),
+    parseCronField(fields[1], 0, 23),
+    parseCronField(fields[2], 1, 31),
+    parseCronField(fields[3], 1, 12),
+    parseCronField(fields[4], 0, 7, true),
+  ] as const
+}
+
+function parseCronField(field: string, min: number, max: number, sunday = false) {
+  let values = new Set<number>()
+  for (let part of field.split(',')) {
+    if (!/^(?:\*|\d+|\d+-\d+)(?:\/\d+)?$/.test(part)) throw new Error(`Invalid cron field "${field}"`)
+    let [range, rawStep] = part.split('/')
+    let step = rawStep === undefined ? 1 : Number(rawStep)
+    if (!Number.isInteger(step) || step < 1) throw new Error(`Invalid cron field "${field}"`)
+
+    let start: number
+    let end: number
+    if (range === '*') [start, end] = [min, max]
+    else if (range.includes('-')) [start, end] = range.split('-').map(Number)
+    else [start, end] = [Number(range), rawStep === undefined ? Number(range) : max]
+    if (!Number.isInteger(start) || !Number.isInteger(end) || start < min || end > max || start > end) throw new Error(`Invalid cron field "${field}"`)
+    for (let value = start; value <= end; value += step) values.add(sunday && value === 7 ? 0 : value)
+  }
+  return {values, restricted: values.size !== (sunday ? 7 : max - min + 1)}
+}
 
 // Extract supported frontmatter without compiling the page. When frontmatter omits a title,
 // use the first static Markdown h1 so every caller gets the same page metadata.
-const frontmatterRe = /^---\s*\n([\s\S]*?)\n---(?:\n|$)/
 export function extractFrontmatter(contents: string): PageFrontmatter {
-  let match = contents.trimStart().match(frontmatterRe)
-  let lines = match?.[1].split(/\r?\n/) || []
-  let scheduledLines = lines.filter(line => /^scheduled\s*:/i.test(line))
-  if (scheduledLines.length > 1) throw new Error('Multiple scheduled fields are not supported')
-  let scheduled = scheduledLines[0]?.replace(/^scheduled\s*:\s*/i, '').trim()
-  let yamlContents = lines.filter(line => !/^scheduled\s*:/i.test(line)).join('\n')
-  let raw = yamlContents ? yaml.safeLoad(yamlContents) as Record<string, any> | undefined : undefined
+  let raw = parseFrontmatter(contents)
+  let schedules = parseScheduledValue(raw.scheduled)
   let metadata: PageFrontmatter = {}
 
-  if (raw?.title) metadata.title = String(raw.title)
+  if (raw.title) metadata.title = String(raw.title)
   else {
     let markdownTitle = contents.match(/^#[ \t]+(.+?)[ \t]*#*[ \t]*$/m)?.[1]?.trim()
     if (markdownTitle && !/[<{]/.test(markdownTitle)) metadata.title = markdownTitle
   }
-  if (raw?.hideInNav === true) metadata.hideInNav = true
-  if (raw?.layout) metadata.layout = String(raw.layout)
-  if (scheduled) metadata.scheduled = scheduled
+  if (raw.hideInNav === true) metadata.hideInNav = true
+  if (raw.layout) metadata.layout = String(raw.layout)
+  if (schedules.length) metadata.scheduled = Array.isArray(raw.scheduled) ? raw.scheduled[0] : raw.scheduled
   return metadata
 }
 

--- a/cli/serve2.ts
+++ b/cli/serve2.ts
@@ -15,7 +15,7 @@ import {config} from '../lang/config.ts'
 import {analyzeWorkspace, GrapheneError, loadWorkspace, toSql} from '../lang/core.ts'
 import {grapheneCsp} from '../ui/csp.ts'
 import {runQuery} from './connections/index.ts'
-import {extractFrontmatter, injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
+import {extractFrontmatter, frontmatterOptions, injectComponentImports, remarkPlugins, rehypePlugins} from './mdCompile.ts'
 import {missingMockFiles, mockFileMap} from './mockFiles.ts'
 import {routeForPage} from './pageRouting.ts'
 import {runVitePlugin} from './run.ts'
@@ -71,6 +71,7 @@ async function createConfig(): Promise<InlineConfig> {
           vitePreprocess(),
           mdsvex({
             extensions: ['.md'],
+            frontmatter: frontmatterOptions,
             remarkPlugins,
             rehypePlugins,
           }) as any,

--- a/docs/base.md
+++ b/docs/base.md
@@ -104,7 +104,21 @@ You can add YAML frontmatter at the top of a page. The following attributes are 
 - `title`: sets the title of the page in navigation. Used if the page has no h1, or to override the title used in the nav.
 - `hideInNav`: set to `true` to exclude the page from the sidebar. The page remains available at its normal URL, so other pages can link to it for detail or drill-down views.
 - `layout`: `notebook` is the default, good for prose interspersed with charts. `dashboard` has a wider max-width, for chart-heavy pages with lots of `<Row>`s.
-- `scheduled`: sends the page to Slack users/channels on a UTC cron schedule: `scheduled: "0 14 * * 1-5" @someuser #somechannel #otherchannel`. Only works with Graphene Cloud. Be sure to clarify the timezone and convert to UTC as needed.
+- `scheduled`: sends the page to Slack users/channels on a UTC cron schedule. Only works with Graphene Cloud. Be sure to clarify the timezone and convert to UTC as needed.
+
+Use one string for a single delivery time:
+
+```yaml
+scheduled: "0 14 * * 1-5 @someuser #somechannel #otherchannel"
+```
+
+Use a YAML list for multiple delivery times:
+
+```yaml
+scheduled:
+  - "0 14 * * 1-5 @someuser"
+  - "30 16 * * * #somechannel"
+```
 
 ## Viz and display components
 - LineChart: title, data, x, y, y2, splitBy, sort, height, width


### PR DESCRIPTION
The original syntax I had wasn't valid, and required a bunch of manual parsing.

This still accepts the old format, so not breaking. We can remove support for it later.