### PR TITLE
Have echarts wait for fonts to load before rendering

### DIFF
--- a/ui/component-utilities/theme.ts
+++ b/ui/component-utilities/theme.ts
@@ -1,6 +1,7 @@
 import * as echarts from 'echarts'
 
 const {registerTheme} = echarts
+export const chartFontFamily = "'Source Sans 3', sans-serif"
 
 // ── Color tokens ────────────────────────────────────────────────────────
 // Palette C · Fjord Dusk
@@ -63,7 +64,7 @@ registerTheme('graphene-theme', {
   color: colorPalette,
   backgroundColor: 'transparent',
   textStyle: {
-    fontFamily: "'Source Sans 3', sans-serif",
+    fontFamily: chartFontFamily,
     color: clr.textMid,
     fontSize: 13,
   },

--- a/ui/components/ECharts.svelte
+++ b/ui/components/ECharts.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import {init} from 'echarts'
-  import {onDestroy, onMount, untrack} from 'svelte'
+  import {onDestroy, onMount, tick, untrack} from 'svelte'
   import ErrorDisplay from '../internal/ErrorDisplay.svelte'
   import {componentLogger, logExtraProps} from '../internal/telemetry.ts'
   import {enrich, horizontalBarCount} from '../component-utilities/enrich.ts'
   import type {EChartsConfig, NormalConfig, QueryResult} from '../component-utilities/types.ts'
-  import '../component-utilities/theme.ts'
+  import {chartFontFamily} from '../component-utilities/theme.ts'
   import CommentButton from './CommentButton.svelte'
   import CsvDownload from './CsvDownload.svelte'
   import Skeleton from './Skeleton.svelte'
@@ -42,6 +42,7 @@
   let resizeObserver: ResizeObserver | null = null
 
   // Use `raw` because data can be big, and there's little upside to making it reactive
+  let fontsReady = $state(false)
   let loaded = $state.raw<QueryResult | null>(null)
   let chartError: Error | null = $state(null)
   let mountedComponentId: string | null = $state(displayId)
@@ -53,6 +54,35 @@
     loaded = res || null
     if (res?.error) chartLogger.error(res.error, {...res.error, componentId: displayId})
   }
+
+  // ECharts caches text widths, so load theme fonts before any chart measurement. A broken or
+  // stalled font must not prevent rendering: after two seconds we accept fallback-font layout.
+  onMount(() => {
+    let renderId = window.$GRAPHENE.renderStart?.()
+    let disposed = false
+    let timer: ReturnType<typeof setTimeout>
+    let deadline = new Promise<void>(resolve => { timer = setTimeout(resolve, 2_000) })
+
+    async function loadFonts() {
+      let fonts = Promise.all([
+        document.fonts.load(`400 13px ${chartFontFamily}`, 'ECharts labels 0123456789'),
+        document.fonts.load(`600 13px ${chartFontFamily}`, 'ECharts labels 0123456789'),
+      ])
+      // Font requests can reject (offline, CSP, missing assets); render with the browser fallback.
+      await Promise.race([deadline, fonts]).catch(() => {})
+      clearTimeout(timer)
+      if (disposed) return
+      fontsReady = true
+      await tick() // Register the chart's own pending render before releasing the font wait.
+      window.$GRAPHENE.renderComplete?.(renderId)
+    }
+    void loadFonts()
+    return () => {
+      disposed = true
+      clearTimeout(timer)
+      window.$GRAPHENE.renderComplete?.(renderId)
+    }
+  })
 
   // If `data` is just a string, kick off a query to fetch the data.
   // This maybe could be an effect, but we'd have to ensure we don't double-subscribe.
@@ -79,7 +109,7 @@
   })
 
   $effect(() => {
-    if (chartError) return
+    if (chartError || !fontsReady) return
 
     if (!loaded || loaded.error || loaded.rows.length == 0) {
       destroyChart()
@@ -181,7 +211,9 @@
 
 </script>
 
-<div class="echarts" bind:this={node} style={chartSizeStyle} data-component-id={mountedComponentId} data-chart-title={chartTitle}>
+<div class="echarts" style={chartSizeStyle} data-component-id={mountedComponentId} data-chart-title={chartTitle}>
+  <!-- ECharts clears its container on dispose. Keep Svelte-owned controls and states outside it. -->
+  <div class="chart-renderer" bind:this={node}></div>
   <div class="component-actions">
     {#if loaded && !loaded.error && !chartError}<CsvDownload data={loaded} exportId={displayId} title={chartTitle} />{/if}
     <CommentButton componentId={mountedComponentId || displayId} title={chartTitle} />
@@ -197,6 +229,7 @@
 
 <style>
   .echarts { position: relative; }
+  .chart-renderer { position: absolute; inset: 0; }
   .component-actions { position: absolute; z-index: 2; top: -.25rem; right: 1rem; display: flex; align-items: center; gap: 0; }
 
   @media (max-width: 600px) {

--- a/ui/internal/LocalApp.svelte
+++ b/ui/internal/LocalApp.svelte
@@ -68,13 +68,6 @@
 
   onMount(async () => {
     try {
-      // force fonts to load before we mount the component.
-      // This is important for echarts, as it measures text and if done with the wrong font, then
-      // a) when the right font loads, things will just slightly not line up with edges
-      // b) test snapshots will differ, as they measure with whatever the system sans font is
-      // c) screenshots taken by `graphene run` might have the wrong font
-      await document.fonts.load("12px 'Source Sans 3'")
-      await document.fonts.ready
       if (blankForTests) return
 
       if (pathName == '_charts') {

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -174,10 +174,6 @@ export const test = base.extend<{browser: Browser; page: Page; sharedPage: Page;
         async ({compName, props}) => {
           if (window.__inst) window.$GRAPHENE.svelte.unmount(window.__inst)
 
-          // ensure fonts have loaded before we mount our component
-          await document.fonts.load("12px 'Source Sans 3'")
-          await document.fonts.ready
-
           let container = document.getElementsByTagName('main')[0] || document.createElement('main')
           if (!container.isConnected) document.body.appendChild(container)
           container.innerHTML = ''
@@ -203,11 +199,11 @@ export const test = base.extend<{browser: Browser; page: Page; sharedPage: Page;
       if (typeof selector !== 'function') throw new Error('chartConfig selector must be a function')
       let selectorSource = selector.toString()
       await sharedPage.waitForFunction(() => {
-        let domNode = document.querySelector('#component-test .echarts') as HTMLElement | null
+        let domNode = document.querySelector('#component-test .chart-renderer') as HTMLElement | null
         return domNode && window.$GRAPHENE.getChart(domNode)
       })
       return await sharedPage.evaluate(source => {
-        let domNode = document.querySelector('#component-test .echarts') as HTMLElement
+        let domNode = document.querySelector('#component-test .chart-renderer') as HTMLElement
         let option = window.$GRAPHENE.getChart(domNode).getModel().getOption()
         try {
           let fn = new Function('config', `return (${source})(config)`)
@@ -221,7 +217,7 @@ export const test = base.extend<{browser: Browser; page: Page; sharedPage: Page;
 
     let chartDispatchAction = async (action: any) => {
       await sharedPage.evaluate(async chartAction => {
-        let domNode = document.querySelector('#component-test .echarts') as HTMLElement | null
+        let domNode = document.querySelector('#component-test .chart-renderer') as HTMLElement | null
         let chart = domNode ? window.$GRAPHENE.getChart(domNode) : null
         chart?.dispatchAction(chartAction)
         await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))

--- a/ui/tests/viz.test.ts
+++ b/ui/tests/viz.test.ts
@@ -507,7 +507,7 @@ test('line chart respects precision metadata in tooltips', async ({mount, shared
 
   await mount('components/LineChart.svelte', {data: {rows, fields}, x: 'month', y: 'win_pct', title: 'Win Rate'})
   let tooltip = await sharedPage.evaluate(() => {
-    let domNode = document.querySelector('#component-test .echarts') as HTMLElement
+    let domNode = document.querySelector('#component-test .chart-renderer') as HTMLElement
     let option = window.$GRAPHENE.getChart(domNode).getOption()
     let series = Array.isArray(option.series) ? option.series[0] : option.series
     return series.tooltip.valueFormatter(12.75)
@@ -601,7 +601,7 @@ test('many-series charts fall back to a single-point tooltip', async ({mount, ch
 // no matter how many series they have. Both tests below cover a way a chart ends up with nothing to hover.
 async function tooltipTrigger(sharedPage: Page) {
   return await sharedPage.evaluate(() => {
-    let domNode = document.querySelector('#component-test .echarts') as HTMLElement
+    let domNode = document.querySelector('#component-test .chart-renderer') as HTMLElement
     let option = window.$GRAPHENE.getChart(domNode).getOption()
     return (Array.isArray(option.tooltip) ? option.tooltip[0] : option.tooltip)?.trigger
   })


### PR DESCRIPTION
I was doing this in LocalApp, but it's really an echarts-specific workaround, and this works for charts outside of LocalApp